### PR TITLE
Add event registrar and events for async producer

### DIFF
--- a/kafka/producer/base.py
+++ b/kafka/producer/base.py
@@ -84,7 +84,7 @@ def _send_upstream(queue, client, codec, batch_time, batch_size,
         async.producer.stop(unsent_messages)
         async.producer.queue.pop(topic_partition, msg, key)
         async.producer.request.send(requests)
-        async.producer.request.succeed(request)
+        async.producer.request.succeed
         async.producer.request.error(error_cls, request)
         async.producer.request.retry(request)
         async.producer.backoff(time_in_ms)
@@ -205,7 +205,7 @@ def _send_upstream(queue, client, codec, batch_time, batch_size,
                           orig_req.messages if log_messages_on_error
                                             else hash(orig_req.messages))
             else:
-                event_registrar.emit('async.producer.request.succeed', orig_req)
+                event_registrar.emit('async.producer.request.succeed')
 
         if not reqs_to_retry:
             request_tries = {}

--- a/kafka/util.py
+++ b/kafka/util.py
@@ -151,3 +151,18 @@ class ReentrantTimer(object):
 
     def __del__(self):
         self.stop()
+
+class EventRegistrar(object):
+    """
+    Handles registration of callable event handlers which are
+    executed in sequence when events are emitted.
+    """
+    def __init__(self):
+        self.handlers = collections.defaultdict(list)
+
+    def register(self, event, handler):
+        self.handlers[event].append(handler)
+
+    def emit(self, event, *args, **kwargs):
+        for handler in self.handlers[event]:
+            handler(*args, **kwargs)

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -13,6 +13,7 @@ from kafka.common import (
     AsyncProducerQueueFull, FailedPayloadsError, NotLeaderForPartitionError,
     ProduceResponsePayload, RetryOptions, TopicPartition
 )
+from kafka.util import EventRegistrar
 from kafka.producer.base import Producer, _send_upstream
 from kafka.protocol import CODEC_NONE
 
@@ -140,7 +141,7 @@ class TestKafkaProducerSendUpstream(unittest.TestCase):
                   Producer.ACK_AFTER_LOCAL_WRITE,
                   Producer.DEFAULT_ACK_TIMEOUT,
                   retry_options,
-                  stop_event))
+                  stop_event, EventRegistrar()))
         self.thread.daemon = True
         self.thread.start()
         time.sleep(sleep_timeout)


### PR DESCRIPTION
@dpkp We ended up building this in our fork and, though it's not exactly ready to be merged, I thought it'd be valuable to throw it out here so we could talk about the use case.

Our issue was that the driver, and the async producer in particular, does a lot of fairly complex stuff which we would really like to be able to keep track of in our monitoring system. Basic metrics like throughput, connection attempts, failures and retries, etc. would greatly help us understand what's going on and alert if we have a problem in our cluster. To do this, we need a way to get information out of the driver.

The approach here is to add a barebones event handling system and emit events at all the critical points in the async producer's operation. If no handlers are registered, this should incur basically zero overhead, but it allows the enduser the option of tying their own events (in our use case, metrics emission) into the producer's workflow. 
