### PR TITLE
remove zero length field name in format string, to work in Python 2.6

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -37,7 +37,7 @@ class KafkaConnection(local):
 
     def _raise_connection_error(self):
         self._dirty = True
-        raise ConnectionError("Kafka @ {}:{} went away".format(self.host, self.port))
+        raise ConnectionError("Kafka @ {0}:{1} went away".format(self.host, self.port))
 
     def _read_bytes(self, num_bytes):
         bytes_left = num_bytes


### PR DESCRIPTION
These zero-length format strings don't work in Python 2.6:

http://stackoverflow.com/questions/10054122/valueerror-zero-length-field-name-in-format-python
