### PR TITLE
check_version / api_version should always be tuples

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -541,7 +541,12 @@ class BrokerConnection(object):
         return self._correlation_id
 
     def check_version(self, timeout=2, strict=False):
-        """Attempt to guess the broker version. This is a blocking call."""
+        """Attempt to guess the broker version.
+
+        Note: This is a blocking call.
+
+        Returns: version tuple, i.e. (0, 10), (0, 9), (0, 8, 2), ...
+        """
 
         # Monkeypatch the connection request timeout
         # Generally this timeout should not get triggered
@@ -643,7 +648,7 @@ class BrokerConnection(object):
 
         log.removeFilter(log_filter)
         self.config['request_timeout_ms'] = stashed_request_timeout_ms
-        return version
+        return tuple(map(int, version.split('.')))
 
     def __repr__(self):
         return "<BrokerConnection host=%s/%s port=%d>" % (self.hostname, self.host,

--- a/test/test_consumer_group.py
+++ b/test/test_consumer_group.py
@@ -139,7 +139,7 @@ def test_paused(kafka_broker, topic):
 
 
 def test_heartbeat_timeout(conn, mocker):
-    mocker.patch('kafka.client_async.KafkaClient.check_version', return_value = '0.9')
+    mocker.patch('kafka.client_async.KafkaClient.check_version', return_value = (0, 9))
     mocker.patch('time.time', return_value = 1234)
     consumer = KafkaConsumer('foobar')
     mocker.patch.object(consumer._coordinator.heartbeat, 'ttl', return_value = 0)

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -15,7 +15,7 @@ from kafka.structs import TopicPartition, OffsetAndMetadata
 
 @pytest.fixture
 def client(mocker):
-    return mocker.Mock(spec=KafkaClient(bootstrap_servers=[]))
+    return mocker.Mock(spec=KafkaClient(bootstrap_servers=[], api_version=(0, 9)))
 
 
 @pytest.fixture

--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -18,7 +18,7 @@ from kafka.structs import TopicPartition, OffsetAndMetadata
 
 @pytest.fixture
 def client(mocker):
-    _cli = mocker.Mock(spec=KafkaClient(bootstrap_servers=[]))
+    _cli = mocker.Mock(spec=KafkaClient(bootstrap_servers=[], api_version=(0, 9)))
     _cli.cluster = mocker.Mock(spec=ClusterMetadata())
     return _cli
 


### PR DESCRIPTION
api_version was previously converted to a tuple internally so that we could easily compare versions. This PR changes the interfaces for KafkaClient.check_version and BrokerConnection.check_version to return these tuples (previously returned str). And the top-level configuration api_version parameter to KafkaConsumer and KafkaProducer also is changed to a tuple.

Also changed is that KafkaClient now performs a check_version probe during `__init__` by default. Previously it did not, although it did perform network IO via bootstrapping. The check_version call does potentially raise an exception, so any user that is using KafkaClient directly would need to either pass an explicit api_version or try / except for NoBrokersAvailable.

The goal here is to simplify api_version handling internally, make the data consistent (now always a tuple), and enable KafkaClient itself to check the api_version in the future for feature flags like using Metadata v1.