### PR TITLE
Fix typo in KafkaConsumer documentation

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -139,7 +139,7 @@ class KafkaConsumer(six.Iterator):
             should verify that the certificate matches the brokers hostname.
             default: true.
         ssl_cafile (str): optional filename of ca file to use in certificate
-            veriication. default: none.
+            verification. default: none.
         ssl_certfile (str): optional filename of file in pem format containing
             the client certificate, as well as any ca certificates needed to
             establish the certificate's authenticity. default: none.


### PR DESCRIPTION
Couldn't find a `CONTRIBUTING.md` or similar, so I apologize if this doesn't follow guidelines; let me know, and I'll fix it. :)