### PR TITLE
Quick ugly fix Python 3 compatibility

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -120,11 +120,12 @@ class BrokerConnection(object):
         if self.state is ConnectionStates.CONNECTING:
             # in non-blocking mode, use repeated calls to socket.connect_ex
             # to check connection status
+            ret = None
             request_timeout = self.config['request_timeout_ms'] / 1000.0
             try:
                 ret = self._sock.connect_ex((self.host, self.port))
-            except socket.error as ret:
-                pass
+            except socket.error as e:
+                ret = e
 
             # Connection succeeded
             if not ret or ret == errno.EISCONN:

--- a/kafka/protocol/message.py
+++ b/kafka/protocol/message.py
@@ -25,6 +25,8 @@ class Message(Struct):
     HEADER_SIZE = 14 # crc(4), magic(1), attributes(1), key+value size(4*2)
 
     def __init__(self, value, key=None, magic=0, attributes=0, crc=0):
+        if isinstance(value, str):
+            value = value.encode()
         assert value is None or isinstance(value, bytes), 'value must be bytes'
         assert key is None or isinstance(key, bytes), 'key must be bytes'
         self.crc = crc


### PR DESCRIPTION
conn.py: 'ret' exception variable is local in Pytthon3. I think is better to rewrite connect method with self._sock.connect() to avoid handling errno & exceptions both. Let me know if this acceptable, will think about more elegant fix.

message.py: value is str. Can't figure out why. 

Fixes tested in Python 3.4.3 & 2.7.6.