### PR TITLE
Fix two bugs in printing bytes instance

### DIFF
--- a/kafka/protocol/types.py
+++ b/kafka/protocol/types.py
@@ -100,7 +100,7 @@ class Bytes(AbstractType):
 
     @classmethod
     def repr(cls, value):
-        return repr(value[:100] + b'...' if len(value) > 100 else b'')
+        return repr(value[:100] + b'...' if value is not None and len(value) > 100 else value)
 
 
 class Boolean(AbstractType):


### PR DESCRIPTION
Bug 1:
When `value` is `None`, trying to call `len(None)` throws an exception.

Bug 2:
When `len(value) <= 100`, the code currently prints `b''` rather than
`value`.

@asdaraujo I cherry-picked this commit from your other PR, as I want to make sure fixes for both of these issues land, and I think the pytest will be a longer journey. I marked you as the commit author to give you credit for finding this issue, if you prefer otherwise I can change it.

@tvoinarovskyi can you review since you wrote this code originally? You normally pay attention to these kinds of details and sometimes use techniques I'm not familiar with, so want to make sure this isn't something you did on purpose...