### PR TITLE
Catch all errors thrown by _get_leader_for_partition in SimpleClient

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -169,7 +169,8 @@ class SimpleClient(object):
         for payload in payloads:
             try:
                 leader = self._get_leader_for_partition(payload.topic, payload.partition)
-            except KafkaUnavailableError:
+            except (KafkaUnavailableError, LeaderNotAvailableError,
+                    UnknownTopicOrPartitionError):
                 leader = None
             payloads_by_broker[leader].append(payload)
         return dict(payloads_by_broker)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -11,7 +11,7 @@ from kafka.common import (
     BrokerMetadata,
     TopicPartition, KafkaUnavailableError,
     LeaderNotAvailableError, UnknownTopicOrPartitionError,
-    KafkaTimeoutError, ConnectionError
+    KafkaTimeoutError, ConnectionError, FailedPayloadsError
 )
 from kafka.conn import KafkaConnection
 from kafka.future import Future
@@ -361,7 +361,7 @@ class TestSimpleClient(unittest.TestCase):
             "topic_noleader", 0,
             [create_message("a"), create_message("b")])]
 
-        with self.assertRaises(LeaderNotAvailableError):
+        with self.assertRaises(FailedPayloadsError):
             client.send_produce_request(requests)
 
     @patch('kafka.SimpleClient._get_conn')
@@ -386,7 +386,7 @@ class TestSimpleClient(unittest.TestCase):
             "topic_doesnt_exist", 0,
             [create_message("a"), create_message("b")])]
 
-        with self.assertRaises(UnknownTopicOrPartitionError):
+        with self.assertRaises(FailedPayloadsError):
             client.send_produce_request(requests)
 
     def test_timeout(self):


### PR DESCRIPTION
Fixes https://travis-ci.org/zackdever/kafka-python/jobs/116534314.

The problem this is addressing is that SimpleClient.send_produce_request(fail_on_error=False) could still fail with a `LeaderNotAvailableError ` or `UnknownTopicOrPartitionError` because they were not caught in `_payloads_by_broker`.

The problem with this approach is that this will now mask those two errors as the more generic `FailedPayloadsError` to all callers of `_send_broker_aware_request`, not just `send_produce_request`.

It's a non-trivial change to isolate this change just to `send_produce_request`, and because this will soon be deprecated, I think this is a decent approach. This will prevent hard failures during produce that are not expected, and at worst may require users to add `FailedPayloadsError` to the list of caught exceptions where they previously caught `LeaderNotAvailableError` and `UnknownTopicOrPartitionError` if they weren't already catching it.