### PR TITLE
Pin pylint and lz4 to avoid breaking tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,10 +5,11 @@ pytest-catchlog==1.2.2
 docker-py==1.10.6
 coveralls==1.2.0
 Sphinx==1.6.4
-lz4==0.10.1
+lz4==0.11.1
 xxhash==1.0.1
 python-snappy==0.5.1
 tox==2.9.1
+pylint==1.8.0
 pytest-pylint==0.7.1
 # pytest-sugar==0.9.0
 pytest-mock==1.6.3

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,13 @@ deps =
     pytest
     pytest-cov
     pytest-catchlog
+    py{27,34,35,36,py}: pylint==1.8.0
     py{27,34,35,36,py}: pytest-pylint
     pytest-sugar
     pytest-mock
     mock
     python-snappy
-    lz4
+    lz4==0.11.1
     xxhash
     py26: unittest2
 commands =


### PR DESCRIPTION
This is a short-term fix to avoid failing all tests. After landing we should investigate the root cause and fix so that we can continue with newer releases for these libraries.