### PR TITLE
add method to seek an absolute position

### DIFF
--- a/kafka/consumer.py
+++ b/kafka/consumer.py
@@ -265,6 +265,10 @@ class SimpleConsumer(Consumer):
         """
         self.partition_info = True
 
+    def seek_absolute(self, offset):
+        for partition in self.offsets.keys():
+            self.offsets[partition] = offset
+
     def seek(self, offset, whence):
         """
         Alter the current offset in the consumer, similar to fseek


### PR DESCRIPTION
kafka ealiest offset is not always equals 0 as file, so we should provide a method for user to specify an absolute position not only relative position.
