### PR TITLE
producer: Set exit timeout to 0 for atexit handler to match __del__

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -371,7 +371,7 @@ class KafkaProducer(object):
         _self = weakref.proxy(self)
         def wrapper():
             try:
-                _self.close()
+                _self.close(timeout=0)
             except (ReferenceError, AttributeError):
                 pass
         return wrapper


### PR DESCRIPTION
Hit a problem with pytest hitting the atexit handler and waiting
for close() timeout forever at teardown.

This commit makes atexit close() equivalent to __del__ behavior,
namely using timeout of 0 for close() completion. If you need a
longer timeout you should be setting it explicitly.