### PR TITLE
Stop using deprecated log.warn()

### DIFF
--- a/kafka/producer/base.py
+++ b/kafka/producer/base.py
@@ -83,7 +83,7 @@ def _send_upstream(queue, client, codec, batch_time, batch_size,
         try:
             client.reinit()
         except Exception as e:
-            log.warn('Async producer failed to connect to brokers; backoff for %s(ms) before retrying', retry_options.backoff_ms)
+            log.warning('Async producer failed to connect to brokers; backoff for %s(ms) before retrying', retry_options.backoff_ms)
             time.sleep(float(retry_options.backoff_ms) / 1000)
         else:
             break
@@ -189,12 +189,12 @@ def _send_upstream(queue, client, codec, batch_time, batch_size,
 
         # doing backoff before next retry
         if retry_state['do_backoff'] and retry_options.backoff_ms:
-            log.warn('Async producer backoff for %s(ms) before retrying', retry_options.backoff_ms)
+            log.warning('Async producer backoff for %s(ms) before retrying', retry_options.backoff_ms)
             time.sleep(float(retry_options.backoff_ms) / 1000)
 
         # refresh topic metadata before next retry
         if retry_state['do_refresh']:
-            log.warn('Async producer forcing metadata refresh metadata before retrying')
+            log.warning('Async producer forcing metadata refresh metadata before retrying')
             try:
                 client.load_metadata_for_topics()
             except Exception:


### PR DESCRIPTION
I missed this in my previous cleanup back in 9221fcf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1615)
<!-- Reviewable:end -->
