### PR TITLE
(Attempt to) Fix deadlock between consumer and heartbeat

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -571,9 +571,7 @@ class KafkaClient(object):
 
                 self._poll(timeout)
 
-            # called without the lock to avoid deadlock potential
-            # if handlers need to acquire locks
-            responses.extend(self._fire_pending_completed_requests())
+                responses.extend(self._fire_pending_completed_requests())
 
             # If all we had was a timeout (future is None) - only do one poll
             # If we do have a future, we keep looping until it is done

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -347,7 +347,7 @@ class BaseCoordinator(object):
 
     def ensure_active_group(self):
         """Ensure that the group is active (i.e. joined and synced)"""
-        with self._lock:
+        with self._client._lock, self._lock:
             if self._heartbeat_thread is None:
                 self._start_heartbeat_thread()
 


### PR DESCRIPTION
This is an attempt to address / fix #1623 and #1626. Major shout out to zhgjun for investigating and suggesting this fix!

Given the thread setup we have right now, I think the easiest way to prevent deadlock is to always acquire the client lock before the coordinator lock. There are still some places in the code that only acquire the coordinator lock. Leaving these in place is dangerous, but I don't think any of them have any possible code path that leads to acquiring the client lock while still holding the coordinator lock.

I've also modified the client poll loop to keep the client lock during callback handling. I don't think this is specifically necessary to fix the deadlock issue reported in the issues above, but I also don't think dropping the client lock before processing callbacks adds any value at this point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1628)
<!-- Reviewable:end -->
