### PR TITLE
Verbose logging on messages signalling data loss in producer

### DIFF
--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -69,7 +69,8 @@ class ProducerBatch(object):
         return future
 
     def done(self, base_offset=None, timestamp_ms=None, exception=None):
-        log.debug("Produced messages to topic-partition %s with base offset"
+        level = logging.DEBUG if exception is None else logging.WARNING
+        log.log(level, "Produced messages to topic-partition %s with base offset"
                   " %s and error %s.", self.topic_partition, base_offset,
                   exception)  # trace
         if self.produce_future.is_done:
@@ -327,7 +328,7 @@ class RecordAccumulator(object):
                     to_remove = []
 
         if expired_batches:
-            log.debug("Expired %d batches in accumulator", count) # trace
+            log.warning("Expired %d batches in accumulator", count) # trace
 
         return expired_batches
 


### PR DESCRIPTION
Recently, I've spend some human days trying to find where in our multi step pipeline we were having a data loss. It turned out one of our producers were generating batches too often resulting to their expiration. But there were no signs of any problems in logs. This PR attempts to fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1553)
<!-- Reviewable:end -->
