### PR TITLE
Dont use soon-to-be-reserved keyword await as function name

### DIFF
--- a/kafka/producer/future.py
+++ b/kafka/producer/future.py
@@ -23,7 +23,7 @@ class FutureProduceResult(Future):
         self._latch.set()
         return ret
 
-    def await(self, timeout=None):
+    def wait(self, timeout=None):
         # wait() on python2.6 returns None instead of the flag value
         return self._latch.wait(timeout) or self._latch.is_set()
 
@@ -46,7 +46,7 @@ class FutureRecordMetadata(Future):
                                     self.relative_offset))
 
     def get(self, timeout=None):
-        if not self.is_done and not self._produce_future.await(timeout):
+        if not self.is_done and not self._produce_future.wait(timeout):
             raise Errors.KafkaTimeoutError(
                 "Timeout after waiting for %s secs." % timeout)
         assert self.is_done

--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -470,7 +470,7 @@ class RecordAccumulator(object):
             for batch in self._incomplete.all():
                 log.debug('Waiting on produce to %s',
                           batch.produce_future.topic_partition)
-                assert batch.produce_future.await(timeout=timeout), 'Timeout waiting for future'
+                assert batch.produce_future.wait(timeout=timeout), 'Timeout waiting for future'
                 assert batch.produce_future.is_done, 'Future not done?'
                 if batch.produce_future.failed():
                     log.warning(batch.produce_future.exception)


### PR DESCRIPTION
Fix #677 
Changes FutureProduceResult `await()` to `wait()`