### PR TITLE
Replace _send_upstream datetime logic with simpler time().

### DIFF
--- a/kafka/producer.py
+++ b/kafka/producer.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
-from datetime import datetime, timedelta
 from itertools import cycle
 from multiprocessing import Queue, Process
 from Queue import Empty
 import logging
 import sys
+import time
 
 from kafka.common import ProduceRequest
 from kafka.common import FailedPayloadsException
@@ -36,7 +36,7 @@ def _send_upstream(topic, queue, client, batch_time, batch_size,
     while not stop:
         timeout = batch_time
         count = batch_size
-        send_at = datetime.now() + timedelta(seconds=timeout)
+        send_at = time.time() + timeout
         msgset = defaultdict(list)
 
         # Keep fetching till we gather enough messages or a
@@ -54,7 +54,7 @@ def _send_upstream(topic, queue, client, batch_time, batch_size,
 
             # Adjust the timeout to match the remaining period
             count -= 1
-            timeout = (send_at - datetime.now()).total_seconds()
+            timeout = send_at - time.time()
             msgset[partition].append(msg)
 
         # Send collected requests upstream


### PR DESCRIPTION
Simplifies the timeout logic.

Avoids two object instantiations for each message sent asynchronously--one for the now() call, one resulting from the datetime arithmetic.

As a nice bonus, time() is also faster than datetime.now(), but I doubt it would be noticeable in the real world:

```
import datetime
import time

beg_time = time.time()
for _ in xrange(0,4000000):
    datetime.datetime.now()
print 'dt - %.2f sec' % (time.time() - beg_time)

beg_time = time.time()
for _ in xrange(0,4000000):
    time.time()
print 'time - %.2f sec' % (time.time() - beg_time)
```

```
dt - 5.72 sec
time - 0.45 sec
```
