### PR TITLE
Fix raise exception from SubscriptionState.assign_from_subscribed

### DIFF
--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -225,7 +225,7 @@ class SubscriptionState(object):
 
         for tp in assignments:
             if tp.topic not in self.subscription:
-                raise ValueError("Assigned partition %s for non-subscribed topic." % tp)
+                raise ValueError("Assigned partition %s for non-subscribed topic." % str(tp))
         self.assignment.clear()
         for tp in assignments:
             self._add_assigned_partition(tp)


### PR DESCRIPTION
Raising `ValueError` from `SubscriptionState.assign_from_subscribed()`
always fails because there is used percent formatting of `TopicPartition`.
But `TopicPartition` is [namedtuple](https://github.com/dpkp/kafka-python/blob/master/kafka/structs.py#L59) with two elements and percent
formatting tries to unpack tuples, fails and raise exception:
`TypeError: not all arguments converted during string formatting`.
Converting to string first solves the issue.