### PR TITLE
Raise non-API exceptions

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -571,11 +571,7 @@ class KafkaProducer(object):
             # handling exceptions and record the errors;
             # for API exceptions return them in the future,
             # for other exceptions raise directly
-        except Errors.KafkaTimeoutError:
-            raise
-        except AssertionError:
-            raise
-        except Exception as e:
+        except Errors.BrokerResponseError as e:
             log.debug("Exception occurred during message send: %s", e)
             return FutureRecordMetadata(
                 FutureProduceResult(TopicPartition(topic, partition)),


### PR DESCRIPTION
The original intent was to catch API exceptions (errors returned by the
broker when trying to produce a message) and delegate them to the
messages' futures. This is copied from the Java producer.

However, we were accidentally catching all exceptions, thereby hiding
exceptions from users unless they explicitly check the result of the
future. Much better to raise client-side errors directly in the
foreground so the user is immediately aware of them and can decide how
to handle.

Fix #1274 