### PR TITLE
Avoid AttributeErrors in _unregister_cleanup

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -314,7 +314,7 @@ class KafkaProducer(object):
         return wrapper
 
     def _unregister_cleanup(self):
-        if getattr(self, '_cleanup'):
+        if getattr(self, '_cleanup', None):
             if hasattr(atexit, 'unregister'):
                 atexit.unregister(self._cleanup) # pylint: disable=no-member
 


### PR DESCRIPTION
If python gc attempts to cleanup a producer object that hasn't fully initialized it can generate a scary log message. Though note that the gc system ignores this error and continues on unabated. Nonetheless, the log message is messy and causes confusion.

Fix #741