### PR TITLE
Adds add_callback/add_errback example to docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -91,6 +91,18 @@ KafkaProducer
     for _ in range(100):
         producer.send('my-topic', b'msg')
 
+    def on_send_success(record_metadata):
+        print(record_metadata.topic)
+        print(record_metadata.partition)
+        print(record_metadata.offset)
+
+    def on_send_error(excp):
+        log.exception()
+        # handle exception
+
+    # produce asynchronously with callbacks 
+    producer.send('my-topic', b'raw_bytes').add_callback(on_send_success).add_errback(on_send_error)
+
     # block until all async messages are sent
     producer.flush()
 


### PR DESCRIPTION
After spending quite some time figuring out how to properly add callbacks/errbacks to the producer.send future obj, decided to add a basic example to the docs (Issue #1256 ).

I didn't really know where to put it as there seemed to be no examples in the docs outside of "Usage Overview", so I just put it there.

I am willing to expand upon this if needed, but I'll need to know where exactly to put it in and some guidance as to what you want to see in terms of explanation/example.

Have a good day!