### PR TITLE
Add list consumer groups offsets

### DIFF
--- a/kafka/structs.py
+++ b/kafka/structs.py
@@ -72,6 +72,7 @@ PartitionMetadata = namedtuple("PartitionMetadata",
     ["topic", "partition", "leader", "replicas", "isr", "error"])
 
 OffsetAndMetadata = namedtuple("OffsetAndMetadata",
+    # TODO add leaderEpoch: OffsetAndMetadata(offset, leaderEpoch, metadata)
     ["offset", "metadata"])
 
 OffsetAndTimestamp = namedtuple("OffsetAndTimestamp",


### PR DESCRIPTION
Add list_consumer_group_offsets() to support fetching the offsets of a consumer group.

Note: As far as I can tell (the Java code is a little inscrutable), the
Java AdminClient doesn't allow specifying the `coordinator_id` or the
`partitions`.

But I decided to include them because they provide a lot of additional
flexibility:

1. allowing users to specify the partitions allows this method to be used even for
older brokers that don't support the OffsetFetchRequest_v2

2. allowing users to specify the coordinator ID gives them a way to
bypass a network round trip. This method will frequently be used for
monitoring, and if you've got 1,000 consumer groups that are being
monitored once a minute, that's ~1.5M requests a day that are
unnecessarily duplicated as the coordinator doesn't change unless
there's an error.

Fix https://github.com/dpkp/kafka-python/issues/950

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1643)
<!-- Reviewable:end -->
