### PR TITLE
Fix batch expiry messages to state seconds

### DIFF
--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -103,11 +103,11 @@ class RecordBatch(object):
 
         error = None
         if not self.in_retry() and is_full and timeout < since_append:
-            error = "%d ms has passed since last append" % since_append
+            error = "%d seconds have passed since last append" % since_append
         elif not self.in_retry() and timeout < since_ready:
-            error = "%d ms has passed since batch creation plus linger time" % since_ready
+            error = "%d seconds have passed since batch creation plus linger time" % since_ready
         elif self.in_retry() and timeout < since_backoff:
-            error = "%d ms has passed since last attempt plus backoff time" % since_backoff
+            error = "%d seconds have passed since last attempt plus backoff time" % since_backoff
 
         if error:
             self.records.close()


### PR DESCRIPTION
time.time() is seconds since epoch, and the deltas are also calculated
in seconds