### PR TITLE
Only increase reconnect backoff if all addrinfos have been tried

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -257,7 +257,7 @@ class BrokerConnection(object):
             self._ssl_context = self.config['ssl_context']
         self._sasl_auth_future = None
         self.last_attempt = 0
-        self._gai = None
+        self._gai = []
         self._sensors = None
         if self.config['metrics']:
             self._sensors = BrokerConnectionMetrics(self.config['metrics'],

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -629,6 +629,9 @@ class BrokerConnection(object):
         self._reconnect_backoff = self.config['reconnect_backoff_ms'] / 1000.0
 
     def _update_reconnect_backoff(self):
+        # Do not mark as failure if there are more dns entries available to try
+        if len(self._gai) > 0:
+            return
         if self.config['reconnect_backoff_max_ms'] > self.config['reconnect_backoff_ms']:
             self._failures += 1
             self._reconnect_backoff = self.config['reconnect_backoff_ms'] * 2 ** (self._failures - 1)


### PR DESCRIPTION
Separated from #1411 . This PR prevents prematurely backing off when trying to connect to a multi-address host. We should only add a backoff delay if all available addresses fail.