### PR TITLE
Clear the metrics dictionary on close (fixes a memory leak).

### DIFF
--- a/kafka/metrics/metrics.py
+++ b/kafka/metrics/metrics.py
@@ -257,3 +257,5 @@ class Metrics(object):
         """Close this metrics repository."""
         for reporter in self._reporters:
             reporter.close()
+
+        self._metrics.clear()


### PR DESCRIPTION
Without this, the dictionary is not being garbage collected and is leaking memory. After applying this patch, the memory leak I described [here](https://github.com/dpkp/kafka-python/issues/1340#issuecomment-411712947) was fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1569)
<!-- Reviewable:end -->
