### PR TITLE
create round-robin partitioner starting from a random partition

### DIFF
--- a/kafka/partitioner/__init__.py
+++ b/kafka/partitioner/__init__.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import
 from kafka.partitioner.default import DefaultPartitioner
 from kafka.partitioner.hashed import HashedPartitioner, Murmur2Partitioner, LegacyPartitioner
 from kafka.partitioner.roundrobin import RoundRobinPartitioner
+from kafka.partitioner.randroundrobin import RandStartRoundRobinPartitioner
 
 __all__ = [
     'DefaultPartitioner', 'RoundRobinPartitioner', 'HashedPartitioner',
-    'Murmur2Partitioner', 'LegacyPartitioner'
+    'Murmur2Partitioner', 'LegacyPartitioner', 'RandStartRoundRobinPartitioner'
 ]

--- a/kafka/partitioner/randroundrobin.py
+++ b/kafka/partitioner/randroundrobin.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+import random
+
+from kafka.partitioner import RoundRobinPartitioner
+from kafka.partitioner.roundrobin import CachedPartitionCycler
+
+
+class RandStartRoundRobinPartitioner(RoundRobinPartitioner):
+    """Random start round robin partitioner.
+     Selects first partition randomly and starts a round robin cycle
+     """
+    def __init__(self, partitions=None):
+        self.partitions_iterable = CachedRandomPartitionCycler(partitions)
+        if partitions:
+            self._set_partitions(partitions)
+        else:
+            self.partitions = None
+
+
+class CachedRandomPartitionCycler(CachedPartitionCycler):
+
+    def next(self):
+        assert self.partitions is not None
+        if self.cur_pos is None:
+            self.cur_pos = random.choice(self.partitions)
+        if not self._index_available(self.cur_pos, self.partitions):
+            self.cur_pos = 0
+        cur_item = self.partitions[self.cur_pos]
+        self.cur_pos += 1
+        return cur_item


### PR DESCRIPTION
This partitioner is useful while using multiple producers that produce limited amount of records.

Instead of using RoundRobinPartitioner which always starts from the first partition (causing unbalanced partitions) this one will pick a random partition to start from.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1608)
<!-- Reviewable:end -->
