### PR TITLE
Check that timestamp_ms value is expected type

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -530,6 +530,8 @@ class KafkaProducer(object):
         assert value is not None or self.config['api_version'] >= (0, 8, 1), (
             'Null messages require kafka >= 0.8.1')
         assert not (value is None and key is None), 'Need at least one: key or value'
+        assert timestamp_ms is None or isinstance(timestamp_ms, int), (
+            'timestamp_ms must be either None or an integer') 
         key_bytes = value_bytes = None
         try:
             # first make sure the metadata for the topic is


### PR DESCRIPTION
I used an assert rather than an exception because if someone runs python with the `-o` flag where asserts are stripped out, they probably don't want to pay the penalty of this check, and if it fails they will get an error, it'll just be difficult to figure it out (as seen in #1271).

Fix #1271 

