### PR TITLE
Wakeup socket optimizations

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -726,7 +726,7 @@ class KafkaClient(object):
     def _clear_wake_fd(self):
         while True:
             try:
-                self._wake_r.recv(1)
+                self._wake_r.recv(1024)
             except:
                 break
 

--- a/kafka/producer/sender.py
+++ b/kafka/producer/sender.py
@@ -163,7 +163,12 @@ class Sender(threading.Thread):
         self.initiate_close()
 
     def add_topic(self, topic):
-        if topic not in self._topics_to_add:
+        # This is generally called from a separate thread
+        # so this needs to be a thread-safe operation
+        # we assume that checking set membership across threads
+        # is ok where self._client._topics should never
+        # remove topics for a producer instance, only add them.
+        if topic not in self._client._topics:
             self._topics_to_add.add(topic)
             self.wakeup()
 


### PR DESCRIPTION
`add_topic` is expected to be idempotent and is called (via `_wait_on_metadata`) on every `producer.send()` . By checking the temporary `_topics_to_add` set, the prior behavior would trigger a very large number of client thread wakeups. This PR alters add_topic so that it checks the client topic list directly, short-circuiting the need to wakeup the client thread. This is a cross-thread check w/o synchronization, but I believe it should be safe in this context.