### PR TITLE
Fix offsets

### DIFF
--- a/kafka/consumer.py
+++ b/kafka/consumer.py
@@ -350,6 +350,12 @@ class SimpleConsumer(Consumer):
 
     def _get_message(self, block=True, timeout=0.1, get_partition_info=None,
                      update_offset=True):
+        """
+        If no messages can be fetched, returns None.
+        If get_partition_info is None, it defaults to self.partition_info
+        If get_partition_info is True, returns (partition, message)
+        If get_partition_info is False, returns message
+        """
         if self.queue.empty():
             # We're out of messages, go grab some more.
             with FetchContext(self, block, timeout):


### PR DESCRIPTION
These changes do the following:
- Only update offsets just before returning messages to the caller rather than after fetching them from kafka
- Never re-fetch messages already in the internal queue
- Clear the queue after seeking since the messages are no longer the right ones. It will clear the queue even if the offsets did not actually change, but I'm trying to keep the code simple instead of handling this corner case efficiently.
- Fix offsets stored in MultiProcessConsumer
