### PR TITLE
Change fixture default host to localhost

### DIFF
--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -191,22 +191,8 @@ class KafkaFixture(Fixture):
             (host, port) = (parse.hostname, parse.port)
             fixture = ExternalService(host, port)
         else:
-            # force IPv6 here because of a confusing point:
-            #
-            #  - if the string "localhost" is passed, Kafka will *only* bind to the IPv4 address of localhost
-            #    (127.0.0.1); however, kafka-python will attempt to connect on ::1 and fail
-            #
-            #  - if the address literal 127.0.0.1 is passed, the metadata request during bootstrap will return
-            #    the name "localhost" and we'll go back to the first case. This is odd!
-            #
-            # Ideally, Kafka would bind to all loopback addresses when we tell it to listen on "localhost" the
-            # way it makes an IPv6 socket bound to both 0.0.0.0/0 and ::/0 when we tell it to bind to "" (that is
-            # to say, when we make a listener of PLAINTEXT://:port.
-            #
-            # Note that even though we specify the bind host in bracket notation, Kafka responds to the bootstrap
-            # metadata request without square brackets later.
             if host is None:
-                host = "[::1]"
+                host = "localhost"
             fixture = KafkaFixture(host, port, broker_id,
                                    zk_host, zk_port, zk_chroot,
                                    transport=transport,


### PR DESCRIPTION
@dpkp, I think the current errors with the Travis build may be because the VM have IPv6 disabled and since the fixtures are forcing the use of IPv6 the Kafka broker cannot bind to a valid address. If this is indeed the case, however, I'm not sure what happened recently that caused builds start failing.

I had a look at the `KafkaFixture` code and saw the comment saying that if the broker binds to an IPv4 address, then "kafka-python will attempt to connect on ::1 and fail".
I'm not sure why that's the case. I checked the code and couldn't find an explanation. Maybe this has been changed since?

I'm also not quite sure what's the use of the bracket notation for the broker address (e.g. `[::1]`). I couldn't find a reference to it in the Kafka documentation. I noticed that it doesn't work with "localhost". If I set the default address to `[localhost]` the tests fail. However, if the address is set to simply `localhost` it seems to work fine on hosts with IPv6 enabled or disabled.

I tested this change on two different VMs: one with IPv6 enabled and the other with IPv6 disabled. All tests passed. So I'm sending this PR to see how it goes on Travis.
