### PR TITLE
Disable default consumer group

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -53,7 +53,7 @@ class KafkaConsumer(six.Iterator):
             partition assignment (if enabled), and to use for fetching and
             committing offsets. If None, auto-partition assignment (via
             group coordinator) and offset commits are disabled.
-            Default: 'kafka-python-default-group'
+            Default: None
         key_deserializer (callable): Any callable that takes a
             raw message key and returns a deserialized key.
         value_deserializer (callable): Any callable that takes a
@@ -207,7 +207,7 @@ class KafkaConsumer(six.Iterator):
     DEFAULT_CONFIG = {
         'bootstrap_servers': 'localhost',
         'client_id': 'kafka-python-' + __version__,
-        'group_id': 'kafka-python-default-group',
+        'group_id': None,
         'key_deserializer': None,
         'value_deserializer': None,
         'fetch_max_wait_ms': 500,

--- a/test/test_consumer_group.py
+++ b/test/test_consumer_group.py
@@ -54,12 +54,14 @@ def test_group(kafka_broker, topic):
     stop = {}
     threads = {}
     messages = collections.defaultdict(list)
+    group_id = 'test-group-' + random_string(6)
     def consumer_thread(i):
         assert i not in consumers
         assert i not in stop
         stop[i] = threading.Event()
         consumers[i] = KafkaConsumer(topic,
                                      bootstrap_servers=connect_str,
+                                     group_id=group_id,
                                      heartbeat_interval_ms=500)
         while not stop[i].is_set():
             for tp, records in six.itervalues(consumers[i].poll(100)):


### PR DESCRIPTION
Originally I thought enabling consumer group behavior by default would be useful. But having watched issue after issue opened following confusion about group semantics, I think it is time to drop the default. I note that the kafka-console-consumer.sh script uses a random consumer group if one is not supplied. This is basically the same thing -- subsequent runs of the same "script" will behave as if there were no rebalancing and no commits.

This should help avoid confusion caused by (1) join group delays due to session timeouts after ctrl-C or other unclean consumer shutdown, (2) no duplicate message consumption after restart due to auto commit.