### PR TITLE
Fixture auto ports

### DIFF
--- a/.covrc
+++ b/.covrc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    kafka/vendor/*

--- a/tox.ini
+++ b/tox.ini
@@ -21,18 +21,18 @@ deps =
     xxhash
     py26: unittest2
 commands =
-    py.test {posargs:--pylint --pylint-rcfile=pylint.rc --pylint-error-types=EF --cov=kafka}
+    py.test {posargs:--pylint --pylint-rcfile=pylint.rc --pylint-error-types=EF --cov=kafka --cov-config=.covrc}
 setenv =
     PROJECT_ROOT = {toxinidir}
 passenv = KAFKA_VERSION
 
 [testenv:py26]
 # pylint doesn't support python2.6
-commands = py.test {posargs:--cov=kafka}
+commands = py.test {posargs:--cov=kafka --cov-config=.covrc}
 
 [testenv:pypy]
 # pylint is super slow on pypy...
-commands = py.test {posargs:--cov=kafka}
+commands = py.test {posargs:--cov=kafka --cov-config=.covrc}
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Attempt to fix transient kafka fixture issues that are seen on travis. The travis logs suggest that kafka brokers are failing because of port conflicts. This PR changes the fixture retry process to try with a new port number after failing.