### PR TITLE
Drop old brokers when rebuilding broker metadata

### DIFF
--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -199,20 +199,21 @@ class ClusterMetadata(object):
         if not metadata.brokers:
             log.warning("No broker metadata found in MetadataResponse")
 
+        _new_brokers = {}
         for broker in metadata.brokers:
             if metadata.API_VERSION == 0:
                 node_id, host, port = broker
                 rack = None
             else:
                 node_id, host, port, rack = broker
-            self._brokers.update({
+            _new_brokers.update({
                 node_id: BrokerMetadata(node_id, host, port, rack)
             })
 
         if metadata.API_VERSION == 0:
-            self.controller = None
+            _new_controller = None
         else:
-            self.controller = self._brokers.get(metadata.controller_id)
+            _new_controller = _new_brokers.get(metadata.controller_id)
 
         _new_partitions = {}
         _new_broker_partitions = collections.defaultdict(set)
@@ -253,6 +254,8 @@ class ClusterMetadata(object):
                           topic, error_type)
 
         with self._lock:
+            self._brokers = _new_brokers
+            self.controller = _new_controller
             self._partitions = _new_partitions
             self._broker_partitions = _new_broker_partitions
             self.unauthorized_topics = _new_unauthorized_topics


### PR DESCRIPTION
When a broker goes down and is removed from the cluster metadata, the current client would still retain the old broker information. This causes KafkaClient.least_loaded_node to sometimes choose a broker which no longer exists, leading to an immediate connection failure and another metadata refresh. In rare cases this could lead to a vicious cycle of metadata refresh while other connections may have pending in-flight-requests and therefore get low priority from least_loaded_node.

This PR changes the metadata response handling to fully reset the internal brokers list and avoid this problem. Note that this does not remove existing BrokerConnection objects from the KafkaClient._conns dict.