### PR TITLE
Catch socket errors during ssl handshake

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -381,7 +381,7 @@ class BrokerConnection(object):
         # old ssl in python2.6 will swallow all SSLErrors here...
         except (SSLWantReadError, SSLWantWriteError):
             pass
-        except SSLZeroReturnError:
+        except (SSLZeroReturnError, ConnectionError):
             log.warning('SSL connection closed by server during handshake.')
             self.close(Errors.ConnectionError('SSL connection closed by server during handshake'))
         # Other SSLErrors will be raised to user


### PR DESCRIPTION
I noticed during testing that a socket disconnect during ssl handshake could lead to an unhandled error.