### PR TITLE
Don't fall into infinite cycle if future is lost during connection loss

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -489,6 +489,7 @@ class KafkaClient(object):
             timeout_ms = self.config['request_timeout_ms']
 
         responses = []
+        start_loop = time.time()
 
         # Loop for futures, break after first loop if None
         while True:
@@ -525,8 +526,13 @@ class KafkaClient(object):
             responses.extend(self._poll(timeout, sleep=sleep))
 
             # If all we had was a timeout (future is None) - only do one poll
-            # If we do have a future, we keep looping until it is done
+            # If we do have a future, we keep looping until it is done or request times out
             if not future or future.is_done:
+                break
+
+            in_loop = (time.time() - start_loop) * 1000.0
+            if in_loop > self.config['request_timeout_ms']:
+                future.failure(Errors.KafkaTimeoutError("Future wasn't done within request timeout."))
                 break
 
         return responses


### PR DESCRIPTION
This is simply it.
Future could be attached to some request and it should fire when response is received. If connection is lost, then request is also lost and cycle in ``KafkaClient.poll()`` will be infinite, causing the whole application to stuck without any ability to recover.

```python
            request = OffsetRequest[0](
                -1, [(topic, [(partition.partition, timestamp, 1) for partition in partitions])]
            )
            future_request = Future()
            _f = self._client.send(node_id, request)
            _f.add_callback(self._handle_offset_response, partitions, future_request)
            _f.add_errback(lambda e: future_request.failure(e))
              # blocks forever, if connection is lost after request is sent
              self._client.poll(future=future_request)
```

I propose to use ``request_timeout_ms`` as a maximum time that could be spend waiting for the future to complete.
