### PR TITLE
Fix lack of timeout support in KafkaClient and KafkaConnection

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -48,7 +48,7 @@ class KafkaClient(object):
 
         host_key = (host, port)
         if host_key not in self.conns:
-            self.conns[host_key] = KafkaConnection(host, port)
+            self.conns[host_key] = KafkaConnection(host, port, timeout=self.timeout)
 
         return self.conns[host_key]
 

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -150,6 +150,6 @@ class KafkaConnection(local):
         """
         self.close()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self._sock.connect((self.host, self.port))
         self._sock.settimeout(self.timeout)
+        self._sock.connect((self.host, self.port))
         self._dirty = False


### PR DESCRIPTION
Timeout was not passed correctly from `KafkaClient` to `KafkaConnection` --- and then was not actually applied to the socket in `KafkaConnection` itself.

To test this, try `KafkaClient('1.2.3.4:1234', timeout=0.1)` --- this hangs for a long time in master (as does `KafkaConnection('1.2.3.4', 1234, 0.1)`.

This is a critical issue in production systems.
