### PR TITLE
Document the ssl_password config option

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -145,6 +145,8 @@ class KafkaConsumer(six.Iterator):
             establish the certificate's authenticity. default: none.
         ssl_keyfile (str): optional filename containing the client private key.
             default: none.
+        ssl_password (str): optional password to be used when loading the
+            certificate chain. default: None.
         ssl_crlfile (str): optional filename containing the CRL to check for
             certificate expiration. By default, no CRL check is done. When
             providing a file, only the leaf certificate will be checked against


### PR DESCRIPTION
PR #750 added the code for passing along a password, but not any documentation on it.