### PR TITLE
Changes for aligning code with offset fetch and commit APIs (Kafka 0.8.1)

### DIFF
--- a/kafka/protocol.py
+++ b/kafka/protocol.py
@@ -439,7 +439,6 @@ class KafkaProtocol(object):
         data: bytes to decode
         """
         ((correlation_id,), cur) = relative_unpack('>i', data, 0)
-        (client_id, cur) = read_short_string(data, cur)
         ((num_topics,), cur) = relative_unpack('>i', data, cur)
 
         for i in xrange(num_topics):
@@ -490,7 +489,6 @@ class KafkaProtocol(object):
         """
 
         ((correlation_id,), cur) = relative_unpack('>i', data, 0)
-        (client_id, cur) = read_short_string(data, cur)
         ((num_topics,), cur) = relative_unpack('>i', data, cur)
 
         for i in range(num_topics):


### PR DESCRIPTION
Commit # 5581649 ::
Kafka API keys have changed for offset fetch and commit requests.
Refer https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/api/RequestKeys.scala#L32

Commit # daabc9f ::
Latest code in the trunk no longer returns client_id in offset fetch and commit response.
Refer https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/api/OffsetFetchResponse.scala
and https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/api/OffsetCommitResponse.scala
