### PR TITLE
fix reconnect_backoff_max_ms default config bug in KafkaProducer

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -295,7 +295,7 @@ class KafkaProducer(object):
         'sock_chunk_bytes': 4096,  # undocumented experimental option
         'sock_chunk_buffer_count': 1000,  # undocumented experimental option
         'reconnect_backoff_ms': 50,
-        'reconnect_backoff_max': 1000,
+        'reconnect_backoff_max_ms': 1000,
         'max_in_flight_requests_per_connection': 5,
         'security_protocol': 'PLAINTEXT',
         'ssl_context': None,


### PR DESCRIPTION
According to the [Kafka Document](http://kafka.apache.org/documentation.html#producerconfigs) and the usage in [client_async.py](https://github.com/dpkp/kafka-python/blob/master/kafka/client_async.py) ，the config  `reconnect_backoff_max` should be `reconnect_backoff_max_ms` 
: )