### PR TITLE
Explicitly check for `None` rather than False

### DIFF
--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -190,7 +190,7 @@ class ConsumerCoordinator(BaseCoordinator):
         # if we were the assignor, then we need to make sure that there have
         # been no metadata updates since the rebalance begin. Otherwise, we
         # won't rebalance again until the next metadata change
-        if self._assignment_snapshot and self._assignment_snapshot != self._metadata_snapshot:
+        if self._assignment_snapshot is not None and self._assignment_snapshot != self._metadata_snapshot:
             self._subscription.mark_for_reassignment()
             return
 


### PR DESCRIPTION
If the group leader somehow gets in a state that it has an empty partition assignment, then `self._assignment_snapshot` will be `{}` which evaluates to `False`. So `self._subscription.mark_for_reassignment()` will never be triggered, even if `self._assignment_snapshot != self._metadata_snapshot`. 

Here is the relevant upstream Java code:
https://github.com/apache/kafka/blob/c5d26c4829583c95af7ca9e961a4d3954f8e09eb/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L197

Fixes the symptoms of #1237 although I suspect there's an additional bug in that case that triggers the condition of the the group leader getting an empty partition assignment.

I'm hesitant with this fix because I still don't fully understand the race condition that results in the group leader simultaneously having:
1. a valid topic subscription
2. an empty partition assignment
3.`subscription.needs_partition_assignment = False`.

Related: #1237 / #1241 / #1242 