### PR TITLE
Allow a client id to be passed to the client

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -20,9 +20,10 @@ class KafkaClient(object):
     CLIENT_ID = "kafka-python"
     ID_GEN = count()
 
-    def __init__(self, host, port, bufsize=4096):
+    def __init__(self, host, port, bufsize=4096, client_id=CLIENT_ID):
         # We need one connection to bootstrap
-        self.bufsize = bufsize
+        self.bufsize   = bufsize
+        self.client_id = client_id
         self.conns = {               # (host, port) -> KafkaConnection
             (host, port): KafkaConnection(host, port, bufsize)
         }
@@ -59,7 +60,7 @@ class KafkaClient(object):
         recurse in the event of a retry.
         """
         requestId = self._next_id()
-        request = KafkaProtocol.encode_metadata_request(KafkaClient.CLIENT_ID,
+        request = KafkaProtocol.encode_metadata_request(self.client_id,
                                                         requestId, topics)
 
         response = self._send_broker_unaware_request(requestId, request)
@@ -156,7 +157,7 @@ class KafkaClient(object):
         for broker, payloads in payloads_by_broker.items():
             conn = self._get_conn_for_broker(broker)
             requestId = self._next_id()
-            request = encoder_fn(client_id=KafkaClient.CLIENT_ID,
+            request = encoder_fn(client_id=self.client_id,
                                  correlation_id=requestId, payloads=payloads)
 
             # Send the request, recv the response


### PR DESCRIPTION
Update the constructor to take an optional `client_id` argument that defaults to `CLIENT_ID`.
