### PR TITLE
Poll was returning duplicate messages with auto-commit disabled due to multiple rebalance trigger

### DIFF
--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -245,6 +245,8 @@ class ConsumerCoordinator(BaseCoordinator):
         # keep track of the metadata used for assignment so that we can check
         # after rebalance completion whether anything has changed
         self._cluster.request_update()
+        for topic in all_subscribed_topics:
+            self._metadata_snapshot[topic] = self._cluster.partitions_for_topic(topic)
         self._assignment_snapshot = self._metadata_snapshot
 
         log.debug("Performing assignment for group %s using strategy %s"


### PR DESCRIPTION
While using the poll feature of KafkaConsumer, we observed that it was returning duplicate messages (consistently on second poll request) if auto-commit is disabled. On debugging we observed that after sending the cluster update-request, it could take up to 2 minutes for metadata_snapshot to get updated. In this time the consumer returned all the produced messages and on next poll, it triggered rebalance again due to metadata_snapshot mismatch (empty earlier). As a result, it fetched the messages again from earliest offset, since the auto-commit was disabled.
Updating the metadata_snapshot after sending cluster update request fixed the issue.