### PR TITLE
Increase default connection timeout

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -10,7 +10,7 @@ from kafka.common import (ErrorMapping, TopicAndPartition,
                           BrokerResponseError, PartitionUnavailableError,
                           KafkaUnavailableError, KafkaRequestError)
 
-from kafka.conn import KafkaConnection
+from kafka.conn import KafkaConnection, DEFAULT_SOCKET_TIMEOUT_SECONDS
 from kafka.protocol import KafkaProtocol
 
 log = logging.getLogger("kafka")
@@ -21,7 +21,11 @@ class KafkaClient(object):
     CLIENT_ID = "kafka-python"
     ID_GEN = count()
 
-    def __init__(self, host, port, client_id=CLIENT_ID, timeout=10):
+    # NOTE: The timeout given to the client should always be greater than the
+    # one passed to SimpleConsumer.get_message(), otherwise you can get a
+    # socket timeout.
+    def __init__(self, host, port, client_id=CLIENT_ID,
+                 timeout=DEFAULT_SOCKET_TIMEOUT_SECONDS):
         # We need one connection to bootstrap
         self.client_id = client_id
         self.timeout = timeout

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -8,6 +8,7 @@ from kafka.common import ConnectionError
 
 log = logging.getLogger("kafka")
 
+DEFAULT_SOCKET_TIMEOUT_SECONDS = 120
 
 class KafkaConnection(local):
     """
@@ -20,10 +21,10 @@ class KafkaConnection(local):
 
     host:    the host name or IP address of a kafka broker
     port:    the port number the kafka broker is listening on
-    timeout: default None. The socket timeout for sending and receiving data.
-             None means no timeout, so a request can block forever.
+    timeout: default 120. The socket timeout for sending and receiving data
+             in seconds. None means no timeout, so a request can block forever.
     """
-    def __init__(self, host, port, timeout=None):
+    def __init__(self, host, port, timeout=DEFAULT_SOCKET_TIMEOUT_SECONDS):
         super(KafkaConnection, self).__init__()
         self.host = host
         self.port = port


### PR DESCRIPTION
This fixes the default behavior, which used to cause a socket timeout when waiting for 10 seconds for a message to be produced. See https://github.com/mumrah/kafka-python/issues/104#issuecomment-32451820
