### PR TITLE
allow for timeout to be None in SimpleConsumer.get_messages

### DIFF
--- a/kafka/consumer.py
+++ b/kafka/consumer.py
@@ -294,7 +294,8 @@ class SimpleConsumer(Consumer):
         iterator = self.__iter__()
 
         # HACK: This splits the timeout between available partitions
-        timeout = timeout * 1.0 / len(self.offsets)
+        if timeout:
+            timeout = timeout * 1.0 / len(self.offsets)
 
         with FetchContext(self, block, timeout):
             while count > 0:


### PR DESCRIPTION
The docstring for `get_messages` states that `None` is a valid argument for `timeout`, but there's a small bug when splitting the timeout between partitions:

```
TypeError                                 Traceback (most recent call last)
<ipython-input-3-2ff994acfcef> in <module>()
----> 1 for message in consumer.get_messages(count=1, block=True, timeout=None):
      2     print message
      3

/Users/zack/repo/kafka-python/kafka/consumer.py in get_messages(self, count, block, timeout)
    295
    296         # HACK: This splits the timeout between available partitions
--> 297         timeout = timeout * 1.0 / len(self.offsets)
    298
    299         with FetchContext(self, block, timeout):

TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
```
