### PR TITLE
Rename _DEFAULT_CONFIG -> DEFAULT_CONFIG in KafkaProducer

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -240,7 +240,7 @@ class KafkaProducer(object):
         Configuration parameters are described in more detail at
         https://kafka.apache.org/0100/configuration.html#producerconfigs
     """
-    _DEFAULT_CONFIG = {
+    DEFAULT_CONFIG = {
         'bootstrap_servers': 'localhost',
         'client_id': None,
         'key_serializer': None,
@@ -280,7 +280,7 @@ class KafkaProducer(object):
 
     def __init__(self, **configs):
         log.debug("Starting the Kafka producer") # trace
-        self.config = copy.copy(self._DEFAULT_CONFIG)
+        self.config = copy.copy(self.DEFAULT_CONFIG)
         for key in self.config:
             if key in configs:
                 self.config[key] = configs.pop(key)

--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -155,7 +155,7 @@ class RecordAccumulator(object):
             produce request upon receiving an error. This avoids exhausting
             all retries in a short period of time. Default: 100
     """
-    _DEFAULT_CONFIG = {
+    DEFAULT_CONFIG = {
         'buffer_memory': 33554432,
         'batch_size': 16384,
         'compression_type': None,
@@ -165,7 +165,7 @@ class RecordAccumulator(object):
     }
 
     def __init__(self, **configs):
-        self.config = copy.copy(self._DEFAULT_CONFIG)
+        self.config = copy.copy(self.DEFAULT_CONFIG)
         for key in self.config:
             if key in configs:
                 self.config[key] = configs.pop(key)

--- a/kafka/producer/sender.py
+++ b/kafka/producer/sender.py
@@ -24,7 +24,7 @@ class Sender(threading.Thread):
     Kafka cluster. This thread makes metadata requests to renew its view of the
     cluster and then sends produce requests to the appropriate nodes.
     """
-    _DEFAULT_CONFIG = {
+    DEFAULT_CONFIG = {
         'max_request_size': 1048576,
         'acks': 1,
         'retries': 0,
@@ -36,7 +36,7 @@ class Sender(threading.Thread):
 
     def __init__(self, client, metadata, accumulator, metrics, **configs):
         super(Sender, self).__init__()
-        self.config = copy.copy(self._DEFAULT_CONFIG)
+        self.config = copy.copy(self.DEFAULT_CONFIG)
         for key in self.config:
             if key in configs:
                 self.config[key] = configs.pop(key)


### PR DESCRIPTION
Change to make KafkaConsumer and KafkaProducer consistent