### PR TITLE
Fix CreatePartitionsRequest_v0

### DIFF
--- a/kafka/protocol/admin.py
+++ b/kafka/protocol/admin.py
@@ -355,7 +355,7 @@ class CreatePartitionsRequest_v0(Request):
             ('topic', String('utf-8')),
             ('new_partitions', Schema(
                 ('count', Int32),
-                ('assignment', Array(Int32)))))),
+                ('assignment', Array(Array(Int32))))))),
         ('timeout', Int32),
         ('validate_only', Boolean)
     )


### PR DESCRIPTION
Hello,

While using your library to develop an Ansible module, I noticed that the current CreatePartitionsRequest_v0 is wrong since 'assignment' is an Array of Array of Int32 (see https://github.com/apache/kafka/blob/a553764c8b1611cafd318022d0fc4a34c861f6ba/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitions.java#L37)

Tested in my project, everything is fine now.

Regards,
Stephen