### PR TITLE
Partitioners fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/_build
 .cache*
 .idea/
 integration-test/
+tests-env/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ servers/*/resources/ssl*
 docs/_build
 .cache*
 .idea/
+integration-test/

--- a/kafka/partitioner/base.py
+++ b/kafka/partitioner/base.py
@@ -5,22 +5,23 @@ class Partitioner(object):
     """
     Base class for a partitioner
     """
-    def __init__(self, partitions):
+    def __init__(self, partitions=None):
         """
         Initialize the partitioner
 
         Arguments:
-            partitions: A list of available partitions (during startup)
+            partitions: A list of available partitions (during startup) OPTIONAL.
         """
         self.partitions = partitions
 
-    def partition(self, key, partitions=None):
+    def __call__(self, key, all_partitions, available_partitions):
         """
-        Takes a string key and num_partitions as argument and returns
+        Takes a string key, num_partitions and available_partitions as argument and returns
         a partition to be used for the message
 
         Arguments:
-            key: the key to use for partitioning
-            partitions: (optional) a list of partitions.
+            key: the key to use for partitioning.
+            all_partitions: a list of the topic's partitions.
+            available_partitions: a list of the broker's currently avaliable partitions(optional).
         """
         raise NotImplementedError('partition function has to be implemented')

--- a/kafka/partitioner/base.py
+++ b/kafka/partitioner/base.py
@@ -14,7 +14,7 @@ class Partitioner(object):
         """
         self.partitions = partitions
 
-    def __call__(self, key, all_partitions, available_partitions):
+    def __call__(self, key, all_partitions=None, available_partitions=None):
         """
         Takes a string key, num_partitions and available_partitions as argument and returns
         a partition to be used for the message

--- a/kafka/partitioner/hashed.py
+++ b/kafka/partitioner/hashed.py
@@ -11,6 +11,11 @@ class Murmur2Partitioner(Partitioner):
     the hash of the key. Attempts to apply the same hashing
     function as mainline java client.
     """
+    def __call__(self, key, partitions=None, available=None):
+        if available:
+            return self.partition(key, available)
+        return self.partition(key, partitions)
+
     def partition(self, key, partitions=None):
         if not partitions:
             partitions = self.partitions
@@ -21,12 +26,15 @@ class Murmur2Partitioner(Partitioner):
         return partitions[idx]
 
 
-class LegacyPartitioner(Partitioner):
+class LegacyPartitioner(object):
     """DEPRECATED -- See Issue 374
 
     Implements a partitioner which selects the target partition based on
     the hash of the key
     """
+    def __init__(self, partitions):
+        self.partitions = partitions
+
     def partition(self, key, partitions=None):
         if not partitions:
             partitions = self.partitions

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -61,6 +61,7 @@ class CachedPartitionCycler(object):
         self.partitions = partitions
 
     def next(self):
+        assert self.partitions is not None
         if self.cur_pos is None or not self._index_available(self.cur_pos, self.partitions):
             self.cur_pos = 1
             return self.partitions[0]

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -18,7 +18,7 @@ class RoundRobinPartitioner(Partitioner):
             cur_partitions = all_partitions
         if not self.partitions:
             self._set_partitions(cur_partitions)
-        elif cur_partitions != self.partitions_iterable.partitions:
+        elif cur_partitions != self.partitions_iterable.partitions and cur_partitions is not None:
             self._set_partitions(cur_partitions)
         return next(self.partitions_iterable)
 
@@ -34,6 +34,7 @@ class CachedPartitionCycler(object):
     def __init__(self, partitions=None):
         self.partitions = partitions
         if partitions:
+            print partitions
             assert type(partitions) is list
         self.cur_pos = None
 
@@ -61,6 +62,7 @@ class CachedPartitionCycler(object):
         self.partitions = partitions
 
     def next(self):
+        print self.partitions
         assert self.partitions is not None
         if self.cur_pos is None or not self._index_available(self.cur_pos, self.partitions):
             self.cur_pos = 1

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -5,7 +5,10 @@ from .base import Partitioner
 
 class RoundRobinPartitioner(Partitioner):
     def __init__(self, partitions=None):
-        self.partitions = None
+        if partitions:
+            self._set_partitions(partitions)
+        else:
+            self.partitions = None
         self.partitions_iterable = CachedPartitionCycler(partitions)
 
     def __call__(self, key, all_partitions, available_partitions):

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -18,7 +18,7 @@ class RoundRobinPartitioner(Partitioner):
             cur_partitions = all_partitions
         if not self.partitions:
             self._set_partitions(cur_partitions)
-        elif cur_partitions != self.partitions_iterable.partitions:
+        elif cur_partitions != self.partitions_iterable.partitions and cur_partitions is not None:
             self._set_partitions(cur_partitions)
         return next(self.partitions_iterable)
 

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -34,7 +34,6 @@ class CachedPartitionCycler(object):
     def __init__(self, partitions=None):
         self.partitions = partitions
         if partitions:
-            print partitions
             assert type(partitions) is list
         self.cur_pos = None
 
@@ -62,7 +61,6 @@ class CachedPartitionCycler(object):
         self.partitions = partitions
 
     def next(self):
-        print self.partitions
         assert self.partitions is not None
         if self.cur_pos is None or not self._index_available(self.cur_pos, self.partitions):
             self.cur_pos = 1

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -23,7 +23,7 @@ class RoundRobinPartitioner(Partitioner):
         self.partitions = available_partitions
         self.partitions_iterable.set_partitions(available_partitions)
 
-    def partition(self, key, all_partitions, available_partitions):
+    def partition(self, key, all_partitions=None, available_partitions=None):
         self.__call__(key, all_partitions, available_partitions)
 
 

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -18,7 +18,7 @@ class RoundRobinPartitioner(Partitioner):
             cur_partitions = all_partitions
         if not self.partitions:
             self._set_partitions(cur_partitions)
-        elif cur_partitions != self.partitions_iterable.partitions and cur_partitions is not None:
+        elif cur_partitions != self.partitions_iterable.partitions:
             self._set_partitions(cur_partitions)
         return next(self.partitions_iterable)
 
@@ -27,7 +27,7 @@ class RoundRobinPartitioner(Partitioner):
         self.partitions_iterable.set_partitions(available_partitions)
 
     def partition(self, key, all_partitions=None, available_partitions=None):
-        self.__call__(key, all_partitions, available_partitions)
+        return self.__call__(key, all_partitions, available_partitions)
 
 
 class CachedPartitionCycler(object):

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -1,26 +1,63 @@
 from __future__ import absolute_import
 
-from itertools import cycle
-
 from .base import Partitioner
 
 
 class RoundRobinPartitioner(Partitioner):
-    """
-    Implements a round robin partitioner which sends data to partitions
-    in a round robin fashion
-    """
-    def __init__(self, partitions):
-        super(RoundRobinPartitioner, self).__init__(partitions)
-        self.iterpart = cycle(partitions)
+    def __init__(self, partitions=None):
+        self.partitions = None
+        self.partitions_iterable = CachedPartitionCycler(partitions)
 
-    def _set_partitions(self, partitions):
+    def _set_partitions(self, available_partitions):
+        self.partitions = available_partitions
+        self.partitions_iterable.set_partitions(available_partitions)
+
+    def __call__(self, key, all_partitions, available_partitions):
+        if available_partitions:
+            cur_partitions = available_partitions
+        else:
+            cur_partitions = all_partitions
+        if not self.partitions:
+            self._set_partitions(cur_partitions)
+        elif cur_partitions != self.partitions_iterable.partitions:
+            self._set_partitions(cur_partitions)
+        return next(self.partitions_iterable)
+
+
+class CachedPartitionCycler(object):
+    def __init__(self, partitions=None):
         self.partitions = partitions
-        self.iterpart = cycle(partitions)
+        if partitions:
+            assert type(partitions) is list
+        self.cur_pos = None
 
-    def partition(self, key, partitions=None):
-        # Refresh the partition list if necessary
-        if partitions and self.partitions != partitions:
-            self._set_partitions(partitions)
+    def __iter__(self):
+        self.next()
 
-        return next(self.iterpart)
+    @staticmethod
+    def _index_available(cur_pos, partitions):
+        return cur_pos < len(partitions)
+
+    def set_partitions(self, partitions):
+        if self.cur_pos:
+            if not self._index_available(self.cur_pos, partitions):
+                self.cur_pos = 0
+                self.partitions = partitions
+                return None
+
+            self.partitions = partitions
+            next_item = self.partitions[self.cur_pos]
+            if next_item in partitions:
+                self.cur_pos = partitions.index(next_item)
+            else:
+                self.cur_pos = 0
+            return None
+        self.partitions = partitions
+
+    def next(self):
+        if self.cur_pos is None or not self._index_available(self.cur_pos, self.partitions):
+            self.cur_pos = 1
+            return self.partitions[0]
+        cur_item = self.partitions[self.cur_pos]
+        self.cur_pos += 1
+        return cur_item

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -8,10 +8,6 @@ class RoundRobinPartitioner(Partitioner):
         self.partitions = None
         self.partitions_iterable = CachedPartitionCycler(partitions)
 
-    def _set_partitions(self, available_partitions):
-        self.partitions = available_partitions
-        self.partitions_iterable.set_partitions(available_partitions)
-
     def __call__(self, key, all_partitions, available_partitions):
         if available_partitions:
             cur_partitions = available_partitions
@@ -22,6 +18,13 @@ class RoundRobinPartitioner(Partitioner):
         elif cur_partitions != self.partitions_iterable.partitions:
             self._set_partitions(cur_partitions)
         return next(self.partitions_iterable)
+
+    def _set_partitions(self, available_partitions):
+        self.partitions = available_partitions
+        self.partitions_iterable.set_partitions(available_partitions)
+
+    def partition(self, key, all_partitions, available_partitions):
+        self.__call__(key, all_partitions, available_partitions)
 
 
 class CachedPartitionCycler(object):

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -11,7 +11,7 @@ class RoundRobinPartitioner(Partitioner):
         else:
             self.partitions = None
 
-    def __call__(self, key, all_partitions, available_partitions):
+    def __call__(self, key, all_partitions=None, available_partitions=None):
         if available_partitions:
             cur_partitions = available_partitions
         else:

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -18,7 +18,7 @@ class RoundRobinPartitioner(Partitioner):
             cur_partitions = all_partitions
         if not self.partitions:
             self._set_partitions(cur_partitions)
-        elif cur_partitions != self.partitions_iterable.partitions and cur_partitions is not None:
+        elif cur_partitions != self.partitions_iterable.partitions:
             self._set_partitions(cur_partitions)
         return next(self.partitions_iterable)
 

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -37,8 +37,8 @@ class CachedPartitionCycler(object):
             assert type(partitions) is list
         self.cur_pos = None
 
-    def __iter__(self):
-        self.next()
+    def __next__(self):
+        return self.next()
 
     @staticmethod
     def _index_available(cur_pos, partitions):

--- a/kafka/partitioner/roundrobin.py
+++ b/kafka/partitioner/roundrobin.py
@@ -5,11 +5,11 @@ from .base import Partitioner
 
 class RoundRobinPartitioner(Partitioner):
     def __init__(self, partitions=None):
+        self.partitions_iterable = CachedPartitionCycler(partitions)
         if partitions:
             self._set_partitions(partitions)
         else:
             self.partitions = None
-        self.partitions_iterable = CachedPartitionCycler(partitions)
 
     def __call__(self, key, all_partitions, available_partitions):
         if available_partitions:

--- a/test/test_partitioner.py
+++ b/test/test_partitioner.py
@@ -3,6 +3,7 @@ import six
 
 from kafka.partitioner import Murmur2Partitioner
 from kafka.partitioner.default import DefaultPartitioner
+from kafka.partitioner import RoundRobinPartitioner
 
 
 def test_default_partitioner():
@@ -20,6 +21,38 @@ def test_default_partitioner():
 
     # with fallback to all_partitions
     assert partitioner(None, all_partitions, []) in all_partitions
+
+
+def test_roundrobin_partitioner():
+    partitioner = RoundRobinPartitioner()
+    all_partitions = list(range(100))
+    available = all_partitions
+    # partitioner should cycle between partitions
+    i = 0
+    max_partition = all_partitions[len(all_partitions) - 1]
+    while i <= max_partition:
+        assert i == partitioner(None, all_partitions, available)
+        i += 1
+
+    i = 0
+    while i <= int(max_partition / 2):
+        assert i == partitioner(None, all_partitions, available)
+        i += 1
+
+    # test dynamic partition re-assignment
+    available = available[:-25]
+
+    while i <= max(available):
+        assert i == partitioner(None, all_partitions, available)
+        i += 1
+
+    all_partitions = list(range(200))
+    available = all_partitions
+
+    max_partition = all_partitions[len(all_partitions) - 1]
+    while i <= max_partition:
+        assert i == partitioner(None, all_partitions, available)
+        i += 1
 
 
 def test_hash_bytes():


### PR DESCRIPTION
The partitioners have been updated to use the new KafkaProducer calls and support the old SimpleProducer APIs.
The partitioners are callable and the RoundRobinPartitioner caches the last partition and supports dynamic partition altering.