### PR TITLE
Use weakref when registering a producer.close atexit to fix normal gc

### DIFF
--- a/kafka/util.py
+++ b/kafka/util.py
@@ -1,3 +1,4 @@
+import atexit
 import binascii
 import collections
 import struct
@@ -188,3 +189,12 @@ class WeakMethod(object):
         if not isinstance(other, WeakMethod):
             return False
         return self._target_id == other._target_id and self._method_id == other._method_id
+
+
+def try_method_on_system_exit(obj, method, *args, **kwargs):
+    def wrapper(_obj, _meth, *args, **kwargs):
+        try:
+            getattr(_obj, _meth)(*args, **kwargs)
+        except (ReferenceError, AttributeError):
+            pass
+    atexit.register(wrapper, weakref.proxy(obj), method, *args, **kwargs)

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -1,4 +1,7 @@
+import gc
+import platform
 import sys
+import threading
 
 import pytest
 
@@ -64,3 +67,14 @@ def test_end_to_end(kafka_broker, compression):
             break
 
     assert msgs == set(['msg %d' % i for i in range(messages)])
+
+
+@pytest.mark.skipif(platform.python_implementation() != 'CPython',
+                    reason='Test relies on CPython-specific gc policies')
+def test_kafka_producer_gc_cleanup():
+    threads = threading.active_count()
+    producer = KafkaProducer(api_version='0.9') # set api_version explicitly to avoid auto-detection
+    assert threading.active_count() == threads + 1
+    del(producer)
+    gc.collect()
+    assert threading.active_count() == threads


### PR DESCRIPTION
Fix #727 