### PR TITLE
Remove assertion with side effect

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -852,8 +852,8 @@ class KafkaClient(object):
     def wakeup(self):
         with self._wake_lock:
             try:
-                assert self._wake_w.send(b'x') == 1
-            except (AssertionError, socket.error):
+                self._wake_w.sendall(b'x')
+            except socket.error:
                 log.warning('Unable to send to wakeup socket!')
 
     def _clear_wake_fd(self):


### PR DESCRIPTION
When running Python code with PYTHONOPTIMIZE=1 assertions are removed. Needless to say, an assertion should never have a side effect that is critical for the program's execution. @dpkp You seem to have ignored the following: https://github.com/dpkp/kafka-python/issues/1184 but I was getting the same symptoms and it took quite some time to figure out the cause. 