### PR TITLE
Short-circuit group coordinator requests when NodeNotReady

### DIFF
--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -422,9 +422,11 @@ class BaseCoordinator(object):
             e = Errors.GroupCoordinatorNotAvailableError(self.coordinator_id)
             return Future().failure(e)
 
-        elif not self._client.ready(self.coordinator_id):
-            e = Errors.NodeNotReadyError(self.coordinator_id)
-            return Future().failure(e)
+        # We assume that coordinator is ready if we're sending SyncGroup
+        # as it typically follows a successful JoinGroup
+        # Also note that if client.ready() enforces a metadata priority policy,
+        # we can get into an infinite loop if the leader assignment process
+        # itself requests a metadata update
 
         future = Future()
         _f = self._client.send(self.coordinator_id, request)

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -287,7 +287,7 @@ class BaseCoordinator(object):
             e = Errors.GroupCoordinatorNotAvailableError(self.coordinator_id)
             return Future().failure(e)
 
-        elif not self._client.ready(self.coordinator_id):
+        elif not self._client.ready(self.coordinator_id, metadata_priority=False):
             e = Errors.NodeNotReadyError(self.coordinator_id)
             return Future().failure(e)
 
@@ -479,7 +479,7 @@ class BaseCoordinator(object):
         if node_id is None:
             return Future().failure(Errors.NoBrokersAvailable())
 
-        elif not self._client.ready(node_id):
+        elif not self._client.ready(node_id, metadata_priority=False):
             e = Errors.NodeNotReadyError(node_id)
             return Future().failure(e)
 
@@ -573,7 +573,7 @@ class BaseCoordinator(object):
             e = Errors.GroupCoordinatorNotAvailableError(self.coordinator_id)
             return Future().failure(e)
 
-        elif not self._client.ready(self.coordinator_id):
+        elif not self._client.ready(self.coordinator_id, metadata_priority=False):
             e = Errors.NodeNotReadyError(self.coordinator_id)
             return Future().failure(e)
 


### PR DESCRIPTION
This PR attempts to reduce error logging caused by _failed_request, primarily for JoinGroupRequest. Also included are snippets for SyncGroupRequest and HeartbeatRequest, though logically these should be less likely to trigger as the coordinator connection should already be primed by a successful JoinGroupRequest the time those requests are sent.