### PR TITLE
Fix #913: If key is null, skip deserializing

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -542,12 +542,12 @@ class Fetcher(six.Iterator):
             raise
 
     def _deserialize(self, msg):
-        if self.config['key_deserializer']:
-            key = self.config['key_deserializer'](msg.key) # pylint: disable-msg=not-callable
+        if self.config['key_deserializer'] and msg.key is not None:
+            key = self.config['key_deserializer'](msg.key)  # pylint: disable-msg=not-callable
         else:
             key = msg.key
         if self.config['value_deserializer']:
-            value = self.config['value_deserializer'](msg.value) # pylint: disable-msg=not-callable
+            value = self.config['value_deserializer'](msg.value)  # pylint: disable-msg=not-callable
         else:
             value = msg.value
         return key, value


### PR DESCRIPTION
Fix #913 

I didn't test the JavaConsumer, but I suspect it skips null keys as it seems the most logical behavior. 

I thought about adding this logic the message value processing as well, but I can't think of a scenario where you'd send a null message, versus it is realistic that you'd send a message with a null key.

Didn't have time to add tests yet.