### PR TITLE
Fix poll() hyperlink in KafkaClient

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -50,7 +50,7 @@ class KafkaClient(object):
 
     Attributes:
         cluster (:any:`ClusterMetadata`): Local cache of cluster metadata, retrieved
-            via MetadataRequests during :meth:`.poll`.
+            via MetadataRequests during :meth:`~kafka.KafkaClient.poll`.
 
     Keyword Arguments:
         bootstrap_servers: 'host[:port]' string (or list of 'host[:port]'


### PR DESCRIPTION
Previously Sphinx was auto-linking to `poll()` in `KafkaConsumer`, so made the link explicit.