### PR TITLE
Always check for request timeouts

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -578,6 +578,14 @@ class KafkaClient(object):
                     if response:
                         responses.append(response)
 
+        for conn in six.itervalues(self._conns):
+            if conn.requests_timed_out():
+                log.warning('%s timed out after %s ms. Closing connection.',
+                            conn, conn.config['request_timeout_ms'])
+                conn.close(error=Errors.RequestTimedOutError(
+                    'Request timed out after %s ms' %
+                    conn.config['request_timeout_ms']))
+
         if self._sensors:
             self._sensors.io_time.record((time.time() - end_select) * 1000000000)
         return responses

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -575,14 +575,6 @@ class BrokerConnection(object):
             log.warning('%s: No in-flight-requests to recv', self)
             return None
 
-        elif self._requests_timed_out():
-            log.warning('%s timed out after %s ms. Closing connection.',
-                        self, self.config['request_timeout_ms'])
-            self.close(error=Errors.RequestTimedOutError(
-                'Request timed out after %s ms' %
-                self.config['request_timeout_ms']))
-            return None
-
         return self._recv()
 
     def _recv(self):
@@ -719,7 +711,7 @@ class BrokerConnection(object):
         self._processing = False
         return response
 
-    def _requests_timed_out(self):
+    def requests_timed_out(self):
         if self.in_flight_requests:
             oldest_at = self.in_flight_requests[0].timestamp
             timeout = self.config['request_timeout_ms'] / 1000.0


### PR DESCRIPTION
Currently we check for request timeouts in BrokerConnection.recv(). But this method is only called in KafkaClient if the socket is polled as read / write ready. If a socket times out without causing a read / write event, the request will never timeout. This happens, for example, if a broker hits a deadlock like https://issues.apache.org/jira/browse/KAFKA-3994

This PR moves the request timeout to the KafkaClient._poll loop and checks every connection on every _poll call.