### PR TITLE
add support for on-demand topic metadata fetch

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -892,7 +892,7 @@ class BrokerConnection(object):
         # so if all else fails, choose that
         return (0, 10, 0)
 
-    def check_version(self, timeout=2, strict=False):
+    def check_version(self, timeout=2, strict=False, topics=[]):
         """Attempt to guess the broker version.
 
         Note: This is a blocking call.
@@ -925,7 +925,7 @@ class BrokerConnection(object):
             ((0, 9), ListGroupsRequest[0]()),
             ((0, 8, 2), GroupCoordinatorRequest[0]('kafka-python-default-group')),
             ((0, 8, 1), OffsetFetchRequest[0]('kafka-python-default-group', [])),
-            ((0, 8, 0), MetadataRequest[0]([])),
+            ((0, 8, 0), MetadataRequest[0](topics)),
         ]
 
         for version, request in test_cases:
@@ -941,7 +941,7 @@ class BrokerConnection(object):
             # the attempt to write to a disconnected socket should
             # immediately fail and allow us to infer that the prior
             # request was unrecognized
-            mr = self.send(MetadataRequest[0]([]))
+            mr = self.send(MetadataRequest[0](topics))
 
             selector = self.config['selector']()
             selector.register(self._sock, selectors.EVENT_READ)

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -276,6 +276,7 @@ class KafkaProducer(object):
         'key_serializer': None,
         'value_serializer': None,
         'acks': 1,
+        'bootstrap_topics_filter': set(),
         'compression_type': None,
         'retries': 0,
         'batch_size': 16384,


### PR DESCRIPTION
This PR adds support for on-demand topic metadata fetching. For now, a KafkaClient will fetch metadata for all topics in the initialization. This will have some performance problem when run with a large Kafka cluster.

Adding a `topics` (type `set`) key-value parameter to `KafkaProducer`. This should be all the topics that `send` will be invoked on. For example, if `send` will be invoked on `send('a', ...)` and `send('b', ...)`, then the value for `topics` will be `{'a', 'b'}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1541)
<!-- Reviewable:end -->
