### PR TITLE
KAFKA-3960: Fix offset fetch when partitions are manually assigned

### DIFF
--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -199,6 +199,7 @@ class SubscriptionState(object):
             del self.assignment[tp]
 
         self.needs_partition_assignment = False
+        self.needs_fetch_committed_offsets = True
 
     def assign_from_subscribed(self, assignments):
         """Update the assignment to the specified partitions


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/KAFKA-3960