### PR TITLE
Replace %s with %r in producer debug log message

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -505,7 +505,7 @@ class KafkaProducer(object):
             tp = TopicPartition(topic, partition)
             if timestamp_ms is None:
                 timestamp_ms = int(time.time() * 1000)
-            log.debug("Sending (key=%s value=%s) to %s", key, value, tp)
+            log.debug("Sending (key=%r value=%r) to %s", key, value, tp)
             result = self._accumulator.append(tp, timestamp_ms,
                                               key_bytes, value_bytes,
                                               self.config['max_block_ms'])


### PR DESCRIPTION
Users can pass some binary data that will cause UnicodeDecodeError if logging handler converts the log record to unicode (e.g. serializes it to JSON object). To the best of my knowledge using %r in the message template is the best way to avoid such kind of problems and quick research confirms that https://mail.python.org/pipermail/python-list/2009-July/542427.html

```python
In [1]: import zlib

In [2]: msg = 'value=%s' % zlib.compress('value')

In [3]: msg.decode('utf-8')
UnicodeDecodeError: 'utf8' codec can't decode byte 0x9c in position 7: invalid start byte

In [4]: msg2 = 'value=%r' % zlib.compress('value')

In [5]: msg2.decode('utf-8')
Out[5]: u"value='x\\x9c+K\\xcc)M\\x05\\x00\\x06j\\x02\\x1e'"
```

Fixes #910