### PR TITLE
time --> timestamp to match Java API

### DIFF
--- a/kafka/protocol/offset.py
+++ b/kafka/protocol/offset.py
@@ -63,7 +63,7 @@ class OffsetRequest_v1(Struct):
             ('topic', String('utf-8')),
             ('partitions', Array(
                 ('partition', Int32),
-                ('time', Int64)))))
+                ('timestamp', Int64)))))
     )
     DEFAULTS = {
         'replica_id': -1


### PR DESCRIPTION
Kafka server protocol calls this timestamp, not time. 

See also  https://github.com/dpkp/kafka-python/pull/951#discussion_r96803189

Thankfully this struct isn't yet used internally in the code, so easy to correct it now.