### PR TITLE
Use latest pytest 3.4.0, but drop pytest-sugar due to incompatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flake8==3.4.1
-pytest==3.2.2
+pytest==3.4.0
 pytest-cov==2.5.1
 pytest-catchlog==1.2.2
 docker-py==1.10.6
@@ -11,6 +11,5 @@ python-snappy==0.5.1
 tox==2.9.1
 pylint==1.8.0
 pytest-pylint==0.7.1
-# pytest-sugar==0.9.0
 pytest-mock==1.6.3
 sphinx-rtd-theme==0.2.4

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     pytest-catchlog
     py{27,34,35,36,py}: pylint==1.8.0
     py{27,34,35,36,py}: pytest-pylint
-    pytest-sugar
     pytest-mock
     mock
     python-snappy


### PR DESCRIPTION
Fix for #1360 