### PR TITLE
Sort partitions before calling partitioner

### DIFF
--- a/kafka/partitioner/default.py
+++ b/kafka/partitioner/default.py
@@ -14,6 +14,13 @@ class DefaultPartitioner(object):
     """
     @classmethod
     def __call__(cls, key, all_partitions, available):
+        """
+        Get the partition corresponding to key
+        :param key: partitioning key
+        :param all_partitions: list of all partitions sorted by partition ID
+        :param available: list of available partitions in no particular order
+        :return: one of the values from all_partitions or available
+        """
         if key is None:
             if available:
                 return random.choice(available)

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -625,7 +625,7 @@ class KafkaProducer(object):
             assert partition in self._metadata.partitions_for_topic(topic), 'Unrecognized partition'
             return partition
 
-        all_partitions = sorted(list(self._metadata.partitions_for_topic(topic)))
+        all_partitions = sorted(self._metadata.partitions_for_topic(topic))
         available = list(self._metadata.available_partitions_for_topic(topic))
         return self.config['partitioner'](serialized_key,
                                           all_partitions,

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -625,7 +625,7 @@ class KafkaProducer(object):
             assert partition in self._metadata.partitions_for_topic(topic), 'Unrecognized partition'
             return partition
 
-        all_partitions = list(self._metadata.partitions_for_topic(topic))
+        all_partitions = sorted(list(self._metadata.partitions_for_topic(topic)))
         available = list(self._metadata.available_partitions_for_topic(topic))
         return self.config['partitioner'](serialized_key,
                                           all_partitions,


### PR DESCRIPTION
Current partitioners assume that the partitions are sorted according
to partition ID in all_partitions. However, this is not guaranteed
in the KafkaProducer implementation as the values that are passed
come from a set. Sets are not guaranteed to iterate values in any
particular order, so we need to sort the values before passing
them further along.

Before this change, the code depended on internal implementation of
Python interpreters. In CPython 3.5 and lower it seems that integers
are returned in sorted order from sets so the code appears to work.
In PyPy and CPython 3.6, sets and dictionaries preserve the order
of insertions [1] which means that the code may not work in these
environments (I have not tested this). As far as I could find,
the order of partitions used in this case is the order that is
returned by the broker, but the documentation does not say anything
about partition order.

[1] https://docs.python.org/3.6/whatsnew/3.6.html#whatsnew36-compactdict