### PR TITLE
Make SSL warning list the correct Python versions

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -36,9 +36,9 @@ try:
     ssl.SSLWantWriteError
     ssl.SSLZeroReturnError
 except:
-    log.warning('old ssl module detected.'
-                ' ssl error handling may not operate cleanly.'
-                ' Consider upgrading to python 3.5 or 2.7')
+    log.warning('Old SSL module detected.'
+                ' SSL error handling may not operate cleanly.'
+                ' Consider upgrading to Python 3.3 or 2.7.9')
     ssl.SSLWantReadError = ssl.SSLError
     ssl.SSLWantWriteError = ssl.SSLError
     ssl.SSLZeroReturnError = ssl.SSLError


### PR DESCRIPTION
Was a bit surprised to see this warning being thrown even though we're already on 2.7

According to the Python docs, the new SSL error classes were added in 2.7.9 and 3.3, so I updated the warning:
https://docs.python.org/3/library/ssl.html?highlight=ssl#ssl.SSLZeroReturnError
https://docs.python.org/2/library/ssl.html#ssl.SSLZeroReturnError