### PR TITLE
Use select to poll sockets for read to reduce CPU usage

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -284,7 +284,7 @@ class SimpleClient(object):
             # block until a socket is ready to be read
             sockets = [
                 conn._sock
-                for future, (conn, _) in connections_by_future.iteritems()
+                for future, (conn, _) in six.iteritems(connections_by_future)
                 if not future.is_done and conn._sock is not None]
             if sockets:
                 read_socks, _, _ = select.select(sockets, [], [])


### PR DESCRIPTION
@dpkp, this pull request is for people who may have the same issue as us #957.  

As SimpleClient is to be deprecated, I used BrokerConnection._sock directly instead of updating BrokerConnection to expose _sock.  Also `select` module is used directly.  You can update it if you think it is needed.