### PR TITLE
Fix infinite loops and cpu overflow

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -155,6 +155,7 @@ class KafkaClient(object):
         'socket_options': [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)],
         'sock_chunk_bytes': 4096,  # undocumented experimental option
         'sock_chunk_buffer_count': 1000,  # undocumented experimental option
+        'max_retry_backoff': float('inf'),
         'retry_backoff_ms': 100,
         'metadata_max_age_ms': 300000,
         'security_protocol': 'PLAINTEXT',

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -623,8 +623,6 @@ class KafkaClient(object):
                 conn.close(error=Errors.RequestTimedOutError(
                     'Request timed out after %s ms' %
                     conn.config['request_timeout_ms']))
-            elif conn.state == '<disconnected>':
-                raise Errors.ConnectionError
 
         if self._sensors:
             self._sensors.io_time.record((time.time() - end_select) * 1000000000)

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -623,6 +623,8 @@ class KafkaClient(object):
                 conn.close(error=Errors.RequestTimedOutError(
                     'Request timed out after %s ms' %
                     conn.config['request_timeout_ms']))
+            elif conn.state == '<disconnected>':
+                raise Errors.ConnectionError
 
         if self._sensors:
             self._sensors.io_time.record((time.time() - end_select) * 1000000000)

--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -213,6 +213,7 @@ class ClusterMetadata(object):
 
         if not metadata.brokers:
             log.warning("No broker metadata found in MetadataResponse")
+            return self.failed_update(Errors.ConnectionError)
 
         _new_brokers = {}
         for broker in metadata.brokers:

--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -31,6 +31,7 @@ class ClusterMetadata(object):
             brokers or partitions. Default: 300000
     """
     DEFAULT_CONFIG = {
+        'max_retry_backoff': float('inf'),
         'retry_backoff_ms': 100,
         'metadata_max_age_ms': 300000,
     }

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -390,7 +390,7 @@ class BrokerConnection(object):
 
             # Needs retry
             else:
-                pass
+                time.sleep(self.config['reconnect_backoff_ms'] / 1000)
 
         if self.state is ConnectionStates.HANDSHAKE:
             if self._try_handshake():

--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -59,6 +59,7 @@ class Fetcher(six.Iterator):
         'iterator_refetch_records': 1,  # undocumented -- interface may change
         'metric_group_prefix': 'consumer',
         'api_version': (0, 8, 0),
+        'max_retry_backoff': float('inf'),
         'retry_backoff_ms': 100
     }
 

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -251,6 +251,7 @@ class KafkaConsumer(six.Iterator):
         'fetch_max_bytes': 52428800,
         'max_partition_fetch_bytes': 1 * 1024 * 1024,
         'request_timeout_ms': 305000, # chosen to be higher than the default of max_poll_interval_ms
+        'max_retry_backoff': float('inf'),
         'retry_backoff_ms': 100,
         'reconnect_backoff_ms': 50,
         'reconnect_backoff_max_ms': 1000,

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -263,14 +263,14 @@ class BaseCoordinator(object):
 
                 if future.failed():
                     if future.retriable():
-                        if self.config['max_retry_backoff'] == retry:
-                            raise future.exception  # pylint: disable-msg=raising-bad-type
-                        retry += 1
                         if getattr(future.exception, 'invalid_metadata', False):
                             log.debug('Requesting metadata for group coordinator request: %s', future.exception)
                             metadata_update = self._client.cluster.request_update()
                             self._client.poll(future=metadata_update)
                         else:
+                            if self.config['max_retry_backoff'] == retry:
+                                raise future.exception  # pylint: disable-msg=raising-bad-type
+                            retry += 1
                             time.sleep(self.config['retry_backoff_ms'] / 1000)
                     else:
                         raise future.exception  # pylint: disable-msg=raising-bad-type

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -34,6 +34,7 @@ class ConsumerCoordinator(BaseCoordinator):
         'session_timeout_ms': 10000,
         'heartbeat_interval_ms': 3000,
         'max_poll_interval_ms': 300000,
+        'max_retry_backoff': float('inf'),
         'retry_backoff_ms': 100,
         'api_version': (0, 10, 1),
         'exclude_internal_topics': True,

--- a/kafka/coordinator/heartbeat.py
+++ b/kafka/coordinator/heartbeat.py
@@ -10,6 +10,7 @@ class Heartbeat(object):
         'heartbeat_interval_ms': 3000,
         'session_timeout_ms': 10000,
         'max_poll_interval_ms': 300000,
+        'max_retry_backoff': float('inf'),
         'retry_backoff_ms': 100,
     }
 

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -286,6 +286,7 @@ class KafkaProducer(object):
         'max_block_ms': 60000,
         'max_request_size': 1048576,
         'metadata_max_age_ms': 300000,
+        'max_retry_backoff': float('inf'),
         'retry_backoff_ms': 100,
         'request_timeout_ms': 30000,
         'receive_buffer_bytes': None,

--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -169,6 +169,7 @@ class RecordAccumulator(object):
         'batch_size': 16384,
         'compression_attrs': 0,
         'linger_ms': 0,
+        'max_retry_backoff': float('inf'),
         'retry_backoff_ms': 100,
         'message_version': 0,
         'metrics': None,

--- a/kafka/producer/sender.py
+++ b/kafka/producer/sender.py
@@ -61,10 +61,11 @@ class Sender(threading.Thread):
             try:
                 self.run_once()
             except Exception:
+                log.exception("Uncaught error in kafka producer I/O thread")
                 if self.config['max_retry_backoff'] == retry:
                     self._force_close = True
+                    break
                 retry += 1
-                log.exception("Uncaught error in kafka producer I/O thread")
 
         log.debug("Beginning shutdown of Kafka producer I/O thread, sending"
                   " remaining records.")
@@ -79,10 +80,11 @@ class Sender(threading.Thread):
             try:
                 self.run_once()
             except Exception:
+                log.exception("Uncaught error in kafka producer I/O thread")
                 if self.config['max_retry_backoff'] == retry:
                     self._force_close = True
+                    break
                 retry += 1
-                log.exception("Uncaught error in kafka producer I/O thread")
 
         if self._force_close:
             # We need to fail all the incomplete batches and wake up the

--- a/kafka/producer/sender.py
+++ b/kafka/producer/sender.py
@@ -59,6 +59,7 @@ class Sender(threading.Thread):
             try:
                 self.run_once()
             except Exception:
+                self._force_close = True
                 log.exception("Uncaught error in kafka producer I/O thread")
 
         log.debug("Beginning shutdown of Kafka producer I/O thread, sending"


### PR DESCRIPTION
Fix multiple infinite loops (locks threads) if connection error :
- Add option "max_retry_backoff" to consomer and producer for more control of retries
- Add Raising connection error if consomer or producer disconnected
- Fix cpu overflow on connection error