### PR TITLE
Document methods that return None

### DIFF
--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -96,6 +96,7 @@ class ClusterMetadata(object):
 
         Returns:
             set: {partition (int), ...}
+            None if topic not found.
         """
         if topic not in self._partitions:
             return None
@@ -119,6 +120,7 @@ class ClusterMetadata(object):
 
         Returns:
             set: {TopicPartition, ...}
+            None if the broker either has no partitions or does not exist.
         """
         return self._broker_partitions.get(broker_id)
 
@@ -130,6 +132,7 @@ class ClusterMetadata(object):
 
         Returns:
             int: node_id for group coordinator
+            None if the group does not exist.
         """
         return self._groups.get(group)
 


### PR DESCRIPTION
If a valid broker in the cluster has no partitions, it will return `None` rather than an empty set.

This was surprising behavior to me, I expected a broker that exists but has no partitions would return an empty set. So I'm not sure if it's better to document the current behavior, or change this to `get(broker_id, set())`.

Similarly documented a few other methods that sometimes can return `None`.