### PR TITLE
supplement socket.gaierror exception in BrokerConnection.connect()

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -118,7 +118,7 @@ class BrokerConnection(object):
                         self._gai = socket.getaddrinfo(self.host, self.port,
                                                        socket.AF_UNSPEC,
                                                        socket.SOCK_STREAM)
-                    except socket.gaierror, ex:
+                    except socket.gaierror as ex:
                         raise socket.gaierror('getaddrinfo failed for {0}:{1}, ' 
                           'exception was {2}. Is your advertised.host.name correct'
                           ' and resolvable?'.format(

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -114,9 +114,16 @@ class BrokerConnection(object):
                     # library like python-adns, or move resolution onto its
                     # own thread. This will be subject to the default libc
                     # name resolution timeout (5s on most Linux boxes)
-                    self._gai = socket.getaddrinfo(self.host, self.port,
-                                                   socket.AF_UNSPEC,
-                                                   socket.SOCK_STREAM)
+                    try:
+                        self._gai = socket.getaddrinfo(self.host, self.port,
+                                                       socket.AF_UNSPEC,
+                                                       socket.SOCK_STREAM)
+                    except socket.gaierror, ex:
+                        raise socket.gaierror('getaddrinfo failed for {0}:{1}, ' 
+                          'exception was {2}. Is your advertised.host.name correct'
+                          ' and resolvable?'.format(
+                             self.host, self.port, ex
+                          ))
                     self._gai_index = 0
                 else:
                     # if self._gai already exists, then we should try the next


### PR DESCRIPTION
If you attempt to instantiate a KafkaConsumer object like this:

k = KafkaConsumer('ILikeTopics', bootstrap_servers = ["myserver:9092"])

.. and the Kafka instance on "myserver" happens to believe that its name is something like "ip-10-0.0.1.ec2.internal", which you can't resolve, you'll get a trace that looks like:

Traceback (most recent call last):
  File "my_kafka_test.py", line 2, in <module>
    k = KafkaConsumer('ILikeTopics', bootstrap_servers = ["myserver:9092"])
  File "/Users/erik/virtualenvs/my_kafka_test/lib/python2.7/site-packages/kafka/consumer/group.py", line 227, in __init__
    self.config['api_version'] = self._client.check_version()
  File "/Users/erik/virtualenvs/my_kafka_test/lib/python2.7/site-packages/kafka/client_async.py", line 673, in check_version
    self._maybe_connect(node_id)
  File "/Users/erik/virtualenvs/my_kafka_test/lib/python2.7/site-packages/kafka/client_async.py", line 247, in _maybe_connect
    conn.connect()
  File "/Users/erik/virtualenvs/my_kafka_test/lib/python2.7/site-packages/kafka/conn.py", line 120, in connect
    socket.SOCK_STREAM)
socket.gaierror: [Errno 8] nodename nor servname provided, or not known

.. which doesn't allude to the real source of the problem.  The socket.gaierror exception should ideally return the host/port combo causing the problem.  (and I also added a note to check the advertised hostname in kafka, I don't know if this is helpful or not, but it was to me!).  