### PR TITLE
Stop pinning `pylint`

### DIFF
--- a/kafka/record/_crc32c.py
+++ b/kafka/record/_crc32c.py
@@ -139,5 +139,7 @@ def crc(data):
 
 if __name__ == "__main__":
     import sys
-    data = sys.stdin.read()
+    # TODO remove the pylint disable once pylint fixes
+    # https://github.com/PyCQA/pylint/issues/2571
+    data = sys.stdin.read()  # pylint: disable=assignment-from-no-return
     print(hex(crc(data)))

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ log_format = %(created)f %(filename)-23s %(threadName)s %(message)s
 deps =
     pytest
     pytest-cov
-    py{27,34,35,36,py}: pylint==1.8.2
+    py{27,34,35,36,py}: pylint
     py{27,34,35,36,py}: pytest-pylint
     pytest-mock
     mock


### PR DESCRIPTION
We have many deprecation warnings in the travis logs for things that are fixed in newer versions of `pylint` or `pylint`'s dependencies.

So opening a PR to see if `master` passes on whatever version travis pulls in. Note that `pylint` >= 2.0 does not support python 2, so this will result in different versions of pylint running for python 2 vs python 3. Personally, I am just fine with this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1611)
<!-- Reviewable:end -->
