### PR TITLE
Raise exception if given a bad topic name

### DIFF
--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -133,6 +133,9 @@ class SubscriptionState(object):
         if self._user_assignment:
             raise IllegalStateError(self._SUBSCRIPTION_EXCEPTION_MESSAGE)
 
+        if isinstance(topics, str):
+            topics = [topics]
+
         if self.subscription == set(topics):
             log.warning("subscription unchanged by change_subscription(%s)",
                         topics)

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -128,6 +128,7 @@ class SubscriptionState(object):
 
         Raises:
             IllegalStateErrror: if assign_from_user has been used already
+            TypeError: if a non-str topic is given
         """
         if self._user_assignment:
             raise IllegalStateError(self._SUBSCRIPTION_EXCEPTION_MESSAGE)
@@ -136,6 +137,9 @@ class SubscriptionState(object):
             log.warning("subscription unchanged by change_subscription(%s)",
                         topics)
             return
+
+        if any(not isinstance(t, str) for t in topics):
+            raise TypeError('All topics must be strings')
 
         log.info('Updating subscribed topics to: %s', topics)
         self.subscription = set(topics)


### PR DESCRIPTION
I accidentally tried to `.subscribe([None])` this morning, and it took a little while to figure out what I'd done wrong.

Thought this check might be useful in the future. What do you think?
