### PR TITLE
Workaround gevent bug in python3 connect_ex monkeypatch

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -270,7 +270,7 @@ class BrokerConnection(object):
                     self.afi = self._sock.family
                     self._gai = None
             except socket.error as err:
-                ret = err
+                ret = self._get_errno(err)
 
             # Connection succeeded
             if not ret or ret == errno.EISCONN:
@@ -317,6 +317,11 @@ class BrokerConnection(object):
                 self.config['state_change_callback'](self)
 
         return self.state
+
+    def _get_errno(self, socket_error):
+        if isinstance(socket_error, BlockingIOError):
+            return socket_error.errno
+        return socket_error
 
     def _wrap_ssl(self):
         assert self.config['security_protocol'] in ('SSL', 'SASL_SSL')


### PR DESCRIPTION
For example, the gevent socket implementation returns a `BlockingIOError` instead of an int errno. This is the only place I see it being used, so I figured this is the simplest fix for now. 

Let me know your thoughts.
