### PR TITLE
Fix Consumer Heartbeat Bugs

### DIFF
--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -594,12 +594,16 @@ class HeartbeatTask(object):
 
     def __call__(self):
         if (self._coordinator.generation < 0 or
-            self._coordinator.need_rejoin() or
-            self._coordinator.coordinator_unknown()):
+            self._coordinator.need_rejoin()):
             # no need to send the heartbeat we're not using auto-assignment
             # or if we are awaiting a rebalance
             log.debug("Skipping heartbeat: no auto-assignment"
                       " or waiting on rebalance")
+            return
+
+        if self._coordinator.coordinator_unknown():
+            log.warning("Coordinator unknown during heartbeat -- will retry")
+            self._handle_heartbeat_failure(Errors.GroupCoordinatorNotAvailableError())
             return
 
         if self._heartbeat.session_expired():

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -536,26 +536,27 @@ class BaseCoordinator(object):
         #self.sensors.heartbeat_latency.record(response.requestLatencyMs())
         error_type = Errors.for_code(response.error_code)
         if error_type is Errors.NoError:
-            log.debug("Received successful heartbeat response.")
+            log.info("Heartbeat successful")
             future.success(None)
         elif error_type in (Errors.GroupCoordinatorNotAvailableError,
                             Errors.NotCoordinatorForGroupError):
-            log.info("Heartbeat failed: coordinator is either not started or"
-                     " not valid; will refresh metadata and retry")
+            log.warning("Heartbeat failed: coordinator is either not started or"
+                        " not valid; will refresh metadata and retry")
             self.coordinator_dead()
             future.failure(error_type())
         elif error_type is Errors.RebalanceInProgressError:
-            log.info("Heartbeat failed: group is rebalancing; re-joining group")
+            log.warning("Heartbeat: group is rebalancing; this consumer needs to"
+                        " re-join")
             self.rejoin_needed = True
             future.failure(error_type())
         elif error_type is Errors.IllegalGenerationError:
-            log.info("Heartbeat failed: local generation id is not current;"
-                     " re-joining group")
+            log.warning("Heartbeat: generation id is not current; this consumer"
+                        " needs to re-join")
             self.rejoin_needed = True
             future.failure(error_type())
         elif error_type is Errors.UnknownMemberIdError:
-            log.info("Heartbeat failed: local member_id was not recognized;"
-                     " resetting and re-joining group")
+            log.warning("Heartbeat: local member_id was not recognized;"
+                        " this consumer needs to re-join")
             self.member_id = JoinGroupRequest.UNKNOWN_MEMBER_ID
             self.rejoin_needed = True
             future.failure(error_type)
@@ -597,8 +598,8 @@ class HeartbeatTask(object):
             self._coordinator.need_rejoin()):
             # no need to send the heartbeat we're not using auto-assignment
             # or if we are awaiting a rebalance
-            log.debug("Skipping heartbeat: no auto-assignment"
-                      " or waiting on rebalance")
+            log.info("Skipping heartbeat: no auto-assignment"
+                     " or waiting on rebalance")
             return
 
         if self._coordinator.coordinator_unknown():
@@ -633,7 +634,7 @@ class HeartbeatTask(object):
         self._client.schedule(self, time.time() + ttl)
 
     def _handle_heartbeat_failure(self, e):
-        log.debug("Heartbeat failed; retrying")
+        log.warning("Heartbeat failed; retrying")
         self._request_in_flight = False
         etd = time.time() + self._coordinator.config['retry_backoff_ms'] / 1000.0
         self._client.schedule(self, etd)


### PR DESCRIPTION
Fix heartbeat 2 bugs identified in #571 (may also fix #569):

- a pending metadata request to the group coordinator during a heartbeat causes the heartbeat to not reschedule propertly
- consumer iteration does not pause to process heartbeat responses, which can cause inadvertent timeouts during slow message processing against large fetch request batches