### PR TITLE
use select.select without instance bounding

### DIFF
--- a/kafka/vendor/selectors34.py
+++ b/kafka/vendor/selectors34.py
@@ -331,7 +331,7 @@ class SelectSelector(_BaseSelectorImpl):
             r, w, x = select.select(r, w, w, timeout)
             return r, w + x, []
     else:
-        _select = select.select
+        _select = staticmethod(select.select)
 
     def select(self, timeout=None):
         timeout = None if timeout is None else max(timeout, 0)


### PR DESCRIPTION
when we use invoking self._select, python will pass self as select.select's first argument and we will get `TypeError: select() takes at most 4 arguments (5 given)`