### PR TITLE
Additional note about order to docs

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -209,7 +209,10 @@ class KafkaProducer(object):
             the computed value. Default: 1000.
         max_in_flight_requests_per_connection (int): Requests are pipelined
             to kafka brokers up to this number of maximum requests per
-            broker connection. Default: 5.
+            broker connection. Note that if this setting is set to be greater
+            than 1 and there are failed sends, there is a risk of message
+            re-ordering due to retries (i.e., if retries are enabled).
+            Default: 5.
         security_protocol (str): Protocol used to communicate with brokers.
             Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
             Default: PLAINTEXT.


### PR DESCRIPTION
Add note, that `max_in_flight_requests_per_connection>1` may change order or messages to `max_in_flight_requests_per_connection` description. I know, that `retries` mentions this, but often you only change max_in_flight_requests_per_connection without reading all option descriptions.