### PR TITLE
Avoid KeyError when filtering fetchable partitions

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -638,11 +638,9 @@ class Fetcher(six.Iterator):
     def _fetchable_partitions(self):
         fetchable = self._subscriptions.fetchable_partitions()
         if self._next_partition_records:
-            if self._next_partition_records.topic_partition in fetchable:
-                fetchable.remove(self._next_partition_records.topic_partition)
+            fetchable.discard(self._next_partition_records.topic_partition)
         for fetch in self._completed_fetches:
-            if fetch.topic_partition in fetchable:
-                fetchable.remove(fetch.topic_partition)
+            fetchable.discard(fetch.topic_partition)
         return fetchable
 
     def _create_fetch_requests(self):

--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -638,9 +638,11 @@ class Fetcher(six.Iterator):
     def _fetchable_partitions(self):
         fetchable = self._subscriptions.fetchable_partitions()
         if self._next_partition_records:
-            fetchable.remove(self._next_partition_records.topic_partition)
+            if self._next_partition_records.topic_partition in fetchable:
+                fetchable.remove(self._next_partition_records.topic_partition)
         for fetch in self._completed_fetches:
-            fetchable.remove(fetch.topic_partition)
+            if fetch.topic_partition in fetchable:
+                fetchable.remove(fetch.topic_partition)
         return fetchable
 
     def _create_fetch_requests(self):


### PR DESCRIPTION
I noticed this failure in a failed travis run. If we attempt to remove a partition that is not currently fetchable, the set will raise a KeyError. To avoid, we test that the element is in the set before removing it.