### PR TITLE
Prevent `pylint` import errors on `six.moves`

### DIFF
--- a/pylint.rc
+++ b/pylint.rc
@@ -1,5 +1,6 @@
 [TYPECHECK]
 ignored-classes=SyncManager,_socketobject
+ignored-modules=kafka.vendor.six.moves
 generated-members=py.*
 
 [MESSAGES CONTROL]


### PR DESCRIPTION
`six.moves` is a dynamically-created namespace that doesn't actually
exist and therefore `pylint` can't statically analyze it.

By default, `pylint` is smart enough to realize that and ignore the
import errors.

However, because we vendor it, the location changes to
`kafka.vendor.six.moves` so `pylint` doesn't realize it should be
ignored.

So this explicitly ignores it.

`pylint` documentation of this feature:
http://pylint.pycqa.org/en/1.9/technical_reference/features.html?highlight=ignored-modules#id34

More background:
* https://github.com/PyCQA/pylint/issues/1640
* https://github.com/PyCQA/pylint/issues/223

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1609)
<!-- Reviewable:end -->
