### PR TITLE
Deleted __del__ as fix for Issue #1218

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -420,9 +420,6 @@ class KafkaProducer(object):
                     pass
         self._cleanup = None
 
-    def __del__(self):
-        self.close(timeout=0)
-
     def close(self, timeout=None):
         """Close this producer.
 


### PR DESCRIPTION
There was previously an issue with kafka logging during shutdown, after all of the global variables had been set to `None`. Most of the suggestions to a fix involved using `atexit.register` at the end of the constructor. After deleting the `__del__` function, looking over the rest of this code, and having no trouble with the Kafka producer logging afterwards, I concluded that this fixed the logging issue. Plus, ever since Python 3.4, it generally seems unwise to use __del__.