### PR TITLE
Enable continuous integration with travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+
+python:
+  - 2.6
+  - 2.7
+
+before_install:
+  - cd kafka-src
+  - ./sbt update
+  - ./sbt package
+  - cd -
+
+install:
+  pip install .
+
+script:
+  - python -m test.test_unit
+  - python -m test.test_integration

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kafka Python client
 
+![travis](https://travis-ci.org/mumrah/kafka-python.png)
+
 This module provides low-level protocol support for Apache Kafka as well as
 high-level consumer and producer classes. Request batching is supported by the
 protocol as well as broker-aware request routing. Gzip and Snappy compression
@@ -15,7 +17,7 @@ Copyright 2013, David Arthur under Apache License, v2.0. See `LICENSE`
 
 # Status
 
-I'm following the version numbers of Kafka, plus one number to indicate the 
+I'm following the version numbers of Kafka, plus one number to indicate the
 version of this project. The current version is 0.8.1-1. This version is under
 development, APIs are subject to change.
 


### PR DESCRIPTION
As the number of contributors increase, it becomes more important to make sure that everyone is able to get started quickly on a clean slate, where 'clean' is defined by the unit tests and integration tests. It also avoids "but it runs on my machine!" scenarios. This pull request adds a travis configuration file which instructs travis-ci to run the tests. A badge indicating the status is included in the README. [Rails](https://github.com/rails/rails) is a great example of a project using travis successfully.
- [travis-ci](https://travis-ci.org/)
- [continuous integration](http://en.wikipedia.org/wiki/Continuous_integration)
- [current build status](https://travis-ci.org/jimjh/kafka-python/builds/12037200), from my fork

Note that you will need to enable github to notify travis whenever a push is made.

At this point, it appears that py2.6 doesn't work too well with `expectFailures`, and that some of the integration tests are failing. I would like to have your help with these.
