### PR TITLE
Include the node id in BrokerConnection __repr__

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -867,8 +867,8 @@ class BrokerConnection(object):
         return version
 
     def __repr__(self):
-        return "<BrokerConnection host=%s/%s port=%d>" % (self.hostname, self.host,
-                                                          self.port)
+        return "<BrokerConnection node_id=%s host=%s/%s port=%d>" % (
+            self.config['node_id'], self.hostname, self.host, self.port)
 
 
 class BrokerConnectionMetrics(object):


### PR DESCRIPTION
Intended to include the node_id with BrokerConnection log messages. This can help differentiate between bootstrap connections and normal cluster connections to the same host/port.