### PR TITLE
Fix of offset fetch request from Kafka in old client

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -704,7 +704,7 @@ class SimpleClient(object):
         encoder = functools.partial(KafkaProtocol.encode_offset_fetch_request,
                           group=group, from_kafka=True)
         decoder = KafkaProtocol.decode_offset_fetch_response
-        resps = self._send_consumer_aware_request(group, payloads, encoder, decoder)
+        resps = self._send_broker_aware_request(payloads, encoder, decoder)
 
         return [resp if not callback else callback(resp) for resp in resps
                 if not fail_on_error or not self._raise_on_response_error(resp)]


### PR DESCRIPTION
I think it's still makes sense to fix it, even if KafkaClient is deprecated,

I also noticed that `_send_consumer_aware_request()` method isn't used anywhere, and methods called from there:
`def send_consumer_metadata_request(self, payloads=[], fail_on_error=True, callback=None)`
and these two has no reference in Kafka protocol available here (https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-TopicMetadataRequest), or at least I wasn't able to find it.
- `KafkaProtocol.encode_consumer_metadata_request`
- `KafkaProtocol.decode_consumer_metadata_response`
