### PR TITLE
Change _pickle_method to use python3 special attributes

### DIFF
--- a/kafka/protocol/pickle.py
+++ b/kafka/protocol/pickle.py
@@ -9,9 +9,15 @@ import types
 
 
 def _pickle_method(method):
-    func_name = method.im_func.__name__
-    obj = method.im_self
-    cls = method.im_class
+    try:
+        func_name = method.__func__.__name__
+        obj = method.__self__
+        cls = method.__self__.__class__
+    except AttributeError:
+        func_name = method.im_func.__name__
+        obj = method.im_self
+        cls = method.im_class
+
     return _unpickle_method, (func_name, obj, cls)
 
 


### PR DESCRIPTION
Issue: _pickle_method() uses attributes are not python 3 compatible.
Fix: updated to use python 3 special attributes.