### PR TITLE
Fail-fast on timeout constraint violations during KafkaConsumer creation

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -273,9 +273,13 @@ class KafkaConsumer(six.Iterator):
         session_timeout_ms = self.config['session_timeout_ms']
         fetch_max_wait_ms = self.config['fetch_max_wait_ms']
         if request_timeout_ms <= session_timeout_ms:
-            raise KafkaConfigurationError("Request timeout ({}) must be larger than session timeout ({})".format(request_timeout_ms, session_timeout_ms))
+            raise KafkaConfigurationError(
+                "Request timeout (" + str(request_timeout_ms) + ") must be larger than session timeout (" +
+                str(session_timeout_ms) + ")")
         if request_timeout_ms <= fetch_max_wait_ms:
-            raise KafkaConfigurationError("Request timeout ({}) must be larger than fetch-max-wait-ms ({})".format(request_timeout_ms, fetch_max_wait_ms))
+            raise KafkaConfigurationError(
+                "Request timeout (" + str(request_timeout_ms) + ") must be larger than fetch-max-wait-ms (" +
+                str(fetch_max_wait_ms) + ")")
 
         metrics_tags = {'client-id': self.config['client_id']}
         metric_config = MetricConfig(samples=self.config['metrics_num_samples'],

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -274,12 +274,11 @@ class KafkaConsumer(six.Iterator):
         fetch_max_wait_ms = self.config['fetch_max_wait_ms']
         if request_timeout_ms <= session_timeout_ms:
             raise KafkaConfigurationError(
-                "Request timeout (" + str(request_timeout_ms) + ") must be larger than session timeout (" +
-                str(session_timeout_ms) + ")")
+                "Request timeout (%s) must be larger than session timeout (%s)" %
+                (request_timeout_ms, session_timeout_ms))
         if request_timeout_ms <= fetch_max_wait_ms:
-            raise KafkaConfigurationError(
-                "Request timeout (" + str(request_timeout_ms) + ") must be larger than fetch-max-wait-ms (" +
-                str(fetch_max_wait_ms) + ")")
+            raise KafkaConfigurationError("Request timeout (%s) must be larger than fetch-max-wait-ms (%s)" %
+                                          (request_timeout_ms, fetch_max_wait_ms))
 
         metrics_tags = {'client-id': self.config['client_id']}
         metric_config = MetricConfig(samples=self.config['metrics_num_samples'],

--- a/test/test_consumer.py
+++ b/test/test_consumer.py
@@ -16,6 +16,14 @@ class TestKafkaConsumer(unittest.TestCase):
         with self.assertRaises(AssertionError):
             SimpleConsumer(MagicMock(), 'group', 'topic', partitions = [ '0' ])
 
+    def test_session_timeout_larger_than_request_timeout_raises(self):
+        with self.assertRaises(KafkaConfigurationError):
+            KafkaConsumer(bootstrap_servers='localhost:9092', session_timeout_ms=60000, request_timeout_ms=40000)
+
+    def test_fetch_max_wait_larger_than_request_timeout_raises(self):
+        with self.assertRaises(KafkaConfigurationError):
+            KafkaConsumer(bootstrap_servers='localhost:9092', fetch_max_wait_ms=41000, request_timeout_ms=40000)
+
 
 class TestMultiProcessConsumer(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith('win'), 'test mocking fails on windows')


### PR DESCRIPTION
Related to #739 

