### PR TITLE
[SimpleConsumer] Fix legacy SimpleConsumer with compressed messages

### DIFF
--- a/kafka/consumer/simple.py
+++ b/kafka/consumer/simple.py
@@ -30,7 +30,6 @@ from ..common import (
     UnknownTopicOrPartitionError, NotLeaderForPartitionError,
     OffsetOutOfRangeError, FailedPayloadsError, check_error
 )
-from kafka import structs
 from kafka.protocol.message import PartialMessage
 
 
@@ -434,26 +433,12 @@ class SimpleConsumer(Consumer):
                     retry_partitions[partition] = buffer_size
                     resp.messages.pop()
 
-                for off_and_msg in resp.messages:
-                    (offset, message) = off_and_msg
-                    # Put the messages in our queue
-                    if message.is_compressed():
-                        inner_messages = message.decompress()
-                        for (offset, _msg_size, inner_msg) in inner_messages:
-                            if offset < self.fetch_offsets[partition]:
-                                log.debug('Skipping message %s because its offset is less than the consumer offset',
-                                          message)
-                                continue
-                            self.queue.put((partition,
-                                            structs.OffsetAndMessage(
-                                                offset=offset,
-                                                message=inner_msg)))
-                            self.fetch_offsets[partition] = offset + 1
-                    else:
-                        if offset < self.fetch_offsets[partition]:
-                            log.debug('Skipping message %s because its offset is less than the consumer offset',
-                                      message)
-                            continue
-                        self.queue.put((partition, off_and_msg))
-                        self.fetch_offsets[partition] = offset + 1
+                for message in resp.messages:
+                    if message.offset < self.fetch_offsets[partition]:
+                        log.debug('Skipping message %s because its offset is less than the consumer offset',
+                                  message)
+                        continue
+                    # Put the message in our queue
+                    self.queue.put((partition, message))
+                    self.fetch_offsets[partition] = message.offset + 1
             partitions = retry_partitions

--- a/kafka/protocol/legacy.py
+++ b/kafka/protocol/legacy.py
@@ -204,20 +204,21 @@ class KafkaProtocol(object):
         return [
             kafka.structs.FetchResponsePayload(
                 topic, partition, error, highwater_offset, [
-                    kafka.structs.OffsetAndMessage(cls.decode_message_set(offset, message))
-                    for offset, _, message in messages])
+                    offset_and_msg
+                    for offset_and_msg in cls.decode_message_set(messages)])
             for topic, partitions in response.topics
                 for partition, error, highwater_offset, messages in partitions
         ]
 
     @classmethod
-    def decode_message_set(cls, offset, message):
-        if message.is_compressed():
-            inner_messages = message.decompress()
-            for (inner_offset, _msg_size, inner_msg) in inner_messages:
-                yield inner_offset, inner_msg
-        else:
-            yield offset, message
+    def decode_message_set(cls, messages):
+        for offset, _, message in messages:
+            if isinstance(message, kafka.protocol.message.Message) and message.is_compressed():
+                inner_messages = message.decompress()
+                for (inner_offset, _msg_size, inner_msg) in inner_messages:
+                    yield kafka.structs.OffsetAndMessage(inner_offset, inner_msg)
+            else:
+                yield kafka.structs.OffsetAndMessage(offset, message)
 
     @classmethod
     def encode_offset_request(cls, payloads=()):


### PR DESCRIPTION
Summary:

Fix legacy SimpleConsumer with compressed messages. Decompress messages if they are compressed and add a test for the new logic.

Test Plan:

KAFKA_VERSION=0.9.0.1 tox -e py27 test/test_consumer_integration.py