### PR TITLE
Fix #1494: "Consumer fails to reconnect on kafka restart in case of mutiple topics"

### DIFF
--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -212,6 +212,7 @@ class ClusterMetadata(object):
 
         if not metadata.brokers:
             log.warning("No broker metadata found in MetadataResponse")
+            return Errors.NoBrokersAvailable()
 
         _new_brokers = {}
         for broker in metadata.brokers:


### PR DESCRIPTION
Fix #1494: "Consumer fails to reconnect on kafka restart in case of mutiple topics"

Prevent `update_metadata()` from moving to unrecoverable state of empty broker list.

