### PR TITLE
set socket timeout for the wake_w

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -151,6 +151,7 @@ class KafkaClient(object):
         'bootstrap_servers': 'localhost',
         'client_id': 'kafka-python-' + __version__,
         'request_timeout_ms': 30000,
+        'max_block_ms': 60000,
         'connections_max_idle_ms': 9 * 60 * 1000,
         'reconnect_backoff_ms': 50,
         'reconnect_backoff_max_ms': 1000,
@@ -198,6 +199,7 @@ class KafkaClient(object):
         self._bootstrap_fails = 0
         self._wake_r, self._wake_w = socket.socketpair()
         self._wake_r.setblocking(False)
+        self._wake_w.settimeout(self.config['max_block_ms'] / 1000.0)
         self._wake_lock = threading.Lock()
 
         self._lock = threading.RLock()
@@ -847,6 +849,9 @@ class KafkaClient(object):
         with self._wake_lock:
             try:
                 self._wake_w.sendall(b'x')
+            except socket.timeout:
+                log.warning('Timeout to send to wakeup socket!')
+                raise Errors.KafkaTimeoutError()
             except socket.error:
                 log.warning('Unable to send to wakeup socket!')
 

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -151,7 +151,7 @@ class KafkaClient(object):
         'bootstrap_servers': 'localhost',
         'client_id': 'kafka-python-' + __version__,
         'request_timeout_ms': 30000,
-        'max_block_ms': 60000,
+        'wakeup_timeout_ms': 3000,
         'connections_max_idle_ms': 9 * 60 * 1000,
         'reconnect_backoff_ms': 50,
         'reconnect_backoff_max_ms': 1000,
@@ -199,7 +199,7 @@ class KafkaClient(object):
         self._bootstrap_fails = 0
         self._wake_r, self._wake_w = socket.socketpair()
         self._wake_r.setblocking(False)
-        self._wake_w.settimeout(self.config['max_block_ms'] / 1000.0)
+        self._wake_w.settimeout(self.config['wakeup_timeout_ms'] / 1000.0)
         self._wake_lock = threading.Lock()
 
         self._lock = threading.RLock()

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -364,6 +364,7 @@ class KafkaProducer(object):
         self._metrics = Metrics(metric_config, reporters)
 
         client = KafkaClient(metrics=self._metrics, metric_group_prefix='producer',
+                             wakeup_timeout_ms=self.config['max_block_ms'],
                              **self.config)
 
         # Get auto-discovered version from client if necessary


### PR DESCRIPTION
hi Dana,

we're running kafka-python on a SNS site in china, yesterday we've met an issue about the kafka host hangs because of some kernel gotchas, and the application containers hangs after the kafka, thus the site is down before we restarted the kafka.

after some investigation, we found the writing side of the `wake_w` socketpair is blocking, and with no socket timeout. if the sender thread can not execute `wake_r.receive` but got blocked, `wake_w.sendall(b'x')` would block the `producer.send()` method without timeout. we have a config option about `max_block_ms` which works on ` buffer is full or metadata unavailable`, but have not worked on the `wake_w.send` yet.

we'd prefer the `wake_w.send` method fails fast with a timeout error instead of blocking forever on the producer thread, so we can save ourselves from hanging all the containers by a CircuitBreaker.

thank you

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1577)
<!-- Reviewable:end -->
