### PR TITLE
Enable absolute imports for modules using Queue.

### DIFF
--- a/kafka/consumer.py
+++ b/kafka/consumer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from collections import defaultdict
 from itertools import izip_longest, repeat
 import logging

--- a/kafka/producer.py
+++ b/kafka/producer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from collections import defaultdict
 from datetime import datetime, timedelta
 from itertools import cycle

--- a/kafka/queue.py
+++ b/kafka/queue.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from copy import copy
 import logging
 from multiprocessing import Process, Queue, Event


### PR DESCRIPTION
When running on Linux with code on a case-insensitive file system,
imports of the `Queue` module fail because python resolves the
wrong file (It is trying to use a relative import of `queue.py` in
the kafka directory). This change forces absolute imports via PEP328.
