### PR TITLE
Added `max_bytes` option and FetchRequest_v3 usage.

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -156,6 +156,8 @@ class KafkaClient(object):
         'sasl_plain_password': None,
     }
     API_VERSIONS = [
+        (0, 10, 1),
+        (0, 10, 0),
         (0, 10),
         (0, 9),
         (0, 8, 2),

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -790,7 +790,8 @@ class BrokerConnection(object):
         log.addFilter(log_filter)
 
         test_cases = [
-            ((0, 10), ApiVersionRequest[0]()),
+            ((0, 10, 1), MetadataRequest[2]([])),
+            ((0, 10, 0), ApiVersionRequest[0]()),
             ((0, 9), ListGroupsRequest[0]()),
             ((0, 8, 2), GroupCoordinatorRequest[0]('kafka-python-default-group')),
             ((0, 8, 1), OffsetFetchRequest[0]('kafka-python-default-group', [])),

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -761,10 +761,10 @@ class BrokerConnection(object):
 
         error_type = Errors.for_code(response.error_code)
         assert error_type is Errors.NoError, "API version check failed"
-        max_versions = {
-            api_key: max_version
+        max_versions = dict([
+            (api_key, max_version)
             for api_key, _, max_version in response.api_versions
-        }
+        ])
         # Get the best match of test cases
         for broker_version, struct in test_cases:
             if max_versions.get(struct.API_KEY, -1) >= struct.API_VERSION:

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -18,6 +18,7 @@ from kafka.metrics.stats import Avg, Count, Max, Rate
 from kafka.protocol.api import RequestHeader
 from kafka.protocol.admin import SaslHandShakeRequest
 from kafka.protocol.commit import GroupCoordinatorResponse
+from kafka.protocol.metadata import MetadataRequest
 from kafka.protocol.types import Int32
 from kafka.version import __version__
 
@@ -752,6 +753,24 @@ class BrokerConnection(object):
         self._correlation_id = (self._correlation_id + 1) % 2**31
         return self._correlation_id
 
+    def _check_version_above_0_10(self, response):
+        test_cases = [
+            # format (<broker verion>, <needed struct>)
+            ((0, 10, 1), MetadataRequest[2])
+        ]
+
+        error_type = Errors.for_code(response.error_code)
+        assert error_type is Errors.NoError, "API version check failed"
+        max_versions = {
+            api_key: max_version
+            for api_key, _, max_version in response.api_versions
+        }
+        # Get the best match of test cases
+        for broker_version, struct in test_cases:
+            if max_versions.get(struct.API_KEY, -1) >= struct.API_VERSION:
+                return broker_version
+        return (0, 10, 0)
+
     def check_version(self, timeout=2, strict=False):
         """Attempt to guess the broker version.
 
@@ -776,7 +795,6 @@ class BrokerConnection(object):
         # socket.error (32, 54, or 104)
         from .protocol.admin import ApiVersionRequest, ListGroupsRequest
         from .protocol.commit import OffsetFetchRequest, GroupCoordinatorRequest
-        from .protocol.metadata import MetadataRequest
 
         # Socket errors are logged as exceptions and can alarm users. Mute them
         from logging import Filter
@@ -790,8 +808,8 @@ class BrokerConnection(object):
         log.addFilter(log_filter)
 
         test_cases = [
-            ((0, 10, 1), MetadataRequest[2]([])),
-            ((0, 10, 0), ApiVersionRequest[0]()),
+            # All cases starting from 0.10 will be based on ApiVersionResponse
+            ((0, 10), ApiVersionRequest[0]()),
             ((0, 9), ListGroupsRequest[0]()),
             ((0, 8, 2), GroupCoordinatorRequest[0]('kafka-python-default-group')),
             ((0, 8, 1), OffsetFetchRequest[0]('kafka-python-default-group', [])),
@@ -831,6 +849,10 @@ class BrokerConnection(object):
                 self._sock.setblocking(False)
 
             if f.succeeded():
+                if version == (0, 10):
+                    # Starting from 0.10 kafka broker we determine version
+                    # by looking at ApiVersionResponse
+                    version = self._check_version_above_0_10(f.value)
                 log.info('Broker version identifed as %s', '.'.join(map(str, version)))
                 log.info('Set configuration api_version=%s to skip auto'
                          ' check_version requests on startup', version)

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -68,7 +68,8 @@ class KafkaConsumer(six.Iterator):
             first message in the first non-empty partition of the fetch is
             larger than this value, the message will still be returned to
             ensure that the consumer can make progress. NOTE: consumer performs
-            multiple fetches in parallel so memory usage will be higher.
+            fetches to multiple brokers in parallel so memory usage will depend
+            on the number of brokers containing partitions for the topic.
             Supported Kafka version >= 0.10.1.0. Default: 52428800 (50 Mb).
         max_partition_fetch_bytes (int): The maximum amount of data
             per-partition the server will return. The maximum total memory

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -63,6 +63,13 @@ class KafkaConsumer(six.Iterator):
             the server will block before answering the fetch request if
             there isn't sufficient data to immediately satisfy the
             requirement given by fetch_min_bytes. Default: 500.
+        fetch_max_bytes (int): The maximum amount of data the server should
+            return for a fetch request. This is not an absolute maximum, if the
+            first message in the first non-empty partition of the fetch is
+            larger than this value, the message will still be returned to
+            ensure that the consumer can make progress. NOTE: consumer performs
+            multiple fetches in parallel so memory usage will be higher.
+            Supported Kafka version >= 0.10.1.0. Default: 52428800 (50 Mb).
         max_partition_fetch_bytes (int): The maximum amount of data
             per-partition the server will return. The maximum total memory
             used for a request = #partitions * max_partition_fetch_bytes.
@@ -209,6 +216,7 @@ class KafkaConsumer(six.Iterator):
         'value_deserializer': None,
         'fetch_max_wait_ms': 500,
         'fetch_min_bytes': 1,
+        'fetch_max_bytes': 52428800,
         'max_partition_fetch_bytes': 1 * 1024 * 1024,
         'request_timeout_ms': 40 * 1000,
         'retry_backoff_ms': 100,

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -608,6 +608,8 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         consumer = self.kafka_consumer(
             auto_offset_reset='earliest', fetch_max_bytes=1)
         fetched_msgs = []
+        # A bit hacky, but we need this in order for message count to be exact
+        consumer._coordinator.ensure_active_group()
         for i in range(10):
             poll_res = consumer.poll(timeout_ms=2000)
             print(poll_res)

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -58,7 +58,8 @@ def test_send_fetches(fetcher, mocker):
 
 
 @pytest.mark.parametrize(("api_version", "fetch_version"), [
-    ((0, 10), 2),
+    ((0, 10, 1), 3),
+    ((0, 10, 0), 2),
     ((0, 9), 1),
     ((0, 8), 0)
 ])


### PR DESCRIPTION
Also added a check for api_version=(0, 10, 1) and MetadataRequest_v2
[KIP-74](https://cwiki.apache.org/confluence/display/KAFKA/KIP-74%3A+Add+Fetch+Response+Size+Limit+in+Bytes)
NOTE: Depends on PR #974