### PR TITLE
Expose ConsumerRebalanceListener in __all__

### DIFF
--- a/kafka/__init__.py
+++ b/kafka/__init__.py
@@ -50,5 +50,5 @@ __all__ = [
     'SimpleClient', 'SimpleProducer', 'KeyedProducer',
     'RoundRobinPartitioner', 'HashedPartitioner',
     'create_message', 'create_gzip_message', 'create_snappy_message',
-    'SimpleConsumer', 'MultiProcessConsumer',
+    'SimpleConsumer', 'MultiProcessConsumer', 'ConsumerRebalanceListener',
 ]


### PR DESCRIPTION
This solves a warning in linters like PyCharm, which warns that a line like:
```
from kafka import ConsumerRebalanceListener
```
is actually accessing a protected member of a class or module. Adding it to `__all__` should solve this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1591)
<!-- Reviewable:end -->
