### PR TITLE
Make UnknownTopicOrPartitionError retriable error

### DIFF
--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -109,6 +109,7 @@ class UnknownTopicOrPartitionError(BrokerResponseError):
     message = 'UNKNOWN_TOPIC_OR_PARTITION'
     description = ('This request is for a topic or partition that does not'
                    ' exist on this broker.')
+    retriable = True
     invalid_metadata = True
 
 


### PR DESCRIPTION
Checked the old client, and the error was retriable there (https://github.com/dpkp/kafka-python/blob/master/kafka/errors.py#L505), so decided there's no need to skip the retry in v0.8 brokers.