### PR TITLE
Flush timeout raises timeout

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -554,6 +554,10 @@ class KafkaProducer(object):
 
         Arguments:
             timeout (float, optional): timeout in seconds to wait for completion.
+            
+        Raises:
+            KafkaTimeoutError: failure to flush buffered records within the 
+                provided timeout 
         """
         log.debug("Flushing accumulated records in producer.")  # trace
         self._accumulator.begin_flush()

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -590,7 +590,7 @@ class KafkaProducer(object):
             set: partition ids for the topic
 
         Raises:
-            TimeoutException: if partitions for topic were not obtained before
+            KafkaTimeoutError: if partitions for topic were not obtained before
                 specified max_wait timeout
         """
         # add topic to metadata topic list if it is not there already.

--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -526,8 +526,11 @@ class RecordAccumulator(object):
             for batch in self._incomplete.all():
                 log.debug('Waiting on produce to %s',
                           batch.produce_future.topic_partition)
-                assert batch.produce_future.wait(timeout=timeout), 'Timeout waiting for future'
-                assert batch.produce_future.is_done, 'Future not done?'
+                if not batch.produce_future.wait(timeout=timeout):
+                    raise Errors.KafkaTimeoutError('Timeout waiting for future')
+                if not batch.produce_future.is_done:
+                    raise Errors.UnknownError('Future not done')
+
                 if batch.produce_future.failed():
                     log.warning(batch.produce_future.exception)
         finally:


### PR DESCRIPTION
https://github.com/dpkp/kafka-python/issues/1094

- Renamed `TimeoutException` to `KafkaTimeoutError`. Outside of the scope of original PR, let me know if I should pull this out.
- Catching both timeout and done assertion checks. My thinking was that if the user did not specify a timeout we would never hit the done check. If the user did specify a timeout and the done check fails it seems reasonable to consider it a timeout. I might be making too large of an assumption here. 