### PR TITLE
KeyedProducer support sending multiple messages at once (mirror other producers)

### DIFF
--- a/kafka/producer.py
+++ b/kafka/producer.py
@@ -250,8 +250,12 @@ class KeyedProducer(Producer):
         return partitioner.partition(key, self.client.topic_partitions[topic])
 
     def send(self, topic, key, msg):
+        # todo: remove this, it was retained only for backward compatibility
+        return self.send_messages(topic, key, msg)
+
+    def send_messages(self, topic, key, *msg):
         partition = self._next_partition(topic, key)
-        return self.send_messages(topic, partition, msg)
+        return super(KeyedProducer, self).send_messages(topic, partition, *msg)
 
     def __repr__(self):
         return '<KeyedProducer batch=%s>' % self.async


### PR DESCRIPTION
For reasons I don't know, the KeyedProducer API is not equivalent to the SimpleProducer.

This PR adds `send_messages` method to support sending multiple messages at once.

A test has been added for the specific case.

I think we should remove send completely to make the producers more uniform but it represents an API break so I didn't include it here. 
