### PR TITLE
import bufferunderflow error

### DIFF
--- a/kafka/util.py
+++ b/kafka/util.py
@@ -3,6 +3,8 @@ from itertools import groupby
 import struct
 from threading import Thread, Event
 
+from common import *
+
 
 def write_int_string(s):
     if s is None:


### PR DESCRIPTION
`util.py` uses `BufferUnderflowError`, but that was moved to `common.py`. This commit adds the import.
