### PR TITLE
Catch socket.errors when sending / recving bytes on wake socketpair

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -829,7 +829,9 @@ class KafkaClient(object):
 
     def wakeup(self):
         with self._wake_lock:
-            if self._wake_w.send(b'x') != 1:
+            try:
+                assert self._wake_w.send(b'x') == 1
+            except (AssertionError, socket.error):
                 log.warning('Unable to send to wakeup socket!')
 
     def _clear_wake_fd(self):
@@ -837,7 +839,7 @@ class KafkaClient(object):
         while True:
             try:
                 self._wake_r.recv(1024)
-            except:
+            except socket.error:
                 break
 
 


### PR DESCRIPTION
During a travis test run, `producer.close()` triggered an unhandled exception during client.wakeup(). The exception was a Broken Pipe during send on the wakeup socketpair. I am not sure what caused the other side of the socketpair to close, but I think we should catch the error and log a warning rather than crash.