### PR TITLE
Remove ConsumerTimeout

### DIFF
--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -476,10 +476,6 @@ class ConsumerNoMoreData(KafkaError):
     pass
 
 
-class ConsumerTimeout(KafkaError):
-    pass
-
-
 class ProtocolError(KafkaError):
     pass
 


### PR DESCRIPTION
This error hasn't been thrown since 1.2.4 and I do not see it anywhere else in the library.

https://github.com/dpkp/kafka-python/blob/bc4cc434cddf403a35d0393d68ecfdbfad17c8e5/docs/changelog.rst#124-july-8-2016

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1587)
<!-- Reviewable:end -->
