### PR TITLE
Add delayed task timeouts to _poll calls

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -302,7 +302,7 @@ class KafkaClient(object):
                 self._finish_connect(node_id)
 
             # Send a metadata request if needed
-            metadata_timeout = self._maybe_refresh_metadata()
+            metadata_timeout_ms = self._maybe_refresh_metadata()
 
             # Send scheduled tasks
             for task, task_future in self._delayed_tasks.pop_ready():
@@ -314,7 +314,9 @@ class KafkaClient(object):
                 else:
                     task_future.success(result)
 
-            timeout = min(timeout_ms, metadata_timeout,
+            task_timeout_ms = max(0, 1000 * (
+              self._delayed_tasks.next_at() - time.time()))
+            timeout = min(timeout_ms, metadata_timeout_ms, task_timeout_ms,
                           self.config['request_timeout_ms'])
             timeout /= 1000.0
 

--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -59,9 +59,13 @@ class ClusterMetadata(object):
         if self._need_update:
             ttl = 0
         else:
-            ttl = self._last_successful_refresh_ms + self.config['metadata_max_age_ms'] - now
-        retry = self._last_refresh_ms + self.config['retry_backoff_ms'] - now
-        return max(ttl, retry, 0)
+            metadata_age = now - self._last_successful_refresh_ms
+            ttl = self.config['metadata_max_age_ms'] - metadata_age
+
+        retry_age = now - self._last_refresh_ms
+        next_retry = self.config['retry_backoff_ms'] - retry_age
+
+        return max(ttl, next_retry, 0)
 
     def request_update(self):
         """


### PR DESCRIPTION
Because timeouts were not considered, calls to poll() with long timeouts and no pending requests could result in large delays for heartbeat / autocommit tasks.