### PR TITLE
added a send_messages api to KeyedProducer

### DIFF
--- a/kafka/producer/keyed.py
+++ b/kafka/producer/keyed.py
@@ -54,6 +54,10 @@ class KeyedProducer(Producer):
         partitioner = self.partitioners[topic]
         return partitioner.partition(key, self.client.get_partition_ids_for_topic(topic))
 
+    def send_messages(self,topic,key,*msg):
+        partition = self._next_partition(topic, key)
+        return self._send_messages(topic, partition, *msg,key=key)
+
     def send(self, topic, key, msg):
         partition = self._next_partition(topic, key)
         return self._send_messages(topic, partition, msg, key=key)


### PR DESCRIPTION
This makes the KeyedProducer api the same for send messages.

I did run into one error and that's if the key is not a str then base producer throws a TypeError. Rather than forcing this in the send_messages call my program that implements this does a type cast.

I'd appreciate a merge on this so I don't have to deploy my own fork :). Thanks!
