### PR TITLE
Ignore MetadataResponses with empty broker list

### DIFF
--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -214,7 +214,8 @@ class ClusterMetadata(object):
             return self.failed_update(error)
 
         if not metadata.brokers:
-            log.warning("No broker metadata found in MetadataResponse")
+            log.warning("No broker metadata found in MetadataResponse -- ignoring.")
+            return self.failed_update(Errors.MetadataEmptyBrokerList(metadata))
 
         _new_brokers = {}
         for broker in metadata.brokers:

--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -54,6 +54,10 @@ class StaleMetadata(KafkaError):
     invalid_metadata = True
 
 
+class MetadataEmptyBrokerList(KafkaError):
+    retriable = True
+
+
 class UnrecognizedBrokerVersion(KafkaError):
     pass
 

--- a/test/test_cluster.py
+++ b/test/test_cluster.py
@@ -1,0 +1,24 @@
+# pylint: skip-file
+from __future__ import absolute_import
+
+import pytest
+
+from kafka.cluster import ClusterMetadata
+from kafka.protocol.metadata import MetadataResponse
+
+import kafka.common as Errors
+
+
+def test_empty_broker_list():
+    cluster = ClusterMetadata()
+    assert len(cluster.brokers()) == 0
+
+    cluster.update_metadata(MetadataResponse[0](
+        [(0, 'foo', 12), (1, 'bar', 34)], []))
+    assert len(cluster.brokers()) == 2
+
+    # empty broker list response should be ignored
+    cluster.update_metadata(MetadataResponse[0](
+        [],  # empty brokers
+        [(17, 'foo', []), (17, 'bar', [])]))  # topics w/ error
+    assert len(cluster.brokers()) == 2

--- a/test/test_cluster.py
+++ b/test/test_cluster.py
@@ -6,8 +6,6 @@ import pytest
 from kafka.cluster import ClusterMetadata
 from kafka.protocol.metadata import MetadataResponse
 
-import kafka.common as Errors
-
 
 def test_empty_broker_list():
     cluster = ClusterMetadata()


### PR DESCRIPTION
Fix for #1494 . The MetadataResponse should be ignored and treated as a failure if the broker list is empty (same as the java client).