### PR TITLE
Move callback processing from BrokerConnection to KafkaClient

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -28,6 +28,7 @@ def mock_conn(conn, success=True):
     else:
         mocked.send.return_value = Future().failure(Exception())
     conn.return_value = mocked
+    conn.recv.return_value = []
 
 
 class TestSimpleClient(unittest.TestCase):
@@ -94,7 +95,7 @@ class TestSimpleClient(unittest.TestCase):
         mock_conn(mocked_conns[('kafka03', 9092)], success=False)
         future = Future()
         mocked_conns[('kafka02', 9092)].send.return_value = future
-        mocked_conns[('kafka02', 9092)].recv.side_effect = lambda: future.success('valid response')
+        mocked_conns[('kafka02', 9092)].recv.return_value = [('valid response', future)]
 
         def mock_get_conn(host, port, afi):
             return mocked_conns[(host, port)]


### PR DESCRIPTION
This is a small refactor to how response callbacks are processed. It is designed to separate the callback chain processing from the network processing code. This will allow us to use a threading lock around client networking that can be released before processing callbacks to reduce the risk of deadlock. This approach is derived from KAFKA-3888 / KIP-62 (background heartbeat thread).