### PR TITLE
moved setblocking(False) after connection is established

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -78,6 +78,13 @@ except ImportError:
     gssapi = None
     GSSError = None
 
+# needed for setblocking()
+try:
+    from gevent import monkey
+    is_gevent_patched = monkey.is_module_patched('ssl')
+except ImportError:
+    is_gevent_patched = False
+
 
 AFI_NAMES = {
     socket.AF_UNSPEC: "unspecified",
@@ -337,6 +344,7 @@ class BrokerConnection(object):
                 log.debug('%s: setting socket option %s', self, option)
                 self._sock.setsockopt(*option)
 
+            self._sock.setblocking(is_gevent_patched)
             self.state = ConnectionStates.CONNECTING
             if self.config['security_protocol'] in ('SSL', 'SASL_SSL'):
                 self._wrap_ssl()
@@ -401,7 +409,8 @@ class BrokerConnection(object):
                     self.state = ConnectionStates.CONNECTED
                 self.config['state_change_callback'](self)
 
-        self._sock.setblocking(False)
+        if is_gevent_patched:
+            self._sock.setblocking(False)
 
         if self.state is ConnectionStates.AUTHENTICATING:
             assert self.config['security_protocol'] in ('SASL_PLAINTEXT', 'SASL_SSL')

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -81,9 +81,9 @@ except ImportError:
 # needed for setblocking()
 try:
     from gevent import monkey
-    is_gevent_patched = monkey.is_module_patched('ssl')
+    is_ssl_gevent_patched = monkey.is_module_patched('ssl')
 except ImportError:
-    is_gevent_patched = False
+    is_ssl_gevent_patched = False
 
 
 AFI_NAMES = {
@@ -344,7 +344,7 @@ class BrokerConnection(object):
                 log.debug('%s: setting socket option %s', self, option)
                 self._sock.setsockopt(*option)
 
-            self._sock.setblocking(is_gevent_patched)
+            self._sock.setblocking(is_ssl_gevent_patched)
             self.state = ConnectionStates.CONNECTING
             if self.config['security_protocol'] in ('SSL', 'SASL_SSL'):
                 self._wrap_ssl()
@@ -409,7 +409,7 @@ class BrokerConnection(object):
                     self.state = ConnectionStates.CONNECTED
                 self.config['state_change_callback'](self)
 
-        if is_gevent_patched:
+        if is_ssl_gevent_patched:
             self._sock.setblocking(False)
 
         if self.state is ConnectionStates.AUTHENTICATING:

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -337,7 +337,6 @@ class BrokerConnection(object):
                 log.debug('%s: setting socket option %s', self, option)
                 self._sock.setsockopt(*option)
 
-            self._sock.setblocking(False)
             self.state = ConnectionStates.CONNECTING
             if self.config['security_protocol'] in ('SSL', 'SASL_SSL'):
                 self._wrap_ssl()
@@ -401,6 +400,8 @@ class BrokerConnection(object):
                     log.info('%s: Connection complete.', self)
                     self.state = ConnectionStates.CONNECTED
                 self.config['state_change_callback'](self)
+
+        self._sock.setblocking(False)
 
         if self.state is ConnectionStates.AUTHENTICATING:
             assert self.config['security_protocol'] in ('SASL_PLAINTEXT', 'SASL_SSL')


### PR DESCRIPTION
Fixes issue #1598 
This commit fixes the exception raised when using SSL connection with gevent monkey patched code.
It's done by moving the `setblocking(False)` command to AFTER the connection has been established.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1599)
<!-- Reviewable:end -->
