### PR TITLE
Fix error in consumer.py test against max_buffer_size

### DIFF
--- a/kafka/consumer.py
+++ b/kafka/consumer.py
@@ -448,7 +448,7 @@ class SimpleConsumer(Consumer):
                     if self.max_buffer_size is None:
                         buffer_size *= 2
                     else:
-                        buffer_size = max(buffer_size * 2,
+                        buffer_size = min(buffer_size * 2,
                                           self.max_buffer_size)
                     log.warn("Fetch size too small, increase to %d (2x) "
                              "and retry", buffer_size)


### PR DESCRIPTION
Was using max(buf_size \* 2, max_buf_size), which could result in a new
buffer size which exceeded the specified max_buffer_size by
(max_buffer_size - 1) bytes.
