### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
     - pip install .
 
 script:
-  - tox -e `if [ "$TRAVIS_PYTHON_VERSION" == "pypy" ]; then echo pypy; else echo py${TRAVIS_PYTHON_VERSION/./} -- --junit-xml=testresults.xml; fi`
+  - tox -e `if [ \"$TRAVIS_PYTHON_VERSION\" == \"pypy\" ]; then echo pypy; else echo py${TRAVIS_PYTHON_VERSION/./}; fi` -- --junit-xml=testresults.xml
 
 after_script:
   - testspace [Kafka-${KAFKA_VERSION}/Python-${TRAVIS_PYTHON_VERSION}]testresults.xml{test}

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ cache:
     - servers/
 
 before_install:
+    - mkdir -p $HOME/bin
+    - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+    - testspace config url $TS_ORG.testspace.com
     - ./build_integration.sh
 
 install:
@@ -34,7 +37,10 @@ install:
     - pip install .
 
 script:
-  - tox -e `if [ "$TRAVIS_PYTHON_VERSION" == "pypy" ]; then echo pypy; else echo py${TRAVIS_PYTHON_VERSION/./}; fi`
+  - tox -e `if [ "$TRAVIS_PYTHON_VERSION" == "pypy" ]; then echo pypy; else echo py${TRAVIS_PYTHON_VERSION/./} -- --junit-xml=testresults.xml; fi`
 
+after_script:
+  - testspace [Kafka-${KAFKA_VERSION}/Python-${TRAVIS_PYTHON_VERSION}]testresults.xml{test}
+ 
 after_success:
   - coveralls


### PR DESCRIPTION
Hi @dpkp  We’ve made a few minor changes to demonstrate how you can better manage your Travis CI build results with [Testspace.com](https://www.testspace.com/). 

YOUR TEST RESULTS, from `our fork`, at https://open.testspace.com/projects/TryTestspace:kafka-python.

`Note`, the only changes for your repo were formatting the test output to use `JUnit`. But this seemed to create a timing issue? I see random test failures (refer [here](https://open.testspace.com/spaces/75174/result_sets)) over ~ 10 builds.

Below are a list of what we see as *value-add*. Hope you check it out. 

---

#### Tired of scrolling through Travis logs to find test failures? 
 
 * Triage failures faster with single-click filtering and complete failure context; call stack, timing info, and more.

#### Wishing your test results were organized?  
 * Move beyond a flat, endless window of test output. In Testspace, your test results mirror your test folders and subfolders as defined in your repo. 
 * For larger volumes of tests, use hierarchy to reflect your overall test design. 

#### Looking for actionable metrics to assess the value of your testing?   
 * View historical tracking of all your important metrics; test case and code coverage growth, static analysis issues, and more.  
 * Leverage analytic indicators to assess the effectiveness of your automated testing. 
 
----

#### Setup is Easy

1. Create a free [Open Source Account](https://signup.testspace.com/?plan_id=open.2)
2. Create a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
