### PR TITLE
Improve KafkaConsumer cleanup

### DIFF
--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -356,10 +356,7 @@ class BaseCoordinator(object):
                 self.rejoining = True
 
             if self._heartbeat_thread is None:
-                log.debug('Starting new heartbeat thread')
-                self._heartbeat_thread = HeartbeatThread(weakref.proxy(self))
-                self._heartbeat_thread.daemon = True
-                self._heartbeat_thread.start()
+                self._start_heartbeat_thread()
 
             while self.need_rejoin():
                 self.ensure_coordinator_ready()
@@ -712,13 +709,30 @@ class BaseCoordinator(object):
     def request_rejoin(self):
         self.rejoin_needed = True
 
+    def _start_heartbeat_thread(self):
+        if self._heartbeat_thread is None:
+            log.info('Starting new heartbeat thread')
+            self._heartbeat_thread = HeartbeatThread(weakref.proxy(self))
+            self._heartbeat_thread.daemon = True
+            self._heartbeat_thread.start()
+
+    def _close_heartbeat_thread(self):
+        if self._heartbeat_thread is not None:
+            log.info('Stopping heartbeat thread')
+            try:
+                self._heartbeat_thread.close()
+            except ReferenceError:
+                pass
+            self._heartbeat_thread = None
+
+    def __del__(self):
+        self._close_heartbeat_thread()
+
     def close(self):
         """Close the coordinator, leave the current group,
         and reset local generation / member_id"""
         with self._lock:
-            if self._heartbeat_thread is not None:
-                self._heartbeat_thread.close()
-                self._heartbeat_thread = None
+            self._close_heartbeat_thread()
             self.maybe_leave_group()
 
     def maybe_leave_group(self):
@@ -877,12 +891,11 @@ class HeartbeatThread(threading.Thread):
             self.coordinator._lock.notify()
 
     def disable(self):
-        with self.coordinator._lock:
-            self.enabled = False
+        self.enabled = False
 
     def close(self):
+        self.closed = True
         with self.coordinator._lock:
-            self.closed = True
             self.coordinator._lock.notify()
 
     def run(self):
@@ -890,7 +903,10 @@ class HeartbeatThread(threading.Thread):
             while not self.closed:
                 self._run_once()
 
-            log.debug('Heartbeat closed!')
+            log.debug('Heartbeat thread closed')
+
+        except ReferenceError:
+            log.debug('Heartbeat thread closed due to coordinator gc')
 
         except RuntimeError as e:
             log.error("Heartbeat thread for group %s failed due to unexpected error: %s",

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -125,6 +125,7 @@ class ConsumerCoordinator(BaseCoordinator):
     def __del__(self):
         if hasattr(self, '_cluster') and self._cluster:
             self._cluster.remove_listener(WeakMethod(self._handle_metadata_update))
+        super(ConsumerCoordinator, self).__del__()
 
     def protocol_type(self):
         return ConsumerProtocol.PROTOCOL_TYPE

--- a/kafka/util.py
+++ b/kafka/util.py
@@ -167,6 +167,14 @@ class WeakMethod(object):
         return self._target_id == other._target_id and self._method_id == other._method_id
 
 
+class Dict(dict):
+    """Utility class to support passing weakrefs to dicts
+
+    See: https://docs.python.org/2/library/weakref.html
+    """
+    pass
+
+
 def try_method_on_system_exit(obj, method, *args, **kwargs):
     def wrapper(_obj, _meth, *args, **kwargs):
         try:


### PR DESCRIPTION
After digging into #1331 a bit it I found a few issues:

(1) heartbeat thread is not stopped unless KafkaConsumer is closed explicitly (or python interpreter exits).
(2) most connection objects have a circular reference preventing garbage collection prior to interpreter shutdown
(3) the client object also has a circular reference preventing gc prior to shutdown

This PR should fix these issues by using weakrefs to break circular references and by shutting down local resources like the heartbeat thread during gc via `__del__`

It appears that there are still circular references preventing gc of KafkaMetrics and possibly SubscriptionState. These do not prevent the consumer, coordinator, client, or connection objects from being cleaned up, so I'm going to leave further fixes for a later PR.