### PR TITLE
Fix message timestamp_type

### DIFF
--- a/kafka/protocol/message.py
+++ b/kafka/protocol/message.py
@@ -64,7 +64,10 @@ class Message(Struct):
         """
         if self.magic == 0:
             return None
-        return self.attributes & self.TIMESTAMP_TYPE_MASK
+        elif self.attributes & self.TIMESTAMP_TYPE_MASK:
+            return 1
+        else:
+            return 0
 
     def _encode_self(self, recalc_crc=True):
         version = self.magic


### PR DESCRIPTION
The help string indicates a return value of `0` or `1` but since self.TIMESTAMP_TYPE_MASK=8, the actual return values are `8` or `0`.