### PR TITLE
Fix skipped integration tests if KAFKA_VERSION unset

### DIFF
--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -2,6 +2,7 @@ import logging
 import os
 import time
 
+import pytest
 from six.moves import xrange
 import six
 
@@ -19,12 +20,14 @@ from kafka.structs import (
     ProduceRequestPayload, TopicPartition, OffsetAndTimestamp
 )
 
+from test.conftest import version
 from test.fixtures import ZookeeperFixture, KafkaFixture
 from test.testutil import (
     KafkaIntegrationTestCase, kafka_versions, random_string, Timer,
     send_messages
 )
 
+@pytest.mark.skipif(not version(), reason="No KAFKA_VERSION set")
 def test_kafka_consumer(simple_client, topic, kafka_consumer_factory):
     """Test KafkaConsumer
     """

--- a/test/test_producer_integration.py
+++ b/test/test_producer_integration.py
@@ -2,6 +2,7 @@ import os
 import time
 import uuid
 
+import pytest
 from six.moves import range
 
 from kafka import (
@@ -14,8 +15,10 @@ from kafka.errors import UnknownTopicOrPartitionError, LeaderNotAvailableError
 from kafka.producer.base import Producer
 from kafka.structs import FetchRequestPayload, ProduceRequestPayload
 
+from test.conftest import version
 from test.fixtures import ZookeeperFixture, KafkaFixture
 from test.testutil import KafkaIntegrationTestCase, kafka_versions, current_offset
+
 
 # TODO: This duplicates a TestKafkaProducerIntegration method temporarily
 # while the migration to pytest is in progress
@@ -32,6 +35,7 @@ def assert_produce_request(client, topic, messages, initial_offset, message_ct,
 
     assert current_offset(client, topic, partition) == initial_offset + message_ct
 
+
 def assert_produce_response(resp, initial_offset):
     """Verify that a produce response is well-formed
     """
@@ -39,6 +43,8 @@ def assert_produce_response(resp, initial_offset):
     assert resp[0].error == 0
     assert resp[0].offset == initial_offset
 
+
+@pytest.mark.skipif(not version(), reason="No KAFKA_VERSION set")
 def test_produce_many_simple(simple_client, topic):
     """Test multiple produces using the SimpleClient
     """


### PR DESCRIPTION
Small PR to fix running unit tests locally w/o starting brokers.