### PR TITLE
Add send_list_offset_request for searching offset by timestamp

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -686,6 +686,16 @@ class SimpleClient(object):
         return [resp if not callback else callback(resp) for resp in resps
                 if not fail_on_error or not self._raise_on_response_error(resp)]
 
+    def send_list_offset_request(self, payloads=[], fail_on_error=True,
+                            callback=None):
+        resps = self._send_broker_aware_request(
+            payloads,
+            KafkaProtocol.encode_list_offset_request,
+            KafkaProtocol.decode_list_offset_response)
+
+        return [resp if not callback else callback(resp) for resp in resps
+                if not fail_on_error or not self._raise_on_response_error(resp)]
+
     def send_offset_commit_request(self, group, payloads=[],
                                    fail_on_error=True, callback=None):
         encoder = functools.partial(KafkaProtocol.encode_offset_commit_request,

--- a/kafka/protocol/legacy.py
+++ b/kafka/protocol/legacy.py
@@ -249,6 +249,35 @@ class KafkaProtocol(object):
         ]
 
     @classmethod
+    def encode_list_offset_request(cls, payloads=()):
+        return kafka.protocol.offset.OffsetRequest[1](
+            replica_id=-1,
+            topics=[(
+                topic,
+                [(
+                    partition,
+                    payload.time)
+                for partition, payload in six.iteritems(topic_payloads)])
+            for topic, topic_payloads in six.iteritems(group_by_topic_and_partition(payloads))])
+
+    @classmethod
+    def decode_list_offset_response(cls, response):
+        """
+        Decode OffsetResponse_v2 into ListOffsetResponsePayloads
+
+        Arguments:
+            response: OffsetResponse_v2
+
+        Returns: list of ListOffsetResponsePayloads
+        """
+        return [
+            kafka.structs.ListOffsetResponsePayload(topic, partition, error, timestamp, offset)
+            for topic, partitions in response.topics
+            for partition, error, timestamp, offset in partitions
+        ]
+
+
+    @classmethod
     def encode_metadata_request(cls, topics=(), payloads=None):
         """
         Encode a MetadataRequest

--- a/kafka/structs.py
+++ b/kafka/structs.py
@@ -37,8 +37,14 @@ FetchResponsePayload = namedtuple("FetchResponsePayload",
 OffsetRequestPayload = namedtuple("OffsetRequestPayload",
     ["topic", "partition", "time", "max_offsets"])
 
+ListOffsetRequestPayload = namedtuple("ListOffsetRequestPayload",
+    ["topic", "partition", "time"])
+
 OffsetResponsePayload = namedtuple("OffsetResponsePayload",
     ["topic", "partition", "error", "offsets"])
+
+ListOffsetResponsePayload = namedtuple("ListOffsetResponsePayload",
+    ["topic", "partition", "error", "timestamp", "offset"])
 
 # https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetCommit/FetchAPI
 OffsetCommitRequestPayload = namedtuple("OffsetCommitRequestPayload",


### PR DESCRIPTION
Currently, Kafka Python has OffsetRequest_v1(It's name changed as ListOffsetRequest v1)
But there is no way to using this request. this is very helpful for searching offset by timestamp.

so, I add send_list_offset_request to request OffsetRequest_v1 and OffsetResponse_v1
and this feature only can use kafka 0.10.1.x or higher.

and, I missed test code, when I looked OffsetRequest test code, they are all skip annotation.
How do I add test for this feature?

Thanks.

```
from kafka import KafkaClient
from kafka.structs import ListOffsetRequestPayload

client = KafkaClient(hosts=['broker1:9092', 'broker2:9092', 'broker3:9092'])
reqs = []
reqs.append(ListOffsetRequestPayload("test2", 0, 1488161648929))
v = client.send_list_offset_request(reqs)
print(v)
```