### PR TITLE
KafkaConsumer.poll should sleep to prevent tight-loops

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -465,7 +465,7 @@ class KafkaConsumer(six.Iterator):
             return records
 
         self._fetcher.init_fetches()
-        self._client.poll(timeout_ms)
+        self._client.poll(timeout_ms=timeout_ms, sleep=True)
         return self._fetcher.fetched_records()
 
     def position(self, partition):


### PR DESCRIPTION
Fixes #572 