### PR TITLE
Avoid busy poll during metadata refresh failure with retry_backoff_ms

### DIFF
--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -131,6 +131,10 @@ class ClusterMetadata(object):
 
         return max(ttl, next_retry, 0)
 
+    def refresh_backoff(self):
+        """Return milliseconds to wait before attempting to retry after failure"""
+        return self.config['retry_backoff_ms']
+
     def request_update(self):
         """Flags metadata for update, return Future()
 


### PR DESCRIPTION
If the cluster enters complete failure -- no nodes are available to service a metadata request -- the client was prone to busy polling, which would peg CPU at 100%. This PR aligns backoff behavior with the official java client using the 'retry_backoff_ms' configuration parameter.