### PR TITLE
Add KafkaConsumer#close

### DIFF
--- a/kafka/consumer/kafka.py
+++ b/kafka/consumer/kafka.py
@@ -268,6 +268,10 @@ class KafkaConsumer(object):
         # Reset message iterator in case we were in the middle of one
         self._reset_message_iterator()
 
+    def close(self):
+        """Close this consumer's underlying client."""
+        self._client.close()
+
     def next(self):
         """Return the next available message
 


### PR DESCRIPTION
In case the answer to #425 is "you can't", this adds a `close` method to KafkaConsumer. I didn't add tests because I didn't see any for KafkaClient.

Fixes #425 