### PR TITLE
Remove offsets version limit

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -893,10 +893,6 @@ class KafkaConsumer(six.Iterator):
                 up the offsets by timestamp.
             KafkaTimeoutError: If fetch failed in request_timeout_ms
         """
-        if self.config['api_version'] <= (0, 10, 0):
-            raise UnsupportedVersionError(
-                "offsets_for_times API not supported for cluster version {}"
-                .format(self.config['api_version']))
         for tp, ts in timestamps.items():
             timestamps[tp] = int(ts)
             if ts < 0:
@@ -928,10 +924,6 @@ class KafkaConsumer(six.Iterator):
                 up the offsets by timestamp.
             KafkaTimeoutError: If fetch failed in request_timeout_ms.
         """
-        if self.config['api_version'] <= (0, 10, 0):
-            raise UnsupportedVersionError(
-                "offsets_for_times API not supported for cluster version {}"
-                .format(self.config['api_version']))
         offsets = self._fetcher.beginning_offsets(
             partitions, self.config['request_timeout_ms'])
         return offsets
@@ -959,10 +951,6 @@ class KafkaConsumer(six.Iterator):
                 up the offsets by timestamp.
             KafkaTimeoutError: If fetch failed in request_timeout_ms
         """
-        if self.config['api_version'] <= (0, 10, 0):
-            raise UnsupportedVersionError(
-                "offsets_for_times API not supported for cluster version {}"
-                .format(self.config['api_version']))
         offsets = self._fetcher.end_offsets(
             partitions, self.config['request_timeout_ms'])
         return offsets

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -727,20 +727,6 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             tp1: p1msg.offset + 1
         })
 
-    @kafka_versions('<0.10.1')
-    def test_kafka_consumer_offsets_for_time_old(self):
-        consumer = self.kafka_consumer()
-        tp = TopicPartition(self.topic, 0)
-
-        with self.assertRaises(UnsupportedVersionError):
-            consumer.offsets_for_times({tp: int(time.time())})
-
-        with self.assertRaises(UnsupportedVersionError):
-            consumer.beginning_offsets([tp])
-
-        with self.assertRaises(UnsupportedVersionError):
-            consumer.end_offsets([tp])
-
     @kafka_versions('>=0.10.1')
     def test_kafka_consumer_offsets_for_times_errors(self):
         consumer = self.kafka_consumer()


### PR DESCRIPTION
Actually the offsets functions work well when the version of kafka is lower than 0.10.0 and the only difference is the offset request's API_VERSION is not the same. I think we need to let more users to enjoy the feature.