### PR TITLE
Small improvements to fetching logic

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -338,6 +338,8 @@ class Fetcher(six.Iterator):
                 for record in self._unpack_message_set(tp, messages):
                     # Fetched compressed messages may include additional records
                     if record.offset < fetch_offset:
+                        log.debug("Skipping message offset: %s (expecting %s)",
+                                  record.offset, fetch_offset)
                         continue
                     drained[tp].append(record)
             else:
@@ -419,6 +421,9 @@ class Fetcher(six.Iterator):
                     # Compressed messagesets may include earlier messages
                     # It is also possible that the user called seek()
                     elif msg.offset != self._subscriptions.assignment[tp].position:
+                        log.debug("Skipping message offset: %s (expecting %s)",
+                                  msg.offset,
+                                  self._subscriptions.assignment[tp].position)
                         continue
 
                     self._subscriptions.assignment[tp].position = msg.offset + 1

--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -537,15 +537,24 @@ class Fetcher(six.Iterator):
         # which can be passed to FetchRequest() via .items()
         fetchable = collections.defaultdict(lambda: collections.defaultdict(list))
 
+        # avoid re-fetching pending offsets
+        pending = set()
+        for fetch_offset, tp, _ in self._records:
+            pending.add((tp, fetch_offset))
+
         for partition in self._subscriptions.fetchable_partitions():
             node_id = self._client.cluster.leader_for_partition(partition)
+            position = self._subscriptions.assignment[partition].position
+
+            # fetch if there is a leader, no in-flight requests, and no _records
             if node_id is None or node_id == -1:
                 log.debug("No leader found for partition %s."
                           " Requesting metadata update", partition)
                 self._client.cluster.request_update()
-            elif self._client.in_flight_request_count(node_id) == 0:
-                # fetch if there is a leader and no in-flight requests
-                position = self._subscriptions.assignment[partition].position
+
+            elif ((partition, position) not in pending and
+                  self._client.in_flight_request_count(node_id) == 0):
+
                 partition_info = (
                     partition.partition,
                     position,


### PR DESCRIPTION
Related to #631 

Add debug logging when skipping messages internally due to offset checks
Increase coverage of StopIteration checks when unpacking message sets
Dont re-send a FetchRequest that is pending in Fetcher._records