### PR TITLE
Fix SASL authentication bugs

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -444,7 +444,10 @@ class BrokerConnection(object):
             sasl_response.add_errback(lambda f, e: f.failure(e), future)
             self._sasl_auth_future = future
         self.recv()
-        if self._sasl_auth_future.failed():
+        # A connection error could trigger close() which will reset the future
+        if self._sasl_auth_future is None:
+            return False
+        elif self._sasl_auth_future.failed():
             ex = self._sasl_auth_future.exception
             if not isinstance(ex, Errors.ConnectionError):
                 raise ex  # pylint: disable-msg=raising-bad-type

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -460,7 +460,12 @@ class BrokerConnection(object):
             self.close(error=error)
             return future.failure(error_type(self))
 
-        if self.config['sasl_mechanism'] == 'PLAIN':
+        if self.config['sasl_mechanism'] not in response.enabled_mechanisms:
+            return future.failure(
+                Errors.UnsupportedSaslMechanismError(
+                    'Kafka broker does not support %s sasl mechanism. Enabled mechanisms are: %s'
+                    % (self.config['sasl_mechanism'], response.enabled_mechanisms)))
+        elif self.config['sasl_mechanism'] == 'PLAIN':
             return self._try_authenticate_plain(future)
         elif self.config['sasl_mechanism'] == 'GSSAPI':
             return self._try_authenticate_gssapi(future)

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -443,7 +443,7 @@ class BrokerConnection(object):
             sasl_response.add_callback(self._handle_sasl_handshake_response, future)
             sasl_response.add_errback(lambda f, e: f.failure(e), future)
             self._sasl_auth_future = future
-        self._recv()
+        self.recv()
         if self._sasl_auth_future.failed():
             ex = self._sasl_auth_future.exception
             if not isinstance(ex, Errors.ConnectionError):


### PR DESCRIPTION
This PR fixes three bugs in sasl handshake processing: First, after #1230 _recv() does not handle futures / in-flight-request processing. We need to call self.recv() if we want callbacks to be triggered automatically. Second, it is possible that recv() may catch a network error and close the connection. This will reset _sasl_auth_future and so we need to validate that it is not None before checking if it failed or succeeded. Third, when processing the SaslHandShakeResponse we should validate that the configured sasl_mechanism is listed as enabled in the handshake response.

In addition, I have consolidated the socket send routine into a single private method, _send_bytes_blocking(data).

Fixes #1255