### PR TITLE
Eagerly concat received bytes

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -79,7 +79,7 @@ class KafkaConnection(local):
 
     def _read_bytes(self, num_bytes):
         bytes_left = num_bytes
-        responses = []
+        result_buffer = six.BytesIO()
 
         log.debug("About to read %d bytes from Kafka", num_bytes)
 
@@ -104,9 +104,9 @@ class KafkaConnection(local):
 
             bytes_left -= len(data)
             log.debug("Read %d/%d bytes from Kafka", num_bytes - bytes_left, num_bytes)
-            responses.append(data)
+            result_buffer.write(data)
 
-        return b''.join(responses)
+        return result_buffer.getvalue()
 
     ##################
     #   Public API   #


### PR DESCRIPTION
This should reduce the amount of memory required for large packets. We're effectively side stepping keeping all the intermediary fragments around, which had us require 10% more the memory.

Couldn't test on neither pypy nor py34. 