### PR TITLE
Remove 'distribute' dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     name="kafka-python",
     version="0.9.0",
 
-    install_requires=["distribute"],
     tests_require=["tox", "mock"],
     cmdclass={"test": Tox},
 


### PR DESCRIPTION
This dependency is unnecessary since this project now uses setuptools and it prevents installing this package with --use-wheel, failing with this traceback:

```
$ pip install --use-wheel distribute
Downloading/unpacking distribute
  Downloading distribute-0.7.3-cp26-none-linux_x86_64.whl
Requirement already satisfied (use --upgrade to upgrade): setuptools>=0.7 in ./venv/lib/python2.6/site-packages (from distribute)
Cleaning up...
Exception:
Traceback (most recent call last):
  File "/home/plucas/lib/python2.6/site-packages/pip/basecommand.py", line 134, in main
    status = self.run(options, args)
  File "/home/plucas/lib/python2.6/site-packages/pip/commands/install.py", line 241, in run
    requirement_set.install(install_options, global_options, root=options.root_path)
  File "/home/plucas/lib/python2.6/site-packages/pip/req.py", line 1256, in install
    if req.name == 'distribute' and req.installed_version in distribute_req:
  File "/home/plucas/lib/python2.6/site-packages/pip/req.py", line 390, in installed_version
    return self.pkg_info()['version']
  File "/home/plucas/lib/python2.6/site-packages/pip/req.py", line 357, in pkg_info
    data = self.egg_info_data('PKG-INFO')
  File "/home/plucas/lib/python2.6/site-packages/pip/req.py", line 293, in egg_info_data
    filename = self.egg_info_path(filename)
  File "/home/plucas/lib/python2.6/site-packages/pip/req.py", line 307, in egg_info_path
    filenames = os.listdir(base)
OSError: [Errno 2] No such file or directory: '/home/plucas/build/distribute/pip-egg-info'
```
