### PR TITLE
Remove non-pip install instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -22,20 +22,6 @@ Bleeding-Edge
     git clone https://github.com/dpkp/kafka-python
     pip install ./kafka-python
 
-Setuptools:
-
-.. code:: bash
-
-    git clone https://github.com/dpkp/kafka-python
-    easy_install ./kafka-python
-
-Using `setup.py` directly:
-
-.. code:: bash
-
-    git clone https://github.com/dpkp/kafka-python
-    cd kafka-python
-    python setup.py install
 
 Optional LZ4 install
 ********************


### PR DESCRIPTION
These days, anyone who needs these instructions should be using `pip`.