### PR TITLE
remove beginning/end offsets request version limit

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -928,10 +928,6 @@ class KafkaConsumer(six.Iterator):
                 up the offsets by timestamp.
             KafkaTimeoutError: If fetch failed in request_timeout_ms.
         """
-        if self.config['api_version'] <= (0, 10, 0):
-            raise UnsupportedVersionError(
-                "offsets_for_times API not supported for cluster version {}"
-                .format(self.config['api_version']))
         offsets = self._fetcher.beginning_offsets(
             partitions, self.config['request_timeout_ms'])
         return offsets
@@ -959,10 +955,6 @@ class KafkaConsumer(six.Iterator):
                 up the offsets by timestamp.
             KafkaTimeoutError: If fetch failed in request_timeout_ms
         """
-        if self.config['api_version'] <= (0, 10, 0):
-            raise UnsupportedVersionError(
-                "offsets_for_times API not supported for cluster version {}"
-                .format(self.config['api_version']))
         offsets = self._fetcher.end_offsets(
             partitions, self.config['request_timeout_ms'])
         return offsets

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -735,12 +735,6 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         with self.assertRaises(UnsupportedVersionError):
             consumer.offsets_for_times({tp: int(time.time())})
 
-        with self.assertRaises(UnsupportedVersionError):
-            consumer.beginning_offsets([tp])
-
-        with self.assertRaises(UnsupportedVersionError):
-            consumer.end_offsets([tp])
-
     @kafka_versions('>=0.10.1')
     def test_kafka_consumer_offsets_for_times_errors(self):
         consumer = self.kafka_consumer()


### PR DESCRIPTION
- Remove beginning_offset and end_offset version limit because the kafka service of lower versions can get accurate offsets in these two functions.
Our discussion is in [#1199](https://github.com/dpkp/kafka-python/pull/1199)