### PR TITLE
Short-circuit BrokerConnection.close() if already disconnected

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -653,10 +653,13 @@ class BrokerConnection(object):
                 will be failed with this exception.
                 Default: kafka.errors.ConnectionError.
         """
+        if self.state is ConnectionStates.DISCONNECTED:
+            if error is not None:
+                log.warning('%s: Duplicate close() with error: %s', self, error)
+            return
         log.info('%s: Closing connection. %s', self, error or '')
-        if self.state is not ConnectionStates.DISCONNECTED:
-            self.state = ConnectionStates.DISCONNECTING
-            self.config['state_change_callback'](self)
+        self.state = ConnectionStates.DISCONNECTING
+        self.config['state_change_callback'](self)
         self._update_reconnect_backoff()
         self._close_socket()
         self.state = ConnectionStates.DISCONNECTED


### PR DESCRIPTION
Separated from #1411 . It is fairly common when handling a connection error for us to call `self.close(error)` inside BrokerConnection, return an error to the caller, and for the caller -- usually KafkaClient -- to call conn.close() again. Right now this causes connection errors to be double logged, which can seem strange. The PR simply checks whether the connection is already disconnected, and if so it does nothing. We assume that the only way to get a BrokerConnection object into the disconnected state is via `close()`