### PR TITLE
change_subscription warning log to info

### DIFF
--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -140,8 +140,9 @@ class ConsumerCoordinator(BaseCoordinator):
                 if self._subscription.subscribed_pattern.match(topic):
                     topics.append(topic)
 
-            self._subscription.change_subscription(topics)
-            self._client.set_topics(self._subscription.group_subscription())
+            if set(topics) != self._subscription.subscription:
+                self._subscription.change_subscription(topics)
+                self._client.set_topics(self._subscription.group_subscription())
 
         # check if there are any changes to the metadata which should trigger
         # a rebalance


### PR DESCRIPTION
When we are using subscription by pattern change subscription is
called every metadata update even when nothing changes. It logs
warning every time topics are not changed. It creates unnecessary
noise in logs. I changed it to level info so it can be easily ignored
(I want to see only warnings from kafka client). Do you think this is
a right approach or I should check in `ConsumerCoordinator._handle_metadata_update`
that no topics has changed and not call `change_subscription` in 
this case? I would then need to change it in aiokafka too because I'm
using that.