### PR TITLE
Consistent error handling in future call/errbacks + better test failures

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -15,3 +15,6 @@ except ImportError:
             pass
 
 logging.getLogger(__name__).addHandler(NullHandler())
+
+from kafka.future import Future
+Future.error_on_callbacks = True  # always fail during testing

--- a/test/test_coordinator.py
+++ b/test/test_coordinator.py
@@ -548,7 +548,7 @@ def test_send_offset_fetch_request_success(patched_coord, partitions):
     patched_coord._client.send.return_value = _f
     future = patched_coord._send_offset_fetch_request(partitions)
     (node, request), _ = patched_coord._client.send.call_args
-    response = OffsetFetchResponse[0]([('foobar', [(0, 0), (1, 0)])])
+    response = OffsetFetchResponse[0]([('foobar', [(0, 123, b'', 0), (1, 234, b'', 0)])])
     _f.success(response)
     patched_coord._handle_offset_fetch_response.assert_called_with(
         future, response) 


### PR DESCRIPTION
Error handling in call/errbacks was different depending on whether the future had already completed. Exceptions were not caught if a callback was added after the future had completed, but they were caught if they were added before the future had completed. This PR ensures that they are always caught.

Additionally, because errors are logged, but not thrown in future callbacks, our tests were not failing on errors such as #667. This PR adds a class variable `error_on_callbacks` to `Future` that can be set so that errors bubble up. By default this is off, but is always turned on for testing. Users could also use this flag if useful.