### PR TITLE
Add metrics to KafkaClient.

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -26,9 +26,8 @@ def time_metric(metric_name):
             start_time = time.time()
             ret = fn(self, *args, **kwargs)
 
-            if self.metrics:
-                metric = getattr(self.metrics, metric_name)
-                metric.addValue(time.time() - start_time)
+            if self.metrics_responder:
+                self.metrics_responder(metric_name, time.time() - start_time)
 
             return ret
         return wrapper
@@ -45,13 +44,13 @@ class KafkaClient(object):
     def __init__(self, hosts, client_id=CLIENT_ID,
                  timeout=DEFAULT_SOCKET_TIMEOUT_SECONDS,
                  correlation_id=0,
-                 metrics=None):
+                 metrics_responder=None):
         # We need one connection to bootstrap
         self.client_id = kafka_bytestring(client_id)
         self.timeout = timeout
         self.hosts = collect_hosts(hosts)
         self.correlation_id = correlation_id
-        self.metrics = metrics
+        self.metrics_responder = metrics_responder
 
         # create connections only when we need them
         self.conns = {}


### PR DESCRIPTION
I am trying to collect data about how long I'm waiting on Kafka; I want to answer questions like "how much latency is there for getting messages out of Kafka?". To this end, I've put together this PR, which adds an option to enable metrics collection in `KafkaClient`.

This uses [scales](https://github.com/Cue/scales), and would let me write stuff like this:

```python
from kafka import KafkaConsumer

consumer = KafkaConsumer('foobar',
                         bootstrap_servers=['localhost:9092'],
                         group_id='kafka_test',
                         enable_metrics=True)

# interesting logic would go here ...
for _ in xrange(10):
    for message in consumer.fetch_messages():
        process(message)

# outputs the 95th percentile of how long it takes to perform send_fetch_request
print consumer.metrics.fetch_request_timer['95percentile']
```

I've only added support for metrics in KafkaConsumer, but I can add other consumers if you agree with this design.