### PR TITLE
Use correct casing for MB

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -85,7 +85,7 @@ class Fetcher(six.Iterator):
                 performs fetches to multiple brokers in parallel so memory
                 usage will depend on the number of brokers containing
                 partitions for the topic.
-                Supported Kafka version >= 0.10.1.0. Default: 52428800 (50 Mb).
+                Supported Kafka version >= 0.10.1.0. Default: 52428800 (50 MB).
             max_partition_fetch_bytes (int): The maximum amount of data
                 per-partition the server will return. The maximum total memory
                 used for a request = #partitions * max_partition_fetch_bytes.

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -74,7 +74,7 @@ class KafkaConsumer(six.Iterator):
             ensure that the consumer can make progress. NOTE: consumer performs
             fetches to multiple brokers in parallel so memory usage will depend
             on the number of brokers containing partitions for the topic.
-            Supported Kafka version >= 0.10.1.0. Default: 52428800 (50 Mb).
+            Supported Kafka version >= 0.10.1.0. Default: 52428800 (50 MB).
         max_partition_fetch_bytes (int): The maximum amount of data
             per-partition the server will return. The maximum total memory
             used for a request = #partitions * max_partition_fetch_bytes.


### PR DESCRIPTION
These values refer to Megabytes, not Megabits.

Fix #1295