### PR TITLE
Fix KafkaConsumer docstring for request_timeout_ms default

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -78,7 +78,7 @@ class KafkaClient(object):
             resulting in a random range between 20% below and 20% above
             the computed value. Default: 1000.
         request_timeout_ms (int): Client request timeout in milliseconds.
-            Default: 40000.
+            Default: 30000.
         retry_backoff_ms (int): Milliseconds to backoff when retrying on
             errors. Default: 100.
         max_in_flight_requests_per_connection (int): Requests are pipelined
@@ -145,7 +145,7 @@ class KafkaClient(object):
     DEFAULT_CONFIG = {
         'bootstrap_servers': 'localhost',
         'client_id': 'kafka-python-' + __version__,
-        'request_timeout_ms': 40000,
+        'request_timeout_ms': 30000,
         'connections_max_idle_ms': 9 * 60 * 1000,
         'reconnect_backoff_ms': 50,
         'reconnect_backoff_max_ms': 1000,

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -116,7 +116,7 @@ class BrokerConnection(object):
             resulting in a random range between 20% below and 20% above
             the computed value. Default: 1000.
         request_timeout_ms (int): Client request timeout in milliseconds.
-            Default: 40000.
+            Default: 30000.
         max_in_flight_requests_per_connection (int): Requests are pipelined
             to kafka brokers up to this number of maximum requests per
             broker connection. Default: 5.
@@ -181,7 +181,7 @@ class BrokerConnection(object):
     DEFAULT_CONFIG = {
         'client_id': 'kafka-python-' + __version__,
         'node_id': 0,
-        'request_timeout_ms': 40000,
+        'request_timeout_ms': 30000,
         'reconnect_backoff_ms': 50,
         'reconnect_backoff_max_ms': 1000,
         'max_in_flight_requests_per_connection': 5,

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -84,7 +84,7 @@ class KafkaConsumer(six.Iterator):
             happens, the consumer can get stuck trying to fetch a large
             message on a certain partition. Default: 1048576.
         request_timeout_ms (int): Client request timeout in milliseconds.
-            Default: 40000.
+            Default: 305000.
         retry_backoff_ms (int): Milliseconds to backoff when retrying on
             errors. Default: 100.
         reconnect_backoff_ms (int): The amount of time in milliseconds to


### PR DESCRIPTION
Fix #1458 . Also no need to keep 40000 as default for internal classes so I reduced to the KafkaProducer default of 30000 (the internal classes should almost never be relying on defaults since the outer classes will pass their own default values if user does not specify).