### PR TITLE
Adding codec abstraction for compatibility

### DIFF
--- a/kafka/__init__.py
+++ b/kafka/__init__.py
@@ -7,7 +7,7 @@ __copyright__ = 'Copyright 2012, David Arthur under Apache License, v2.0'
 from kafka.client import KafkaClient
 from kafka.conn import KafkaConnection
 from kafka.protocol import (
-    create_message, create_gzip_message, create_snappy_message
+    create_message, create_encoded_message 
 )
 from kafka.producer import SimpleProducer, KeyedProducer
 from kafka.partitioner import RoundRobinPartitioner, HashedPartitioner
@@ -16,6 +16,5 @@ from kafka.consumer import SimpleConsumer, MultiProcessConsumer
 __all__ = [
     'KafkaClient', 'KafkaConnection', 'SimpleProducer', 'KeyedProducer',
     'RoundRobinPartitioner', 'HashedPartitioner', 'SimpleConsumer',
-    'MultiProcessConsumer', 'create_message', 'create_gzip_message',
-    'create_snappy_message'
+    'MultiProcessConsumer', 'create_message', 'create_encoded_message'
 ]

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -6,7 +6,7 @@ from kafka.codec import (
     snappy_encode, snappy_decode
 )
 from kafka.protocol import (
-    create_gzip_message, create_message, create_snappy_message, KafkaProtocol
+    create_message, create_encoded_message, KafkaProtocol
 )
 from testutil import *
 

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 
 from kafka import *  # noqa
+from kafka.protocol import CODEC_NONE, CODEC_GZIP, CODEC_SNAPPY
 from kafka.common import *  # noqa
 from kafka.consumer import MAX_FETCH_BUFFER_SIZE_BYTES
 from fixtures import ZookeeperFixture, KafkaFixture


### PR DESCRIPTION
The `Codec` class has been added to support Snappy-Xerial compatibility in the Producer. Without this, Java-based consumers will be unable to decode messages produced by non-Xerial Snappy producers.