### PR TITLE
Honor reconnect_backoff in conn.connect()

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -278,7 +278,7 @@ class BrokerConnection(object):
 
     def connect(self):
         """Attempt to connect and return ConnectionState"""
-        if self.state is ConnectionStates.DISCONNECTED:
+        if self.state is ConnectionStates.DISCONNECTED and not self.blacked_out():
             self.last_attempt = time.time()
             next_lookup = self._next_afi_host_port()
             if not next_lookup:

--- a/test/test_conn.py
+++ b/test/test_conn.py
@@ -263,6 +263,7 @@ def test_lookup_on_connect():
     ]
 
     with mock.patch("socket.getaddrinfo", return_value=mock_return2) as m:
+        conn.last_attempt = 0
         conn.connect()
         m.assert_called_once_with(hostname, port, 0, 1)
         conn.close()
@@ -288,6 +289,7 @@ def test_relookup_on_failure():
     ]
 
     with mock.patch("socket.getaddrinfo", return_value=mock_return2) as m:
+        conn.last_attempt = 0
         conn.connect()
         m.assert_called_once_with(hostname, port, 0, 1)
         conn.close()


### PR DESCRIPTION
While debugging a heartbeat thread issue I noticed that BrokerConnection reconnects do not always honor the reconnect backoff. This PR updates the lowest level call (`connect()`) so that it will only start a new connection after the backoff period.