### PR TITLE
Check against basestring instead of str in collect.hosts.

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -19,7 +19,7 @@ def collect_hosts(hosts, randomize=True):
     randomize the returned list.
     """
 
-    if isinstance(hosts, str):
+    if isinstance(hosts, basestring):
         hosts = hosts.strip().split(',')
 
     result = []

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -449,6 +449,16 @@ class TestKafkaClient(unittest.TestCase):
             [('kafka01', 9092), ('kafka02', 9092), ('kafka03', 9092)],
             client.hosts)
 
+    def test_init_with_unicode_csv(self):
+
+        with patch.object(KafkaClient, 'load_metadata_for_topics'):
+            client = KafkaClient(
+                hosts=u'kafka01:9092,kafka02:9092,kafka03:9092')
+
+        self.assertItemsEqual(
+            [('kafka01', 9092), ('kafka02', 9092), ('kafka03', 9092)],
+            client.hosts)
+
     def test_send_broker_unaware_request_fail(self):
         'Tests that call fails when all hosts are unavailable'
 


### PR DESCRIPTION
This makes it work with `hosts` string in `unicode`.
