### PR TITLE
Give better struct errors

### DIFF
--- a/kafka/protocol/types.py
+++ b/kafka/protocol/types.py
@@ -8,16 +8,20 @@ from .abstract import AbstractType
 def _pack(f, value):
     try:
         return pack(f, value)
-    except error:
-        raise ValueError(error)
+    except error as e:
+        raise ValueError("Error encountered when attempting to convert value: "
+                        "{} to struct format: '{}', hit error: {}"
+                        .format(value, f, e))
 
 
 def _unpack(f, data):
     try:
         (value,) = unpack(f, data)
         return value
-    except error:
-        raise ValueError(error)
+    except error as e:
+        raise ValueError("Error encountered when attempting to convert value: "
+                        "{} to struct format: '{}', hit error: {}"
+                        .format(value, f, e))
 
 
 class Int8(AbstractType):


### PR DESCRIPTION
Stop shadowing the word `error` because we want to know what the specific exception message was.

Also give more details on exactly which value failed. We don't know who submitted the value, but perhaps it's unique enough that we can debug it better.

Fix #1318