### PR TITLE
Fix possible request draining in ensure_active_group

### DIFF
--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -246,9 +246,12 @@ class BaseCoordinator(object):
             # This is important in particular to avoid resending a pending
             # JoinGroup request.
             if self._client.in_flight_request_count(self.coordinator_id):
-                while self._client.in_flight_request_count(self.coordinator_id):
-                    self._client.poll()
-                continue
+                while not self.coordinator_unknown():
+                    self._client.poll(delayed_tasks=False)
+                    if not self._client.in_flight_request_count(self.coordinator_id):
+                        break
+                else:
+                    continue
 
             future = self._send_join_group_request()
             self._client.poll(future=future)


### PR DESCRIPTION
PR to address a possibly strange state in which we mark the coordinator dead during the request-draining loop in ensure_active_group. If coordinator_id is None, in_flight_request_count() will return the *total* requests across all nodes. To avoid even stranger interactions with state mutation, disable delayed task running while we're trying to drain the in-flight-requests.