### PR TITLE
Use KafkaClient callback to manage BrokerConnection state changes

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -162,6 +162,12 @@ class KafkaClient(object):
             log.debug("Node %s connected", node_id)
             if node_id in self._connecting:
                 self._connecting.remove(node_id)
+            if 'bootstrap' in self._conns and node_id != 'bootstrap':
+                bootstrap = self._conns.pop('bootstrap')
+                # XXX: make conn.close() require error to cause refresh
+                self._refresh_on_disconnects = False
+                bootstrap.close()
+                self._refresh_on_disconnects = True
 
         # Connection failures imply that our metadata is stale, so let's refresh
         elif conn.state is ConnectionStates.DISCONNECTING:

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -119,7 +119,10 @@ class KafkaClient(object):
         metadata_request = MetadataRequest[0]([])
         for host, port, afi in hosts:
             log.debug("Attempting to bootstrap via node at %s:%s", host, port)
-            bootstrap = BrokerConnection(host, port, afi, **self.config)
+            cb = functools.partial(self._conn_state_change, 'bootstrap')
+            bootstrap = BrokerConnection(host, port, afi,
+                                         state_change_callback=cb,
+                                         **self.config)
             bootstrap.connect()
             while bootstrap.connecting():
                 bootstrap.connect()

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -352,6 +352,102 @@ class BrokerConnection(object):
         self._correlation_id = (self._correlation_id + 1) % 2**31
         return self._correlation_id
 
+    def check_version(self, timeout=2, strict=False):
+        """Attempt to guess the broker version. This is a blocking call."""
+
+        # Monkeypatch the connection request timeout
+        # Generally this timeout should not get triggered
+        # but in case it does, we want it to be reasonably short
+        stashed_request_timeout_ms = self.config['request_timeout_ms']
+        self.config['request_timeout_ms'] = timeout * 1000
+
+        # kafka kills the connection when it doesnt recognize an API request
+        # so we can send a test request and then follow immediately with a
+        # vanilla MetadataRequest. If the server did not recognize the first
+        # request, both will be failed with a ConnectionError that wraps
+        # socket.error (32, 54, or 104)
+        from .protocol.admin import ListGroupsRequest
+        from .protocol.commit import OffsetFetchRequest, GroupCoordinatorRequest
+        from .protocol.metadata import MetadataRequest
+
+        # Socket errors are logged as exceptions and can alarm users. Mute them
+        from logging import Filter
+        class ConnFilter(Filter):
+            def filter(self, record):
+                if record.funcName in ('recv', 'send'):
+                    return False
+                return True
+        log_filter = ConnFilter()
+        log.addFilter(log_filter)
+
+        test_cases = [
+            ('0.9', ListGroupsRequest[0]()),
+            ('0.8.2', GroupCoordinatorRequest[0]('kafka-python-default-group')),
+            ('0.8.1', OffsetFetchRequest[0]('kafka-python-default-group', [])),
+            ('0.8.0', MetadataRequest[0]([])),
+        ]
+
+        def connect():
+            self.connect()
+            if self.connected():
+                return
+            timeout_at = time.time() + timeout
+            while time.time() < timeout_at and self.connecting():
+                if self.connect() is ConnectionStates.CONNECTED:
+                    return
+                time.sleep(0.05)
+            raise Errors.NodeNotReadyError()
+
+        for version, request in test_cases:
+            connect()
+            f = self.send(request)
+            # HACK: sleeping to wait for socket to send bytes
+            time.sleep(0.1)
+            # when broker receives an unrecognized request API
+            # it abruptly closes our socket.
+            # so we attempt to send a second request immediately
+            # that we believe it will definitely recognize (metadata)
+            # the attempt to write to a disconnected socket should
+            # immediately fail and allow us to infer that the prior
+            # request was unrecognized
+            metadata = self.send(MetadataRequest[0]([]))
+
+            if self._sock:
+                self._sock.setblocking(True)
+            resp_1 = self.recv()
+            resp_2 = self.recv()
+            if self._sock:
+                self._sock.setblocking(False)
+
+            assert f.is_done, 'Future is not done? Please file bug report'
+
+            if f.succeeded():
+                log.info('Broker version identifed as %s', version)
+                break
+
+            # Only enable strict checking to verify that we understand failure
+            # modes. For most users, the fact that the request failed should be
+            # enough to rule out a particular broker version.
+            if strict:
+                # If the socket flush hack did not work (which should force the
+                # connection to close and fail all pending requests), then we
+                # get a basic Request Timeout. This is not ideal, but we'll deal
+                if isinstance(f.exception, Errors.RequestTimedOutError):
+                    pass
+                elif six.PY2:
+                    assert isinstance(f.exception.args[0], socket.error)
+                    assert f.exception.args[0].errno in (32, 54, 104)
+                else:
+                    assert isinstance(f.exception.args[0], ConnectionError)
+            log.info("Broker is not v%s -- it did not recognize %s",
+                     version, request.__class__.__name__)
+        else:
+            raise Errors.UnrecognizedBrokerVersion()
+
+        log.removeFilter(log_filter)
+        self.config['request_timeout_ms'] = stashed_request_timeout_ms
+        return version
+
     def __repr__(self):
         return "<BrokerConnection host=%s port=%d>" % (self.host, self.port)
 

--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -1,5 +1,5 @@
-import time
 import socket
+import time
 
 import pytest
 
@@ -83,25 +83,39 @@ def test_maybe_connect(conn):
     else:
         assert False, 'Exception not raised'
 
+    # New node_id creates a conn object
     assert 0 not in cli._conns
     conn.state = ConnectionStates.DISCONNECTED
     conn.connect.side_effect = lambda: conn._set_conn_state(ConnectionStates.CONNECTING)
     assert cli._maybe_connect(0) is False
     assert cli._conns[0] is conn
-    assert 0 in cli._connecting
 
-    conn.connect.side_effect = lambda: conn._set_conn_state(ConnectionStates.CONNECTED)
-    assert cli._maybe_connect(0) is True
-    assert 0 not in cli._connecting
+
+def test_conn_state_change(mocker, conn):
+    cli = KafkaClient()
+
+    node_id = 0
+    conn.state = ConnectionStates.CONNECTING
+    cli._conn_state_change(node_id, conn)
+    assert node_id in cli._connecting
+
+    conn.state = ConnectionStates.CONNECTED
+    cli._conn_state_change(node_id, conn)
+    assert node_id not in cli._connecting
 
     # Failure to connect should trigger metadata update
     assert cli.cluster._need_update is False
-    conn.state = ConnectionStates.CONNECTING
-    cli._connecting.add(0)
-    conn.connect.side_effect = lambda: conn._set_conn_state(ConnectionStates.DISCONNECTED)
-    assert cli._maybe_connect(0) is False
-    assert 0 not in cli._connecting
+    conn.state = ConnectionStates.DISCONNECTING
+    cli._conn_state_change(node_id, conn)
+    assert node_id not in cli._connecting
     assert cli.cluster._need_update is True
+
+    conn.state = ConnectionStates.CONNECTING
+    cli._conn_state_change(node_id, conn)
+    assert node_id in cli._connecting
+    conn.state = ConnectionStates.DISCONNECTING
+    cli._conn_state_change(node_id, conn)
+    assert node_id not in cli._connecting
 
 
 def test_ready(mocker, conn):

--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -34,7 +34,10 @@ def test_bootstrap_servers(mocker, bootstrap, expected_hosts):
 def test_bootstrap_success(conn):
     conn.state = ConnectionStates.CONNECTED
     cli = KafkaClient()
-    conn.assert_called_once_with('localhost', 9092, socket.AF_INET, **cli.config)
+    args, kwargs = conn.call_args
+    assert args == ('localhost', 9092, socket.AF_INET)
+    kwargs.pop('state_change_callback')
+    assert kwargs == cli.config
     conn.connect.assert_called_with()
     conn.send.assert_called_once_with(MetadataRequest[0]([]))
     assert cli._bootstrap_fails == 0
@@ -44,7 +47,10 @@ def test_bootstrap_success(conn):
 def test_bootstrap_failure(conn):
     conn.state = ConnectionStates.DISCONNECTED
     cli = KafkaClient()
-    conn.assert_called_once_with('localhost', 9092, socket.AF_INET, **cli.config)
+    args, kwargs = conn.call_args
+    assert args == ('localhost', 9092, socket.AF_INET)
+    kwargs.pop('state_change_callback')
+    assert kwargs == cli.config
     conn.connect.assert_called_with()
     conn.close.assert_called_with()
     assert cli._bootstrap_fails == 1


### PR DESCRIPTION
Also pushes check_version() code from KafkaClient to BrokerConnection.

This work is cleanup in preparation for a transition from select to selectors