### PR TITLE
Changes:

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -191,6 +191,7 @@ class KafkaClient(object):
         self._selector.register(self._wake_r, selectors.EVENT_READ)
         self._closed = False
         self._sensors = None
+        self.reachable = True
         if self.config['metrics']:
             self._sensors = KafkaClientMetrics(self.config['metrics'],
                                                self.config['metric_group_prefix'],
@@ -198,8 +199,8 @@ class KafkaClient(object):
 
         self._bootstrap(collect_hosts(self.config['bootstrap_servers']))
 
-        # Check Broker Version if not set explicitly
-        if self.config['api_version'] is None:
+        # Check Broker Version if not set explicitly and only when kafka cluster is reachable
+        if self.reachable and self.config['api_version'] is None:
             check_timeout = self.config['api_version_auto_timeout_ms'] / 1000
             self.config['api_version'] = self.check_version(timeout=check_timeout)
 
@@ -219,14 +220,24 @@ class KafkaClient(object):
         else:
             metadata_request = MetadataRequest[1](None)
 
+        _count_host = 0
         for host, port, afi in hosts:
+            _count_host += 1
             log.debug("Attempting to bootstrap via node at %s:%s", host, port)
             cb = functools.partial(self._conn_state_change, 'bootstrap')
             bootstrap = BrokerConnection(host, port, afi,
                                          state_change_callback=cb,
                                          node_id='bootstrap',
                                          **self.config)
-            bootstrap.connect()
+            try:
+                bootstrap.connect()
+            except socket.gaierror as gaiErr:
+                log.error('Error to bootstrap via node at %s:%s = %s', host, port, repr(gaiErr))
+                if _count_host < len(hosts):
+                    continue
+                else:
+                    self.reachable = False
+
             while bootstrap.connecting():
                 bootstrap.connect()
             if bootstrap.state is not ConnectionStates.CONNECTED:
@@ -250,6 +261,7 @@ class KafkaClient(object):
             break
         # No bootstrap found...
         else:
+            self.reachable = False
             log.error('Unable to bootstrap from %s', hosts)
             # Max exponential backoff is 2^12, x4000 (50ms -> 200s)
             self._bootstrap_fails = min(self._bootstrap_fails + 1, 12)
@@ -653,6 +665,7 @@ class KafkaClient(object):
         # Last option: try to bootstrap again
         # this should only happen if no prior bootstrap has been successful
         log.error('No nodes found in metadata -- retrying bootstrap')
+        self.reachable = False
         self._bootstrap(collect_hosts(self.config['bootstrap_servers']))
         return None
 


### PR DESCRIPTION
Current Scenario:
If cluster is unreachable, instance creation of KafkaProducer does not throw any error or exception. So during message send to Kafka, it will get KafkaTimeout Error (as per documentation).

Problem:
Due to this, user could not know the status of connection before actual send. It will unnecessary waste time and make hard to handle error in some cases. Like if someone tries to implement in AWS Lambda as KafkaProducer.

This changes addresses this problem with keeping the existing flow as it is.
How:
It will introduce a variable in KafkaProducer which will be set False if and only if Kafka cluster failed to reach/connect. So as per the state of this boolean variable user can handle failed secnarios better.

Comment for this commit:
* Boolean variables are introduced in kafka.py and client_async.py
  So that if kafka cluster is not reachable during creation of KafkaProducer instance
  that variable would be False neither True

