### PR TITLE
Improve BrokerConnection initialization

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -948,7 +948,6 @@ class BrokerConnection(object):
 
             selector = self.config['selector']()
             selector.register(self._sock, selectors.EVENT_READ)
-
             while not (f.is_done and mr.is_done):
                 selector.select(1)
                 for response, future in self.recv():

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -948,10 +948,11 @@ class BrokerConnection(object):
 
             selector = self.config['selector']()
             selector.register(self._sock, selectors.EVENT_READ)
+
             while not (f.is_done and mr.is_done):
+                selector.select(1)
                 for response, future in self.recv():
                     future.success(response)
-                selector.select(1)
             selector.close()
 
             if f.succeeded():


### PR DESCRIPTION
This should improve the BrokerConnection initialization performance avoiding call `selector.select(1)` without data to fetch in socket.
This PR is related to https://github.com/dpkp/kafka-python/issues/1468