### PR TITLE
Remove unused ivy_root variable

### DIFF
--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -48,7 +48,6 @@ class Fixture(object):
                                   os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
     kafka_root = os.environ.get("KAFKA_ROOT",
                                 os.path.join(project_root, 'servers', kafka_version, "kafka-bin"))
-    ivy_root = os.environ.get('IVY_ROOT', os.path.expanduser("~/.ivy2/cache"))
 
     def __init__(self):
         self.child = None


### PR DESCRIPTION
This is no longer used anywhere in the codebase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1617)
<!-- Reviewable:end -->
