### PR TITLE
Stop pinning lz4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     pytest-mock
     mock
     python-snappy
-    lz4==0.11.1
+    lz4
     xxhash
     py26: unittest2
 commands =


### PR DESCRIPTION
Opening a PR to check if tests pass with the new version. If so, we'll want to bump `requirements-dev.txt` as well, since it was also pinned in c2331db80c31d5222d1c267b8a0de5ce58b7f6f0.

Many thanks to @jonathanunderwood for his diligent work here: https://github.com/dpkp/kafka-python/issues/1021#issuecomment-359161985