### PR TITLE
reduce memory copies when consuming kafka responses

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -38,12 +38,9 @@ class KafkaConnection(local):
 
     def _consume_response(self):
         """
-        Fully consumer the response iterator
+        Fully consume the response iterator
         """
-        data = ""
-        for chunk in self._consume_response_iter():
-            data += chunk
-        return data
+        return "".join(self._consume_response_iter())
 
     def _consume_response_iter(self):
         """


### PR DESCRIPTION
Hi,

This is a simple change that uses the `.join()` method of strings to join the chunks read from kafka. This reduces memory copies and memory allocations, as the joined string can be allocated all at once, rather than for each chunk. This improvement is especially noticeable when reading large messages.

I've also fixed a typo in the docstring.
