### PR TITLE
Fix #257 - Allow KafkaConnection to work correctly with gevent.

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -38,7 +38,21 @@ def collect_hosts(hosts, randomize=True):
     return result
 
 
-class KafkaConnection(local):
+class ConnectionBaseClass(type):
+    """
+    Metaclass to make KafkaConnection work with gevent.
+    """
+    def __new__(mcs, name, bases, attrs):
+        if local.__module__ == 'gevent.local':
+            # change base to object to avoid using one connection per greenlet
+            bases = (object,)
+        else:
+            bases = (local,)
+
+        return type(name, bases, attrs)
+
+
+class KafkaConnection(six.with_metaclass(ConnectionBaseClass)):
     """
     A socket connection to a single Kafka broker
 


### PR DESCRIPTION
KafkaConnection inherits from threading.local, which is patched by
gevent to ensure one connection per greenlet, instead of one per
thread. If threading.local patching is detected, the base class
will be changed to object.
