### PR TITLE
Drop recursion in Fetcher _unpack_message_set

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -361,6 +361,14 @@ class Fetcher(six.Iterator):
                     # If relative offset is used, we need to decompress the entire message first to compute
                     # the absolute offset.
                     inner_mset = msg.decompress()
+
+                    # There should only ever be a single layer of compression
+                    if inner_mset[0][-1].is_compressed():
+                        log.warning('MessageSet at %s offset %d appears '
+                                    ' double-compressed. This should not'
+                                    ' happen -- check your producers!',
+                                    tp, offset)
+
                     if msg.magic > 0:
                         last_offset, _, _ = inner_mset[-1]
                         absolute_base_offset = offset - last_offset

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -123,6 +123,13 @@ class KafkaConsumer(six.Iterator):
         consumer_timeout_ms (int): number of milliseconds to block during
             message iteration before raising StopIteration (i.e., ending the
             iterator). Default -1 (block forever).
+        skip_double_compressed_messages (bool): A bug in KafkaProducer <= 1.2.4
+            caused some messages to be corrupted via double-compression.
+            By default, the fetcher will return these messages as a compressed
+            blob of bytes with a single offset, i.e. how the message was
+            actually published to the cluster. If you prefer to have the
+            fetcher automatically detect corrupt messages and skip them,
+            set this option to True. Default: False.
         security_protocol (str): Protocol used to communicate with brokers.
             Valid values are: PLAINTEXT, SSL. Default: PLAINTEXT.
         ssl_context (ssl.SSLContext): pre-configured SSLContext for wrapping
@@ -189,6 +196,7 @@ class KafkaConsumer(six.Iterator):
         'send_buffer_bytes': None,
         'receive_buffer_bytes': None,
         'consumer_timeout_ms': -1,
+        'skip_double_compressed_messages': False,
         'security_protocol': 'PLAINTEXT',
         'ssl_context': None,
         'ssl_check_hostname': True,


### PR DESCRIPTION
Attempt to simplify unpacking of compressed messages. Related to #718 -- KafkaConsumer no longer attempts to decompress more than a single layer of messages. If a message set was double-compressed by the producer, this patch will cause KafkaConsumer to return the compressed bytes as a single message for the entire batch. A warning will be logged, but otherwise the data will no longer appear "skipped", it will appear as corrupted. If the user wants to simply skip these messages, there is a new configuration parameter `skip_double_compressed_messages`

Longer term we should refactor Message / MessageSets to expose raw bytes and let handle_fetch_response unpack and decompress (this is how the java client operates)