### PR TITLE
Consume-produce integration test with Snappy codec

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>

--- a/test/test_consumeproduce_integration.py
+++ b/test/test_consumeproduce_integration.py
@@ -5,9 +5,10 @@ from test.testutil import (
     KafkaIntegrationTestCase, kafka_versions, random_string
 )
 from kafka import (
-    SimpleConsumer, SimpleProducer
+    SimpleConsumer, SimpleProducer, SimpleClient
 )
 from kafka.protocol import CODEC_SNAPPY
+import six
 
 
 class TestConsumerIntegration(KafkaIntegrationTestCase):
@@ -21,6 +22,10 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         cls.server = KafkaFixture.instance(0, cls.zk.host, cls.zk.port,
                                             zk_chroot=chroot)
 
+    def setUp(self):
+        super(TestConsumerIntegration, self).setUp()
+        self.client_producer = SimpleClient('%s:%d' % (self.server.host, self.server.port))
+
     @classmethod
     def tearDownClass(cls):
         if not os.environ.get('KAFKA_VERSION'):
@@ -29,10 +34,12 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         cls.server.close()
         cls.zk.close()
 
+    @kafka_versions('>=0.8.1')
     def test_snappy(self):
         cons = SimpleConsumer(self.client, "group", self.topic)
-        prod = SimpleProducer(self.client, codec=CODEC_SNAPPY)
-        content = "hey-hey are you going to transfer me?"
+        prod = SimpleProducer(self.client_producer, codec=CODEC_SNAPPY)
+        content = six.b("hey-hey are you going to transfer me?")
         prod.send_messages(self.topic, content)
-        msg = cons.get_message()
+        msg = cons.get_message(timeout=1.0)
         assert msg.message.value == content
+

--- a/test/test_consumeproduce_integration.py
+++ b/test/test_consumeproduce_integration.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import os
+from test.fixtures import ZookeeperFixture, KafkaFixture
+from test.testutil import (
+    KafkaIntegrationTestCase, kafka_versions, random_string
+)
+from kafka import (
+    SimpleConsumer, SimpleProducer
+)
+from kafka.protocol import CODEC_SNAPPY
+
+
+class TestConsumerIntegration(KafkaIntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.environ.get('KAFKA_VERSION'):
+            return
+
+        cls.zk = ZookeeperFixture.instance()
+        chroot = random_string(10)
+        cls.server = KafkaFixture.instance(0, cls.zk.host, cls.zk.port,
+                                            zk_chroot=chroot)
+
+    @classmethod
+    def tearDownClass(cls):
+        if not os.environ.get('KAFKA_VERSION'):
+            return
+
+        cls.server.close()
+        cls.zk.close()
+
+    def test_snappy(self):
+        cons = SimpleConsumer(self.client, "group", self.topic)
+        prod = SimpleProducer(self.client, codec=CODEC_SNAPPY)
+        content = "hey-hey are you going to transfer me?"
+        prod.send_messages(self.topic, content)
+        msg = cons.get_message()
+        assert msg.message.value == content

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,8 @@ deps =
     py{26,27}: six
     py26: unittest2
 commands =
-    py.test {posargs:--pylint --pylint-rcfile=pylint.rc --pylint-error-types=EF --cov=kafka}
+    py.test -v -s -k test_snappy
+#    py.test {posargs:--pylint --pylint-rcfile=pylint.rc --pylint-error-types=EF --cov=kafka} -k test_snappy
 setenv =
     PROJECT_ROOT = {toxinidir}
 passenv = KAFKA_VERSION


### PR DESCRIPTION
Hi guys,
Before 1.0.x series consumer was able to detect if message was compressed and use the necessary decompression codec. During refactoring from `kafka.common` to `kafka.structs` this feature was lost. That breaks backwards compatibility. It would be nice if we could merge this test along with getting back lost feature, or figure some other way how to fix it.
