### PR TITLE
Background tasks may not run during consumer.poll when using max_records

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -608,6 +608,9 @@ class KafkaConsumer(six.Iterator):
             # fetched records.
             if not partial:
                 self._fetcher.send_fetches()
+
+            # To handle any heartbeat tasks
+            self._client.poll(tiemout_ms=0)
             return records
 
         # Send any new fetches (won't resend pending fetches)


### PR DESCRIPTION
Observation: While testing the KafkaConsumer using poll method for multiple instances and consuming messages at a low rate (~1Msg/sec) without any manual or auto commits, we observed that the rebalance was not getting triggered when a new instance was added or removed.

Steps to reproduce the issue:
a) Create consumer with auto-commit disabled, with at least 2 partitions.
b) Start 1st consumer instance
c) Consume messages at a very slow rate (~1Msg/sec), without any manual commits
d) Start another instance
No rebalance is triggered for the first instance. Both the instances are assigned from both the partitions. 

On debugging we found that on consumer.poll call the client.poll is [not](https://github.com/dpkp/kafka-python/blob/master/kafka/consumer/group.py#L607) sent if there are previously fetched records. This lead to missing the handling of heartbeat tasks (every 3 seconds) for the running instance. As a result for any newly added or removed the instance, the consumer-group is treated as new one and assigned all partitions instead of partitioner dividing between them.

We also saw that the client.poll request in case the message_iterator method is used instead of poll.
The issue is not seen in the case of the iterator method.

The [fix is](https://github.com/dpkp/kafka-python/blob/master/kafka/consumer/group.py#L607) to send client-poll with timeout 0 to avoid any performance impacts due to additional polls.

We tested the fix internally and tested for performance impact as minimal.

Is there a reason that client.poll is not called on every consumer.poll?