### PR TITLE
Include LICENSE in PyPI sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include kafka *.py
+include LICENSE


### PR DESCRIPTION
Allows downstream OS packagers and porters to include the LICENSE file in package installations