### PR TITLE
Add ssl_password to default_config dicts. Send ssl_password when loading cert chains

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -59,6 +59,7 @@ class KafkaClient(object):
         'ssl_cafile': None,
         'ssl_certfile': None,
         'ssl_keyfile': None,
+        'ssl_password': None,
         'ssl_crlfile': None,
     }
 

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -71,6 +71,7 @@ class BrokerConnection(object):
         'ssl_certfile': None,
         'ssl_keyfile': None,
         'ssl_crlfile': None,
+        'ssl_password': None,
         'api_version': (0, 8, 2),  # default to most restrictive
         'state_change_callback': lambda conn: True,
     }
@@ -228,7 +229,8 @@ class BrokerConnection(object):
                 log.info('%s: Loading SSL Key from %s', str(self), self.config['ssl_keyfile'])
                 self._ssl_context.load_cert_chain(
                     certfile=self.config['ssl_certfile'],
-                    keyfile=self.config['ssl_keyfile'])
+                    keyfile=self.config['ssl_keyfile'],
+                    password=self.config['ssl_password'])
             if self.config['ssl_crlfile']:
                 if not hasattr(ssl, 'VERIFY_CRL_CHECK_LEAF'):
                     log.error('%s: No CRL support with this version of Python.'

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -196,6 +196,7 @@ class KafkaConsumer(six.Iterator):
         'ssl_certfile': None,
         'ssl_keyfile': None,
         'ssl_crlfile': None,
+        'ssl_password': None,
         'api_version': 'auto',
         'api_version_auto_timeout_ms': 2000,
         'connections_max_idle_ms': 9 * 60 * 1000, # not implemented yet


### PR DESCRIPTION
Our team wanted to be able to set an ssl_password in config so a KafkaConsumer could be created with SSL certification and not need to enter a password manually. This minor changes add the ssl_password in all the default config dicts necessary and allow for it to be set when instantiating a consumer instance.