### PR TITLE
Force lz4 to disable Kafka-unsupported block linking when encoding

### DIFF
--- a/kafka/codec.py
+++ b/kafka/codec.py
@@ -20,9 +20,15 @@ try:
     import lz4.frame as lz4
 
     def _lz4_compress(payload, **kwargs):
-        kwargs.pop('block_linked', None)
-        # Kafka does not support block linked mode
-        return lz4.compress(payload, block_linked=False, **kwargs)
+        # Kafka does not support LZ4 dependent blocks
+        try:
+            # For lz4>=0.12.0
+            kwargs.pop('block_linked', None)
+            return lz4.compress(payload, block_linked=False, **kwargs)
+        except TypeError:
+            # For earlier versions of lz4
+            kwargs.pop('block_mode', None)
+            return lz4.compress(payload, block_mode=1, **kwargs)
 
 except ImportError:
     lz4 = None

--- a/kafka/codec.py
+++ b/kafka/codec.py
@@ -18,6 +18,12 @@ except ImportError:
 
 try:
     import lz4.frame as lz4
+
+    def _lz4_compress(payload, **kwargs):
+        kwargs.pop('block_linked', None)
+        # Kafka does not support block linked mode
+        return lz4.compress(payload, block_linked=False, **kwargs)
+
 except ImportError:
     lz4 = None
 
@@ -202,7 +208,7 @@ def snappy_decode(payload):
 
 
 if lz4:
-    lz4_encode = lz4.compress # pylint: disable-msg=no-member
+    lz4_encode = _lz4_compress # pylint: disable-msg=no-member
 elif lz4f:
     lz4_encode = lz4f.compressFrame # pylint: disable-msg=no-member
 elif lz4framed:


### PR DESCRIPTION
Kafka does not support LZ4 compression with dependent blocks

https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockOutputStream.java#L343

This issue was first noticed when encoding larger-than-usual messages in our application.

This change appears to solve the problem by enforcing compression with independent blocks in the underlying LZ4 package.
