### PR TITLE
Mark last_attempt time during connection close to fix blackout

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -504,6 +504,7 @@ class BrokerConnection(object):
             self._sock.close()
             self._sock = None
         self.state = ConnectionStates.DISCONNECTED
+        self.last_attempt = time.time()
         self._sasl_auth_future = None
         self._receiving = False
         self._next_payload_bytes = 0


### PR DESCRIPTION
The blackout calculation relies on conn.last_attempt to determine how long before attempting a reconnect. In order to correctly blackout disconnected nodes, we need to set the timer on disconnect.