### PR TITLE
Close leaked selector in version check

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -919,6 +919,7 @@ class BrokerConnection(object):
                 for response, future in self.recv():
                     future.success(response)
                 selector.select(1)
+            selector.close()
 
             if f.succeeded():
                 if isinstance(request, ApiVersionRequest[0]):


### PR DESCRIPTION
Separated from #1411 -- this is a simple fix to hopefully avoid leaking fds.