### PR TITLE
Just cancel in-flight-requests when connection closed without error

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -510,7 +510,7 @@ class BrokerConnection(object):
         self._rbuffer.seek(0)
         self._rbuffer.truncate()
         if error is None:
-            error = Errors.ConnectionError(str(self))
+            error = Errors.Cancelled(str(self))
         while self.in_flight_requests:
             ifr = self.in_flight_requests.popleft()
             ifr.future.failure(error)


### PR DESCRIPTION
Semantically this makes more sense, and it should improve logging. Also note that invalid_metadata is False for Cancelled but was True for ConnectionError.