### PR TITLE
Add CRL support to SSL support

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -59,6 +59,7 @@ class KafkaClient(object):
         'ssl_cafile': None,
         'ssl_certfile': None,
         'ssl_keyfile': None,
+        'ssl_crlfile': None,
     }
 
     def __init__(self, **configs):
@@ -110,6 +111,11 @@ class KafkaClient(object):
                 the client certificate, as well as any ca certificates needed to
                 establish the certificate's authenticity. default: none.
             ssl_keyfile (str): optional filename containing the client private key.
+                default: none.
+            ssl_crlfile (str): optional filename containing the CRL to check for
+                certificate expiration. By default, no CRL check is done. When
+                providing a file, only the leaf certificate will be checked against
+                this CRL. The CRL can only be checked with Python 3.4+ or 2.7.9+.
                 default: none.
         """
         self.config = copy.copy(self.DEFAULT_CONFIG)

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -138,6 +138,11 @@ class KafkaConsumer(six.Iterator):
             establish the certificate's authenticity. default: none.
         ssl_keyfile (str): optional filename containing the client private key.
             default: none.
+        ssl_crlfile (str): optional filename containing the CRL to check for
+            certificate expiration. By default, no CRL check is done. When
+            providing a file, only the leaf certificate will be checked against
+            this CRL. The CRL can only be checked with Python 3.4+ or 2.7.9+.
+            default: none.
         api_version (str): specify which kafka API version to use.
             0.9 enables full group coordination features; 0.8.2 enables
             kafka-storage offset commits; 0.8.1 enables zookeeper-storage
@@ -187,6 +192,7 @@ class KafkaConsumer(six.Iterator):
         'ssl_cafile': None,
         'ssl_certfile': None,
         'ssl_keyfile': None,
+        'ssl_crlfile': None,
         'api_version': 'auto',
         'connections_max_idle_ms': 9 * 60 * 1000, # not implemented yet
         'metric_reporters': [],

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -207,6 +207,11 @@ class KafkaProducer(object):
             establish the certificate's authenticity. default: none.
         ssl_keyfile (str): optional filename containing the client private key.
             default: none.
+        ssl_crlfile (str): optional filename containing the CRL to check for
+            certificate expiration. By default, no CRL check is done. When
+            providing a file, only the leaf certificate will be checked against
+            this CRL. The CRL can only be checked with Python 3.4+ or 2.7.9+.
+            default: none.
         api_version (str): specify which kafka API version to use.
             If set to 'auto', will attempt to infer the broker version by
             probing various APIs. Default: auto
@@ -243,6 +248,7 @@ class KafkaProducer(object):
         'ssl_cafile': None,
         'ssl_certfile': None,
         'ssl_keyfile': None,
+        'ssl_crlfile': None,
         'api_version': 'auto',
     }
 


### PR DESCRIPTION
A user can provide a CRL whose peer certificate will be checked
against. This only works with Python 3.4+ and Python 2.7.9+.

Lightly tested with `example.py`.