### PR TITLE
break up some circular references and close client wake pipe on __del__

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -97,6 +97,10 @@ class KafkaClient(object):
         self._bootstrap(collect_hosts(self.config['bootstrap_servers']))
         self._wake_r, self._wake_w = os.pipe()
 
+    def __del__(self):
+        os.close(self._wake_r)
+        os.close(self._wake_w)
+
     def _bootstrap(self, hosts):
         # Exponential backoff if bootstrap fails
         backoff_ms = self.config['reconnect_backoff_ms'] * 2 ** self._bootstrap_fails

--- a/test/test_coordinator.py
+++ b/test/test_coordinator.py
@@ -19,6 +19,7 @@ from kafka.protocol.commit import (
     OffsetCommitResponse, OffsetFetchRequest_v0, OffsetFetchRequest_v1,
     OffsetFetchResponse)
 from kafka.protocol.metadata import MetadataResponse
+from kafka.util import WeakMethod
 
 import kafka.common as Errors
 
@@ -46,7 +47,7 @@ def test_init(conn):
 
     # metadata update on init 
     assert cli.cluster._need_update is True
-    assert coordinator._handle_metadata_update in cli.cluster._listeners
+    assert WeakMethod(coordinator._handle_metadata_update) in cli.cluster._listeners
 
 
 @pytest.mark.parametrize("api_version", [(0, 8, 0), (0, 8, 1), (0, 8, 2), (0, 9)])


### PR DESCRIPTION
closes #552

saw these errors after running consumers for a while (hrs or sometimes days):

```
sync-files-cache_1 |   File "/usr/local/lib/python2.7/dist-packages/kafka/consumer/group.py", line 182, in __init__
sync-files-cache_1 |     self.config['api_version'] = self._client.check_version()
sync-files-cache_1 |   File "/usr/local/lib/python2.7/dist-packages/kafka/client_async.py", line 615, in check_version
sync-files-cache_1 |     self.poll(future=f)
sync-files-cache_1 |   File "/usr/local/lib/python2.7/dist-packages/kafka/client_async.py", line 355, in poll
sync-files-cache_1 |     responses.extend(self._poll(timeout, sleep=sleep))
sync-files-cache_1 |   File "/usr/local/lib/python2.7/dist-packages/kafka/client_async.py", line 390, in _poll
sync-files-cache_1 |     ready, _, _ = select.select(fds, [], [], timeout)
sync-files-cache_1 | ValueError: filedescriptor out of range in select()
```

though each consumer was closed and ref to it released the fd count of the process increases. it looks like we don't close client wake pipe fds on `__del__` and the client was not being gc'd due to circular refs (just used https://github.com/mgedmin/objgraph to dump backrefs).

this patch fixed it (fd count remained ~ the same for hrs where before would monotonically inc within mins). meantime workaround was just to restart the crashed process.
