### PR TITLE
Log connection closes

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -229,7 +229,7 @@ class KafkaClient(object):
             bootstrap.connect()
             while bootstrap.connecting():
                 bootstrap.connect()
-            if bootstrap.state is not ConnectionStates.CONNECTED:
+            if not bootstrap.connected():
                 bootstrap.close()
                 continue
             future = bootstrap.send(metadata_request)
@@ -261,7 +261,7 @@ class KafkaClient(object):
                 return True
             return False
         conn = self._conns[node_id]
-        return conn.state is ConnectionStates.DISCONNECTED and not conn.blacked_out()
+        return conn.disconnected() and not conn.blacked_out()
 
     def _conn_state_change(self, node_id, conn):
         if conn.connecting():
@@ -398,7 +398,7 @@ class KafkaClient(object):
 
         conn = self._conns[node_id]
         time_waited_ms = time.time() - (conn.last_attempt or 0)
-        if conn.state is ConnectionStates.DISCONNECTED:
+        if conn.disconnected():
             return max(self.config['reconnect_backoff_ms'] - time_waited_ms, 0)
         elif conn.connecting():
             return 0

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -557,7 +557,7 @@ class KafkaClient(object):
                         log.warning('Protocol out of sync on %r, closing', conn)
                 except socket.error:
                     pass
-                conn.close()
+                conn.close(Errors.ConnectionError('Socket EVENT_READ without in-flight-requests'))
                 continue
 
             # Accumulate as many responses as the connection has pending

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -154,8 +154,8 @@ class BrokerConnection(object):
             sasl_plain_password (str): password for sasl PLAIN authentication.
                 Default: None
         """
-        self.host = host
         self.hostname = host
+        self.host = host
         self.port = port
         self.afi = afi
         self._init_host = host
@@ -194,7 +194,6 @@ class BrokerConnection(object):
         self._receiving = False
         self._next_payload_bytes = 0
         self.last_attempt = 0
-        self.last_failure = 0
         self._processing = False
         self._correlation_id = 0
         self._gai = None
@@ -363,7 +362,6 @@ class BrokerConnection(object):
         except ssl.SSLError as e:
             log.exception('%s: Failed to wrap socket in SSLContext!', str(self))
             self.close(e)
-            self.last_failure = time.time()
 
     def _try_handshake(self):
         assert self.config['security_protocol'] in ('SSL', 'SASL_SSL')
@@ -496,7 +494,6 @@ class BrokerConnection(object):
             self._sock.close()
             self._sock = None
         self.state = ConnectionStates.DISCONNECTED
-        self.last_failure = time.time()
         self._receiving = False
         self._next_payload_bytes = 0
         self._rbuffer.seek(0)

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -207,7 +207,6 @@ class BrokerConnection(object):
     def connect(self):
         """Attempt to connect and return ConnectionState"""
         if self.state is ConnectionStates.DISCONNECTED:
-            self.close()
             log.debug('%s: creating new socket', str(self))
             # if self.afi is set to AF_UNSPEC, then we need to do a name
             # resolution and try all available address families

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -523,6 +523,7 @@ class BrokerConnection(object):
         return self._send(request, expect_response=expect_response)
 
     def _send(self, request, expect_response=True):
+        assert self.state in (ConnectionStates.AUTHENTICATING, ConnectionStates.CONNECTED)
         future = Future()
         correlation_id = self._next_correlation_id()
         header = RequestHeader(request,


### PR DESCRIPTION
This adds INFO logging for each BrokerConnection.close(), including the upstream error when available.