### PR TITLE
Fix for Python 3 byte string handling

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -45,5 +45,7 @@
 * Lou Marvin Caraig, [@se7entyse7en](https://github.com/se7entyse7en)
 * waliaashish85, [@waliaashish85](https://github.com/waliaashish85)
 * Mark Roberts, [@wizzat](https://github.com/wizzat)
+* Christophe Lecointe [@christophelec](https://github.com/christophelec)
+* Mohamed Helmi Hichri [@hellich](https://github.com/hellich)
 
 Thanks to all who have contributed!

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -566,9 +566,9 @@ class BrokerConnection(object):
             # Kafka currently doesn't support integrity or confidentiality security layers, so we
             # simply set QoP to 'auth' only (first octet). We reuse the max message size proposed
             # by the server
-            msg = Int8.encode(SASL_QOP_AUTH & Int8.decode(io.BytesIO(msg[0]))) + msg[1:]
+            msg = Int8.encode(SASL_QOP_AUTH & Int8.decode(io.BytesIO(msg[0:1]))) + msg[1:]
             # add authorization identity to the response, GSS-wrap and send it
-            msg = client_ctx.wrap(msg + auth_id, False).message
+            msg = client_ctx.wrap(msg + auth_id.encode(), False).message
             size = Int32.encode(len(msg))
             self._send_bytes_blocking(size + msg)
 


### PR DESCRIPTION
Due to differences in byte string handling between Python 2 and 3, this fix is required to be able to use Kerberos authentication with Python 3
