### PR TITLE
fix AttributeError NoneType thrown by calling consumer subscription

### DIFF
--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -59,7 +59,7 @@ class SubscriptionState(object):
             offset_reset_strategy = OffsetResetStrategy.NONE
         self._default_offset_reset_strategy = offset_reset_strategy
 
-        self.subscription = None # set() or None
+        self.subscription = set() # set() or None
         self.subscribed_pattern = None # regex str or None
         self._group_subscription = set()
         self._user_assignment = set()


### PR DESCRIPTION
when calling consumer.subscription() without subscribe any topic, we got 

```python
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "./kafka_consumer.py", line 110, in run
    print consumer.subscription()
  File "/workplace/kafka-python/kafka/consumer/group.py", line 828, in subscription
    return self._subscription.subscription.copy()
AttributeError: 'NoneType' object has no attribute 'copy'
```
this pr just fix the subscription default value 