### PR TITLE
Default max_poll_records to Java default of 500

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -117,7 +117,7 @@ class KafkaConsumer(six.Iterator):
         session_timeout_ms (int): The timeout used to detect failures when
             using Kafka's group management facilities. Default: 30000
         max_poll_records (int): The maximum number of records returned in a
-            single call to poll().
+            single call to poll(). Default: 500
         receive_buffer_bytes (int): The size of the TCP receive buffer
             (SO_RCVBUF) to use when reading data. Default: None (relies on
             system defaults). The java client defaults to 32768.
@@ -223,7 +223,7 @@ class KafkaConsumer(six.Iterator):
         'partition_assignment_strategy': (RangePartitionAssignor, RoundRobinPartitionAssignor),
         'heartbeat_interval_ms': 3000,
         'session_timeout_ms': 30000,
-        'max_poll_records': sys.maxsize,
+        'max_poll_records': 500,
         'receive_buffer_bytes': None,
         'send_buffer_bytes': None,
         'socket_options': [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)],


### PR DESCRIPTION
The Java consumer now defaults to 500 as of Kafka 0.10.1.0. Switch to this rather than `sys.maxsize` to reduce surprises since this library explicitly tries to mirror the Java library.