### PR TITLE
Fix consumer group test bug

### DIFF
--- a/test/test_consumer_group.py
+++ b/test/test_consumer_group.py
@@ -95,7 +95,12 @@ def test_group(kafka_broker, topic):
                 generations = set([consumer._coordinator.generation
                                    for consumer in list(consumers.values())])
 
-                if len(generations) == 1:
+                # New generation assignment is not complete until
+                # coordinator.rejoining = False
+                rejoining = any([consumer._coordinator.rejoining
+                                 for consumer in list(consumers.values())])
+
+                if not rejoining and len(generations) == 1:
                     for c, consumer in list(consumers.items()):
                         logging.info("[%s] %s %s: %s", c,
                                      consumer._coordinator.generation,


### PR DESCRIPTION
The coordinator updates the local generation_id after JoinGroup, but new assignments are not available until after SyncGroup. Use the coordinator.rejoining flag to wait until all consumers are in new generation and have new assignments.