### PR TITLE
Dont refresh metadata on failed group coordinator request unless needed

### DIFF
--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -213,12 +213,10 @@ class BaseCoordinator(object):
             self._client.poll(future=future)
 
             if future.failed():
-                if isinstance(future.exception,
-                              Errors.GroupCoordinatorNotAvailableError):
-                    continue
-                elif future.retriable():
-                    metadata_update = self._client.cluster.request_update()
-                    self._client.poll(future=metadata_update)
+                if future.retriable():
+                    if getattr(future.exception, 'invalid_metadata', False):
+                        metadata_update = self._client.cluster.request_update()
+                        self._client.poll(future=metadata_update)
                 else:
                     raise future.exception  # pylint: disable-msg=raising-bad-type
 


### PR DESCRIPTION
Existing group coordinator discovery code triggers a metadata refresh on any error other than a small whitelist (GroupCoordinatorNotAvailableError). This PR drops the whitelist in favor of a simple check for the invalid_metadata attribute on retriable kafka errors.

This is expected to reduce unneeded metadata refreshes when, for example, the socket is simply still connecting (NodeNotReadyError).