### PR TITLE
KAFKA-3197: improve producer batch ordering

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -286,7 +286,9 @@ class KafkaProducer(object):
         message_version = 1 if self.config['api_version'] >= (0, 10) else 0
         self._accumulator = RecordAccumulator(message_version=message_version, **self.config)
         self._metadata = client.cluster
+        guarantee_message_order = bool(self.config['max_in_flight_requests_per_connection'] == 1)
         self._sender = Sender(client, self._metadata, self._accumulator,
+                              guarantee_message_order=guarantee_message_order,
                               **self.config)
         self._sender.daemon = True
         self._sender.start()


### PR DESCRIPTION
Fix #595 -- when max.in.flight.request.per.connection = 1, attempt to guarantee ordering in producer
