### PR TITLE
Removed pytest-catchlog dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ log_format = %(created)f %(filename)-23s %(threadName)s %(message)s
 deps =
     pytest
     pytest-cov
-    pytest-catchlog
     py{27,34,35,36,py}: pylint==1.8.2
     py{27,34,35,36,py}: pytest-pylint
     pytest-mock


### PR DESCRIPTION
No longer necessary since pytest-catchlog has been merged into pytest's core.
This commit addresses the following warning in pytest output:

  pytest-catchlog plugin has been merged into the core, please remove it from your requirements.

Fixes #1379