### PR TITLE
change default timeout of KafkaProducer.close() to threading.TIMEOUT_MAX

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -400,7 +400,7 @@ class KafkaProducer(object):
             log.info('Kafka producer closed')
             return
         if timeout is None:
-            timeout = 999999999
+            timeout = threading.TIMEOUT_MAX
         assert timeout >= 0
 
         log.info("Closing the Kafka producer with %s secs timeout.", timeout)


### PR DESCRIPTION
To fix OverflowError: timeout value is too large error