### PR TITLE
Handle broken LZ4 framing 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,8 +102,9 @@ Compression
 ***********
 
 kafka-python supports gzip compression/decompression natively. To produce or
-consume snappy and lz4 compressed messages, you must install `lz4` (`lz4-cffi`
-if using pypy) and/or `python-snappy` (also requires snappy library).
+consume lz4 compressed messages, you must install lz4tools and xxhash (modules
+may not work on python2.6). To enable snappy compression/decompression install
+python-snappy (also requires snappy library).
 See `Installation <http://kafka-python.readthedocs.org/en/master/install.html#optional-snappy-install>`_
 for more information.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,8 +101,9 @@ Compression
 ***********
 
 kafka-python supports gzip compression/decompression natively. To produce or
-consume snappy and lz4 compressed messages, you must install lz4 (lz4-cffi
-if using pypy) and/or python-snappy (also requires snappy library).
+consume lz4 compressed messages, you must install lz4tools and xxhash (modules
+may not work on python2.6). To enable snappy, install python-snappy (also
+requires snappy library).
 See `Installation <install.html#optional-snappy-install>`_ for more information.
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -40,14 +40,12 @@ Using `setup.py` directly:
 Optional LZ4 install
 ********************
 
-To enable LZ4 compression/decompression, install `lz4`:
+To enable LZ4 compression/decompression, install lz4tools and xxhash:
 
->>> pip install lz4
+>>> pip install lz4tools
+>>> pip install xxhash
 
-Or `lz4-cffi` if using pypy:
-
->>> pip install lz4-cffi
-
+*Note*: these modules do not support python2.6
 
 Optional Snappy install
 ***********************

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from kafka import KafkaConsumer, KafkaProducer
@@ -9,9 +11,13 @@ from test.testutil import random_string
 @pytest.mark.parametrize("compression", [None, 'gzip', 'snappy', 'lz4'])
 def test_end_to_end(kafka_broker, compression):
 
-    # LZ4 requires 0.8.2
-    if compression == 'lz4' and version() < (0, 8, 2):
-        return
+    if compression == 'lz4':
+        # LZ4 requires 0.8.2
+        if version() < (0, 8, 2):
+            return
+        # LZ4 python libs dont work on python2.6
+        elif sys.version_info < (2, 7):
+            return
 
     connect_str = 'localhost:' + str(kafka_broker.port)
     producer = KafkaProducer(bootstrap_servers=connect_str,

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -6,10 +6,17 @@ from test.testutil import random_string
 
 
 @pytest.mark.skipif(not version(), reason="No KAFKA_VERSION set")
-def test_end_to_end(kafka_broker):
+@pytest.mark.parametrize("compression", [None, 'gzip', 'snappy', 'lz4'])
+def test_end_to_end(kafka_broker, compression):
+
+    # LZ4 requires 0.8.2
+    if compression == 'lz4' and version() < (0, 8, 2):
+        return
+
     connect_str = 'localhost:' + str(kafka_broker.port)
     producer = KafkaProducer(bootstrap_servers=connect_str,
                              max_block_ms=10000,
+                             compression_type=compression,
                              value_serializer=str.encode)
     consumer = KafkaConsumer(bootstrap_servers=connect_str,
                              group_id=None,

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ deps =
     pytest-mock
     mock
     python-snappy
-    py{26,27,33,34,35}: lz4
-    pypy: lz4-cffi
+    lz4tools
+    xxhash
     py{26,27}: six
     py26: unittest2
 commands =


### PR DESCRIPTION
Kafka brokers attempt to implement the LZ4 framing specification, but inadvertently included the magic bytes in the header checksum calculation. To support kafka's LZ4 compression, we have to compress / decompress as normal but overwrite the checksum w/ a broken [when compressing] or correct [when decompressing] byte.