### PR TITLE
Cleanup fixture imports

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,8 +4,8 @@ import inspect
 
 import pytest
 
-from test.fixtures import KafkaFixture, ZookeeperFixture
-from test.testutil import kafka_version, random_string
+from test.fixtures import KafkaFixture, ZookeeperFixture, random_string, version as kafka_version
+
 
 @pytest.fixture(scope="module")
 def version():

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -14,7 +14,7 @@ from kafka.codec import (
     lz4_encode_old_kafka, lz4_decode_old_kafka,
 )
 
-from test.testutil import random_string
+from test.fixtures import random_string
 
 
 def test_gzip():

--- a/test/test_consumer_group.py
+++ b/test/test_consumer_group.py
@@ -13,7 +13,7 @@ from kafka.coordinator.base import MemberState, Generation
 from kafka.structs import TopicPartition
 
 from test.conftest import version
-from test.testutil import random_string
+from test.fixtures import random_string
 
 
 def get_connect_str(kafka_broker):

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -24,9 +24,9 @@ from kafka.structs import (
 )
 
 from test.conftest import version
-from test.fixtures import ZookeeperFixture, KafkaFixture
+from test.fixtures import ZookeeperFixture, KafkaFixture, random_string
 from test.testutil import (
-    KafkaIntegrationTestCase, kafka_versions, random_string, Timer,
+    KafkaIntegrationTestCase, kafka_versions, Timer,
     send_messages
 )
 

--- a/test/test_failover_integration.py
+++ b/test/test_failover_integration.py
@@ -9,8 +9,8 @@ from kafka.errors import (
 from kafka.producer.base import Producer
 from kafka.structs import TopicPartition
 
-from test.fixtures import ZookeeperFixture, KafkaFixture
-from test.testutil import KafkaIntegrationTestCase, random_string
+from test.fixtures import ZookeeperFixture, KafkaFixture, random_string
+from test.testutil import KafkaIntegrationTestCase
 
 
 log = logging.getLogger(__name__)

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -8,7 +8,7 @@ import pytest
 from kafka import KafkaConsumer, KafkaProducer, TopicPartition
 from kafka.producer.buffer import SimpleBufferPool
 from test.conftest import version
-from test.testutil import random_string
+from test.fixtures import random_string
 
 
 def test_buffer_pool():

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -19,6 +19,7 @@ from kafka.errors import (
 from kafka.structs import OffsetRequestPayload, ProduceRequestPayload
 from test.fixtures import random_string, version_str_to_list, version as kafka_version #pylint: disable=wrong-import-order
 
+
 def kafka_versions(*versions):
 
     def construct_lambda(s):
@@ -65,12 +66,6 @@ def kafka_versions(*versions):
 
     return real_kafka_versions
 
-def get_open_port():
-    sock = socket.socket()
-    sock.bind(("", 0))
-    port = sock.getsockname()[1]
-    sock.close()
-    return port
 
 _MESSAGES = {}
 def msg(message):


### PR DESCRIPTION
`random_string` now comes from `test.fixtures` and was being
transparently imported via `test.testutil` so this bypasses the
pointless indirect import.

Similarly, `kafka_version` was transparently imported by `test.testutil`
from `test.fixtures`.

Also removed `random_port()` in `test.testutil` because its unused as its been replaced
by the one in `test.fixtures`.

This is part of the pytest migration that was started back in
a1869c4be5f47b4f6433610249aaf29af4ec95e5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1616)
<!-- Reviewable:end -->
