### PR TITLE
Move fetching last known offset logic to a stand alone function.

### DIFF
--- a/kafka/consumer.py
+++ b/kafka/consumer.py
@@ -123,6 +123,7 @@ class Consumer(object):
                           callback=get_or_init_offset_callback,
                           fail_on_error=False)
             self.offsets[partition] = offset
+        self.fetch_offsets = self.offsets.copy()
 
     def commit(self, partitions=None):
         """


### PR DESCRIPTION
The `Consumer` class fetches the last known offsets in `__init__` if
`auto_commit` is enabled, but it would be nice to expose this behavior
for consumers that aren't using auto commit. This doesn't change
existing behavior, just exposes the ability to easily fetch and set the
last known offsets. Once #162 or something similar lands this may no
longer be necessary, but it looks like that might take a while to make
it through.
