### PR TITLE
[FIX] When no pending messages was giving -1 instead of 0.

### DIFF
--- a/kafka/consumer.py
+++ b/kafka/consumer.py
@@ -193,7 +193,7 @@ class Consumer(object):
             partition = resp.partition
             pending = resp.offsets[0]
             offset = self.offsets[partition]
-            total += pending - offset - (1 if offset > 0 else 0)
+            total += pending - offset
 
         return total
 


### PR DESCRIPTION
When there was no pending messages, the pending method was answering -1. It should be 0. I don't see a reason for the modifier (-1) when offset is greater than 0.
