### PR TITLE
Fix throttle_time_ms sensor for FetchRequest v0

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -653,7 +653,8 @@ class Fetcher(six.Iterator):
 
         self._sensors.bytes_fetched.record(total_bytes)
         self._sensors.records_fetched.record(total_count)
-        self._sensors.fetch_throttle_time_sensor.record(response['throttle_time_ms'])
+        if response.API_VERSION >= 1:
+            self._sensors.fetch_throttle_time_sensor.record(response.throttle_time_ms)
         self._sensors.fetch_latency.record((recv_time - send_time) * 1000)
 
 


### PR DESCRIPTION
Still need to investigate why tests aren't failing.

Could also look at possibly removing `fetch_throttle_time_sensor` entirely when the api version is 0. This isn't what caused the bug, but I just realized that `throttle_time_ms` is only available starting with api version 1.