### PR TITLE
Correctly respect timeouts in consumer poll interface

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -642,7 +642,7 @@ class KafkaConsumer(six.Iterator):
         # Send any new fetches (won't resend pending fetches)
         self._fetcher.send_fetches()
 
-        timeout_ms = min(timeout_ms, self._coordinator.time_to_next_poll())
+        timeout_ms = min(timeout_ms, self._coordinator.time_to_next_poll() * 1000)
         self._client.poll(timeout_ms=timeout_ms)
         # after the long poll, we should check whether the group needs to rebalance
         # prior to returning data so that the group can stabilize faster


### PR DESCRIPTION
`ConsumerCoordinator.time_to_next_poll()` returns seconds, so need to convert to milliseconds.

Fixes https://github.com/dpkp/kafka-python/issues/1383