### PR TITLE
Silence suprious warnings

### DIFF
--- a/kafka/producer/base.py
+++ b/kafka/producer/base.py
@@ -471,5 +471,5 @@ class Producer(object):
         self.stopped = True
 
     def __del__(self):
-        if not self.stopped:
+        if self.async and not self.stopped:
             self.stop()


### PR DESCRIPTION
Our app uses `SimpleProducer` and logs lots of these warnings (from line 438):

   producer.stop() called, but producer is not async

This destructor appears to be the cause.

(Also, is it wise to do a thread join from a destructor?)