### PR TITLE
Use raw in case string overridden

### DIFF
--- a/kafka/protocol/types.py
+++ b/kafka/protocol/types.py
@@ -10,7 +10,7 @@ def _pack(f, value):
         return pack(f, value)
     except error as e:
         raise ValueError("Error encountered when attempting to convert value: "
-                        "{} to struct format: '{}', hit error: {}"
+                        "{!r} to struct format: '{}', hit error: {}"
                         .format(value, f, e))
 
 
@@ -20,7 +20,7 @@ def _unpack(f, data):
         return value
     except error as e:
         raise ValueError("Error encountered when attempting to convert value: "
-                        "{} to struct format: '{}', hit error: {}"
+                        "{!r} to struct format: '{}', hit error: {}"
                         .format(value, f, e))
 
 


### PR DESCRIPTION
This should reduce confusion in the off-chance that `str` is overridden.

Thanks to Taras for the suggestion: https://github.com/dpkp/kafka-python/pull/1320/files#r155716948