### PR TITLE
Avoid KeyError: -1 when deleted topics linger

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -255,6 +255,8 @@ class KafkaClient(object):
             self.topic_partitions[topic] = []
             for partition, meta in partitions.items():
                 topic_part = TopicAndPartition(topic, partition)
+                if meta.leader == -1:
+                    raise PartitionUnavailableError("Leader is unassigned for %s-%s" % (topic, partition))
                 self.topics_to_brokers[topic_part] = brokers[meta.leader]
                 self.topic_partitions[topic].append(partition)
 


### PR DESCRIPTION
I have hit this error in Kafka 0.8.1 a few times where after deleting a topic it still reports somehow into the client, and I end up with:

```
File "env/src/kafka-python/kafka/client.py", line 39, in __init__
    self.load_metadata_for_topics()  # bootstrap with all metadata
File "env/src/kafka-python/kafka/client.py", line 258, in load_metadata_for_topics
    self.topics_to_brokers[topic_part] = brokers[meta.leader]
KeyError: -1
```
