### PR TITLE
Prevent Fetcher from refetching messages when consuming compacted topics with poll() and max_records

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -360,7 +360,7 @@ class Fetcher(six.Iterator):
                 part_records = part.take(max_records)
                 if not part_records:
                     return 0
-                next_offset = part_records[-1].offset + 1
+                next_offset = part.fetch_offset
 
                 log.log(0, "Returning fetched records at offset %d for assigned"
                            " partition %s and update position to %s", position,


### PR DESCRIPTION
When a topic is compacted, consecutive messages might not have
consecutive offsets. `Fetcher._append` seems to  discard
`PartitionRecords` whenever the offset of the first message of a part
was not equal to the offset of the last message of the previous part + 1.
This is almost always the case for compacted topics (at least when
fetching from the 'earliest' offset).
Using `part.fetch_offset` instead ensures the whole
`PartitionRecords` is not discarded the first time offsets are not
consecutive, avoiding sending "useless" new FetchRequests.

In my case, using `consumer.poll(max_records=50)`, the first
`FetchResponse` returned ~13,000 records, ~12,950 were discarded
because the offset of the 51st record was not equal to the offset of
the 50th record + 1, a new `FetchRequest` was sent, and so on....
With this change, the whole ~13,000 messages were correctly used and
only one `FetchRequest` had to be sent.
(The topic was `__consumer_offsets` which is compacted).