### PR TITLE
Fix consumer iteration on compacted topics

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -438,7 +438,7 @@ class Fetcher(six.Iterator):
 
                     # Compressed messagesets may include earlier messages
                     # It is also possible that the user called seek()
-                    elif msg.offset != self._subscriptions.assignment[tp].position:
+                    elif msg.offset < self._subscriptions.assignment[tp].position:
                         log.debug("Skipping message offset: %s (expecting %s)",
                                   msg.offset,
                                   self._subscriptions.assignment[tp].position)

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -350,6 +350,7 @@ class TopicPartitionState(object):
         self.reset_strategy = None # the reset strategy if awaitingReset is set
         self._position = None # offset exposed to the user
         self.highwater = None
+        self.drop_pending_message_set = False
 
     def _set_position(self, offset):
         assert self.has_valid_position, 'Valid position required'
@@ -371,6 +372,7 @@ class TopicPartitionState(object):
         self.awaiting_reset = False
         self.reset_strategy = None
         self.has_valid_position = True
+        self.drop_pending_message_set = True
 
     def pause(self):
         self.paused = True


### PR DESCRIPTION
KafkaConsumer iteration was broken for compacted topics. This PR should fix that as well as fix the `seek()` semantics that are affected by it.

@zackdever -- thank you for finding this bug!