### PR TITLE
Stop using broker-errors for client-side problems

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -881,7 +881,7 @@ class BrokerConnection(object):
                 .format(version))
         # _api_versions is set as a side effect of check_versions() on a cluster
         # that supports 0.10.0 or later
-        return self._api_versions;
+        return self._api_versions
 
     def _infer_broker_version_from_api_versions(self, api_versions):
         # The logic here is to check the list of supported request versions

--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -62,6 +62,10 @@ class UnrecognizedBrokerVersion(KafkaError):
     pass
 
 
+class IncompatibleBrokerVersion(KafkaError):
+    pass
+
+
 class CommitFailedError(KafkaError):
     def __init__(self, *args, **kwargs):
         super(CommitFailedError, self).__init__(


### PR DESCRIPTION
`UnsupportedVersionError` is intended to indicate a server-side error:
https://github.com/dpkp/kafka-python/blob/ba7372e44ffa1ee49fb4d5efbd67534393e944db/kafka/errors.py#L375-L378

So we should not be raising it for client-side errors. I realize that
semantically this seems like the appropriate error to raise. However,
this is confusing when debugging... for a real-life example, see
https://github.com/Parsely/pykafka/issues/697. So I strongly feel that
server-side errors should be kept separate from client-side errors,
even if all the client is doing is proactively protecting against
hitting a situation where the broker would return this error.

Fix https://github.com/dpkp/kafka-python/issues/1627

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1639)
<!-- Reviewable:end -->
