### PR TITLE
Bump KafkaConsumer's request_timeout to 305000ms

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -74,7 +74,7 @@ class KafkaConsumer(six.Iterator):
             happens, the consumer can get stuck trying to fetch a large
             message on a certain partition. Default: 1048576.
         request_timeout_ms (int): Client request timeout in milliseconds.
-            Default: 40000.
+            Default: 305000.
         retry_backoff_ms (int): Milliseconds to backoff when retrying on
             errors. Default: 100.
         reconnect_backoff_ms (int): The amount of time in milliseconds to
@@ -213,7 +213,7 @@ class KafkaConsumer(six.Iterator):
         'fetch_max_wait_ms': 500,
         'fetch_min_bytes': 1,
         'max_partition_fetch_bytes': 1 * 1024 * 1024,
-        'request_timeout_ms': 40 * 1000,
+        'request_timeout_ms': 305000,
         'retry_backoff_ms': 100,
         'reconnect_backoff_ms': 50,
         'max_in_flight_requests_per_connection': 5,


### PR DESCRIPTION
The Java Consumer [changed the value to 305000 in `0.10.1.0`](https://kafka.apache.org/documentation/#upgrade_1010_notable):

>  The new Java Consumer now supports heartbeating from a background thread. There is a new configuration max.poll.interval.ms which controls the maximum time between poll invocations before the consumer will proactively leave the group (5 minutes by default). The value of the configuration request.timeout.ms must always be larger than max.poll.interval.ms because this is the maximum time that a JoinGroup request can block on the server while the consumer is rebalancing, so we have changed its default value to just above 5 minutes. Finally, the default value of session.timeout.ms has been adjusted down to 10 seconds, and the default value of max.poll.records has been changed to 500.

See the current upstream value here: https://kafka.apache.org/documentation/#configuration

This value was only changed in `KafkaConsumer`. So we don't also need to update `KafkaProducer` / `KafkaClient` as the upstream Java implementations still default to `30000`. The broker default is also `30000`.

----

Note: 
Merging this may be slightly premature since #948 hasn't been done to add `max.poll.interval.ms` yet, but I don't see any harm in adding this now. 

Sessions will still timeout, this just gives the brokers/cluster a bit longer to handle things like consumer group coordination etc.

In one of our dev environments, we were seeing a lot of these timeouts at the current default of `40000` using the new `KafkaConsumer`. Weirdly, the timeouts were being hit even though the consumer had no messages to consume and they were starting with default offset of `latest`. 

This doesn't quite feel right. It's a dev cluster, so everything on VMs and the network can be flaky/slow. But I still wouldn't have expected a consumer that was simply sitting there would be hitting this request timeout at 40 seconds.

Still, when I bumped their request timeouts up to this new `305000` value, the timeout errors went away, and the consumers remained stable as best I could tell.