### PR TITLE
Always include an error for logging when the coordinator is marked dead

### DIFF
--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -525,7 +525,7 @@ class ConsumerCoordinator(BaseCoordinator):
                                     Errors.RequestTimedOutError):
                     log.debug("OffsetCommit for group %s failed: %s",
                               self.group_id, error_type.__name__)
-                    self.coordinator_dead()
+                    self.coordinator_dead(error_type())
                     future.failure(error_type(self.group_id))
                     return
                 elif error_type in (Errors.UnknownMemberIdError,
@@ -630,7 +630,7 @@ class ConsumerCoordinator(BaseCoordinator):
                         future.failure(error)
                     elif error_type is Errors.NotCoordinatorForGroupError:
                         # re-discover the coordinator and retry
-                        self.coordinator_dead()
+                        self.coordinator_dead(error_type())
                         future.failure(error)
                     elif error_type in (Errors.UnknownMemberIdError,
                                         Errors.IllegalGenerationError):


### PR DESCRIPTION
The current logging does not show what error causes the group coordinator to be marked dead. This PR passes the upstream error to coodinator_dead() so that it can be logged.