### PR TITLE
Remove support for api versions as strings from KafkaAdmin

### DIFF
--- a/kafka/admin/kafka.py
+++ b/kafka/admin/kafka.py
@@ -171,16 +171,6 @@ class KafkaAdmin(object):
         self.config = copy.copy(self.DEFAULT_CONFIG)
         self.config.update(configs)
 
-        # api_version was previously a str. accept old format for now
-        if isinstance(self.config['api_version'], str):
-            deprecated = self.config['api_version']
-            if deprecated == 'auto':
-                self.config['api_version'] = None
-            else:
-                self.config['api_version'] = tuple(map(int, deprecated.split('.')))
-            log.warning('use api_version=%s [tuple] -- "%s" as str is deprecated',
-                        str(self.config['api_version']), deprecated)
-
         # Configure metrics
         metrics_tags = {'client-id': self.config['client_id']}
         metric_config = MetricConfig(samples=self.config['metrics_num_samples'],


### PR DESCRIPTION
This is a new class, so let's not support the old version strings and
saddle ourselves with tech debt right from the get-go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1644)
<!-- Reviewable:end -->
