### PR TITLE
WIP: Use the new FetchRequest/Response_v3 calls

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -664,7 +664,9 @@ class Fetcher(six.Iterator):
                 log.debug("Adding fetch request for partition %s at offset %d",
                           partition, position)
 
-        if self.config['api_version'] >= (0, 10):
+        if self.config['api_version'] >= (0, 10, 1):
+            version = 3
+        elif (0, 10, 1) > self.config['api_version'] >= (0, 10):
             version = 2
         elif self.config['api_version'] == (0, 9):
             version = 1

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -60,6 +60,7 @@ def test_send_fetches(fetcher, mocker):
 
 
 @pytest.mark.parametrize(("api_version", "fetch_version"), [
+    ((0, 10, 1), 3),
     ((0, 10), 2),
     ((0, 9), 1),
     ((0, 8), 0)


### PR DESCRIPTION
WIP--DO NOT MERGE

#943 added the structs, but didn't actually implement support for using them. This starts to add support for actually using them.

Needs a good bit more work to finish the TODOs listed in https://github.com/dpkp/kafka-python/issues/870#issuecomment-273290009

Anyone else feel free to take a stab at this, not sure I'll have time to finish this.

