### PR TITLE
Add temp workaround for upstream pylint bug

### DIFF
--- a/kafka/record/_crc32c.py
+++ b/kafka/record/_crc32c.py
@@ -139,5 +139,7 @@ def crc(data):
 
 if __name__ == "__main__":
     import sys
-    data = sys.stdin.read()
+    # TODO remove the pylint disable once pylint fixes
+    # https://github.com/PyCQA/pylint/issues/2571
+    data = sys.stdin.read()  # pylint: disable=assignment-from-no-return
     print(hex(crc(data)))


### PR DESCRIPTION
Temporarily workaround https://github.com/PyCQA/pylint/issues/2571 so that we can stop pinning `pylint` (https://github.com/dpkp/kafka-python/pull/1611)