### PR TITLE
Add ACL protocol and admin methods

### DIFF
--- a/kafka/admin/__init__.py
+++ b/kafka/admin/__init__.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import
 
 from kafka.admin.config_resource import ConfigResource, ConfigResourceType
 from kafka.admin.client import KafkaAdminClient
-from kafka.admin.acl_resource import (AclResource, AclOperation, AclResourceType, AclPermissionType,
-                                      AclResourcePatternType)
+from kafka.admin.acl_resource import (ACLResource, ACLOperation, ACLResourceType, ACLPermissionType,
+                                      ACLResourcePatternType)
 from kafka.admin.new_topic import NewTopic
 from kafka.admin.new_partitions import NewPartitions
 
 __all__ = [
-    'ConfigResource', 'ConfigResourceType', 'KafkaAdminClient', 'NewTopic', 'NewPartitions', 'AclResource', 'AclOperation',
-    'AclResourceType', 'AclPermissionType', 'AclResourcePatternType'
+    'ConfigResource', 'ConfigResourceType', 'KafkaAdminClent', 'NewTopic', 'NewPartitions', 'ACLResource', 'ACLOperation',
+    'ACLResourceType', 'ACLPermissionType', 'ACLResourcePatternType'
 ]

--- a/kafka/admin/__init__.py
+++ b/kafka/admin/__init__.py
@@ -2,9 +2,12 @@ from __future__ import absolute_import
 
 from kafka.admin.config_resource import ConfigResource, ConfigResourceType
 from kafka.admin.client import KafkaAdminClient
+from kafka.admin.acl_resource import (AclResource, AclOperation, AclResourceType, AclPermissionType,
+                                      AclResourcePatternType)
 from kafka.admin.new_topic import NewTopic
 from kafka.admin.new_partitions import NewPartitions
 
 __all__ = [
-    'ConfigResource', 'ConfigResourceType', 'KafkaAdminClient', 'NewTopic', 'NewPartitions'
+    'ConfigResource', 'ConfigResourceType', 'KafkaAdminClient', 'NewTopic', 'NewPartitions', 'AclResource', 'AclOperation',
+    'AclResourceType', 'AclPermissionType', 'AclResourcePatternType'
 ]

--- a/kafka/admin/acl_resource.py
+++ b/kafka/admin/acl_resource.py
@@ -1,0 +1,84 @@
+from __future__ import absolute_import
+
+# enum in stdlib as of py3.4
+try:
+    from enum import IntEnum  # pylint: disable=import-error
+except ImportError:
+    # vendored backport module
+    from kafka.vendor.enum34 import IntEnum
+
+class AclResourceType(IntEnum):
+    """An enumerated type of config resources"""
+
+    ANY = 1,
+    BROKER = 4,
+    DELEGATION_TOKEN = 6,
+    GROUP = 3,
+    TOPIC = 2,
+    TRANSACTIONAL_ID = 5
+
+class AclOperation(IntEnum):
+    """An enumerated type of acl operations"""
+
+    ANY = 1,
+    ALL = 2,
+    READ = 3,
+    WRITE = 4,
+    CREATE = 5,
+    DELETE = 6,
+    ALTER = 7,
+    DESCRIBE = 8,
+    CLUSTER_ACTION = 9,
+    DESCRIBE_CONFIGS = 10,
+    ALTER_CONFIGS = 11,
+    IDEMPOTENT_WRITE = 12
+
+
+class AclPermissionType(IntEnum):
+    """An enumerated type of permissions"""
+
+    ANY = 1,
+    DENY = 2,
+    ALLOW = 3
+
+class AclResourcePatternType(IntEnum):
+    """An enumerated type of resource patterns"""
+
+    ANY = 1,
+    MATCH = 2,
+    LITERAL = 3,
+    PREFIXED = 4
+
+class AclResource(object):
+    """A class for specifying config resources.
+    Arguments:
+        resource_type (ConfigResourceType): the type of kafka resource
+        name (string): The name of the kafka resource
+        configs ({key : value}): A  maps of config keys to values.
+    """
+
+    def __init__(
+            self,
+            resource_type,
+            operation,
+            permission_type,
+            name=None,
+            principal=None,
+            host=None,
+            pattern_type=AclResourcePatternType.LITERAL
+    ):
+        if not isinstance(resource_type, AclResourceType):
+            resource_type = AclResourceType[str(resource_type).upper()]  # pylint: disable-msg=unsubscriptable-object
+        self.resource_type = resource_type
+        if not isinstance(operation, AclOperation):
+            operation = AclOperation[str(operation).upper()]  # pylint: disable-msg:unsubscriptable-object
+        self.operation = operation
+        if not isinstance(permission_type, AclPermissionType):
+            permission_type = AclPermissionType[str(permission_type).upper()]  # pylint: disable-msg=unsubscriptable-object
+        self.permission_type = permission_type
+        self.name = name
+        self.principal = principal
+        self.host = host
+        if not isinstance(pattern_type, AclResourcePatternType):
+            pattern_type = AclResourcePatternType[str(pattern_type).upper()]  # pylint: disable-msg=unsubscriptable-object
+        self.pattern_type = pattern_type

--- a/kafka/admin/acl_resource.py
+++ b/kafka/admin/acl_resource.py
@@ -7,7 +7,7 @@ except ImportError:
     # vendored backport module
     from kafka.vendor.enum34 import IntEnum
 
-class AclResourceType(IntEnum):
+class ACLResourceType(IntEnum):
     """An enumerated type of config resources"""
 
     ANY = 1,
@@ -17,7 +17,7 @@ class AclResourceType(IntEnum):
     TOPIC = 2,
     TRANSACTIONAL_ID = 5
 
-class AclOperation(IntEnum):
+class ACLOperation(IntEnum):
     """An enumerated type of acl operations"""
 
     ANY = 1,
@@ -34,14 +34,14 @@ class AclOperation(IntEnum):
     IDEMPOTENT_WRITE = 12
 
 
-class AclPermissionType(IntEnum):
+class ACLPermissionType(IntEnum):
     """An enumerated type of permissions"""
 
     ANY = 1,
     DENY = 2,
     ALLOW = 3
 
-class AclResourcePatternType(IntEnum):
+class ACLResourcePatternType(IntEnum):
     """An enumerated type of resource patterns"""
 
     ANY = 1,
@@ -49,7 +49,7 @@ class AclResourcePatternType(IntEnum):
     LITERAL = 3,
     PREFIXED = 4
 
-class AclResource(object):
+class ACLResource(object):
     """A class for specifying config resources.
     Arguments:
         resource_type (ConfigResourceType): the type of kafka resource
@@ -65,20 +65,20 @@ class AclResource(object):
             name=None,
             principal=None,
             host=None,
-            pattern_type=AclResourcePatternType.LITERAL
+            pattern_type=ACLResourcePatternType.LITERAL
     ):
-        if not isinstance(resource_type, AclResourceType):
-            resource_type = AclResourceType[str(resource_type).upper()]  # pylint: disable-msg=unsubscriptable-object
+        if not isinstance(resource_type, ACLResourceType):
+            resource_type = ACLResourceType[str(resource_type).upper()]  # pylint: disable-msg=unsubscriptable-object
         self.resource_type = resource_type
-        if not isinstance(operation, AclOperation):
-            operation = AclOperation[str(operation).upper()]  # pylint: disable-msg:unsubscriptable-object
+        if not isinstance(operation, ACLOperation):
+            operation = ACLOperation[str(operation).upper()]  # pylint: disable-msg:unsubscriptable-object
         self.operation = operation
-        if not isinstance(permission_type, AclPermissionType):
-            permission_type = AclPermissionType[str(permission_type).upper()]  # pylint: disable-msg=unsubscriptable-object
+        if not isinstance(permission_type, ACLPermissionType):
+            permission_type = ACLPermissionType[str(permission_type).upper()]  # pylint: disable-msg=unsubscriptable-object
         self.permission_type = permission_type
         self.name = name
         self.principal = principal
         self.host = host
-        if not isinstance(pattern_type, AclResourcePatternType):
-            pattern_type = AclResourcePatternType[str(pattern_type).upper()]  # pylint: disable-msg=unsubscriptable-object
+        if not isinstance(pattern_type, ACLResourcePatternType):
+            pattern_type = ACLResourcePatternType[str(pattern_type).upper()]  # pylint: disable-msg=unsubscriptable-object
         self.pattern_type = pattern_type

--- a/kafka/admin/acl_resource.py
+++ b/kafka/admin/acl_resource.py
@@ -7,6 +7,7 @@ except ImportError:
     # vendored backport module
     from kafka.vendor.enum34 import IntEnum
 
+
 class ACLResourceType(IntEnum):
     """An enumerated type of config resources"""
 

--- a/kafka/admin/acl_resource.py
+++ b/kafka/admin/acl_resource.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from kafka.errors import IllegalArgumentError
 
 # enum in stdlib as of py3.4
 try:
@@ -69,17 +70,17 @@ class ACLResource(object):
             pattern_type=ACLResourcePatternType.LITERAL
     ):
         if not isinstance(resource_type, ACLResourceType):
-            resource_type = ACLResourceType[str(resource_type).upper()]  # pylint: disable-msg=unsubscriptable-object
+            raise IllegalArgumentError("resource_param must be of type ACLResourceType")
         self.resource_type = resource_type
         if not isinstance(operation, ACLOperation):
-            operation = ACLOperation[str(operation).upper()]  # pylint: disable-msg:unsubscriptable-object
+            raise IllegalArgumentError("operation must be of type ACLOperation")
         self.operation = operation
         if not isinstance(permission_type, ACLPermissionType):
-            permission_type = ACLPermissionType[str(permission_type).upper()]  # pylint: disable-msg=unsubscriptable-object
+            raise IllegalArgumentError("permission_type must be of type ACLPermissionType")
         self.permission_type = permission_type
         self.name = name
         self.principal = principal
         self.host = host
         if not isinstance(pattern_type, ACLResourcePatternType):
-            pattern_type = ACLResourcePatternType[str(pattern_type).upper()]  # pylint: disable-msg=unsubscriptable-object
+            raise IllegalArgumentError("pattern_type must be of type ACLResourcePatternType")
         self.pattern_type = pattern_type

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -429,8 +429,6 @@ class KafkaAdminClient(object):
     # describe cluster functionality is in ClusterMetadata
     # Note: if implemented here, send the request to the least_loaded_node()
 
-    # describe_acls protocol not yet implemented
-    # Note: send the request to the least_loaded_node()
     def describe_acls(self, acl_resource):
         """Describe a set of ACLs
         """
@@ -462,7 +460,7 @@ class KafkaAdminClient(object):
                     .format(version)
             )
 
-        return self._send(request)
+        return self._send_request_to_node(self._client.least_loaded_node(), request)
 
     @staticmethod
     def _convert_create_acls_resource_request_v0(acl_resource):
@@ -498,8 +496,6 @@ class KafkaAdminClient(object):
             acl_resource.permission_type
         )
 
-    # create_acls protocol not yet implemented
-    # Note: send the request to the least_loaded_node()
     def create_acls(self, acl_resources):
         """Create a set of ACLs"""
 
@@ -518,7 +514,7 @@ class KafkaAdminClient(object):
                     .format(version)
             )
 
-        return self._send(request)
+        return self._send_request_to_node(self._client.least_loaded_node(), request)
 
     @staticmethod
     def _convert_delete_acls_resource_request_v0(acl_resource):
@@ -543,8 +539,6 @@ class KafkaAdminClient(object):
             acl_resource.permission_type
         )
 
-    # delete_acls protocol not yet implemented
-    # Note: send the request to the least_loaded_node()
     def delete_acls(self, acl_resources):
         """Delete a set of ACLSs"""
 
@@ -564,7 +558,7 @@ class KafkaAdminClient(object):
                     .format(version)
             )
 
-        return self._send(request)
+        return self._send_request_to_node(self._client.least_loaded_node(), request)
 
     @staticmethod
     def _convert_describe_config_resource_request(config_resource):

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -457,8 +457,8 @@ class KafkaAdminClient(object):
 
             )
         else:
-            raise UnsupportedVersionError(
-                "missing implementation of DescribeAcls for library supported version {}"
+            raise NotImplementedError(
+                "Support for DescribeAcls v{} has not yet been added to KafkaAdmin."
                     .format(version)
             )
 
@@ -513,11 +513,10 @@ class KafkaAdminClient(object):
                 creations=[self._convert_create_acls_resource_request_v1(acl_resource) for acl_resource in acl_resources]
             )
         else:
-            raise UnsupportedVersionError(
-                "missing implementation of DescribeAcls for library supported version {}"
+            raise NotImplementedError(
+                "Support for CreateAcls v{} has not yet been added to KafkaAdmin."
                     .format(version)
             )
-
 
         return self._send(request)
 
@@ -560,8 +559,8 @@ class KafkaAdminClient(object):
                 filters=[self._convert_delete_acls_resource_request_v1(acl_resource) for acl_resource in acl_resources]
             )
         else:
-            raise UnsupportedVersionError(
-                "missing implementation of DescribeAcls for library supported version {}"
+            raise NotImplementedError(
+                "Support for DeleteAcls v{} has not yet been added to KafkaAdmin."
                     .format(version)
             )
 

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -503,7 +503,7 @@ class KafkaAdminClient(object):
     def create_acls(self, acl_resources):
         """Create a set of ACLs"""
 
-        version = self._matching_api_version(DescribeAclsRequest)
+        version = self._matching_api_version(CreateAclsRequest)
         if version == 0:
             request = CreateAclsRequest[version](
                 creations=[self._convert_create_acls_resource_request_v0(acl_resource) for acl_resource in acl_resources]
@@ -548,7 +548,7 @@ class KafkaAdminClient(object):
     def delete_acls(self, acl_resources):
         """Delete a set of ACLSs"""
 
-        version = self._matching_api_version(DescribeAclsRequest)
+        version = self._matching_api_version(DeleteAclsRequest)
 
         if version == 0:
             request = DeleteAclsRequest[version](

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -19,7 +19,7 @@ from kafka.protocol.admin import (
 from kafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
 from kafka.protocol.metadata import MetadataRequest
 from kafka.structs import TopicPartition, OffsetAndMetadata
-from kafka.admin.acl_resource import AclOperation, AclPermissionType
+from kafka.admin.acl_resource import ACLOperation, ACLPermissionType
 from kafka.version import __version__
 
 
@@ -464,9 +464,9 @@ class KafkaAdminClient(object):
 
     @staticmethod
     def _convert_create_acls_resource_request_v0(acl_resource):
-        if acl_resource.operation == AclOperation.ANY:
+        if acl_resource.operation == ACLOperation.ANY:
             raise IllegalArgumentError("operation must not be ANY")
-        if acl_resource.permission_type == AclPermissionType.ANY:
+        if acl_resource.permission_type == ACLPermissionType.ANY:
             raise IllegalArgumentError("permission_type must not be ANY")
 
         return (
@@ -481,9 +481,9 @@ class KafkaAdminClient(object):
     @staticmethod
     def _convert_create_acls_resource_request_v1(acl_resource):
 
-        if acl_resource.operation == AclOperation.ANY:
+        if acl_resource.operation == ACLOperation.ANY:
             raise IllegalArgumentError("operation must not be ANY")
-        if acl_resource.permission_type == AclPermissionType.ANY:
+        if acl_resource.permission_type == ACLPermissionType.ANY:
             raise IllegalArgumentError("permission_type must not be ANY")
 
         return (

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -27,12 +27,12 @@ def test_new_partitions():
 
 
 def test_acl_resource():
-    good_resource = kafka.admin.AclResource("TOPIC", "ALL", "ALLOW", "foo",
+    good_resource = kafka.admin.ACLResource("TOPIC", "ALL", "ALLOW", "foo",
                                             "User:bar", "*", "LITERAL")
-    assert(good_resource.resource_type == kafka.admin.AclResourceType.TOPIC)
-    assert(good_resource.operation == kafka.admin.AclOperation.ALL)
-    assert(good_resource.permission_type == kafka.admin.AclPermissionType.ALLOW)
-    assert(good_resource.pattern_type == kafka.admin.AclResourcePatternType.LITERAL)
+    assert(good_resource.resource_type == kafka.admin.ACLResourceType.TOPIC)
+    assert(good_resource.operation == kafka.admin.ACLOperation.ALL)
+    assert(good_resource.permission_type == kafka.admin.ACLPermissionType.ALLOW)
+    assert(good_resource.pattern_type == kafka.admin.ACLResourcePatternType.LITERAL)
 
 def test_new_topic():
     with pytest.raises(IllegalArgumentError):

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -27,12 +27,22 @@ def test_new_partitions():
 
 
 def test_acl_resource():
-    good_resource = kafka.admin.ACLResource("TOPIC", "ALL", "ALLOW", "foo",
-                                            "User:bar", "*", "LITERAL")
+    good_resource = kafka.admin.ACLResource(
+        kafka.admin.ACLResourceType.TOPIC,
+        kafka.admin.ACLOperation.ALL,
+        kafka.admin.ACLPermissionType.ALLOW,
+        "foo",
+        "User:bar",
+        "*",
+        kafka.admin.ACLResourcePatternType.LITERAL
+    )
     assert(good_resource.resource_type == kafka.admin.ACLResourceType.TOPIC)
     assert(good_resource.operation == kafka.admin.ACLOperation.ALL)
     assert(good_resource.permission_type == kafka.admin.ACLPermissionType.ALLOW)
     assert(good_resource.pattern_type == kafka.admin.ACLResourcePatternType.LITERAL)
+
+    with pytest.raises(IllegalArgumentError):
+        bad_resource = kafka.admin.ACLResource("TOPIC", "ALL", "ALLOW", "foo", "User:bar", "*", "LITERAL")
 
 def test_new_topic():
     with pytest.raises(IllegalArgumentError):

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -26,6 +26,14 @@ def test_new_partitions():
     assert good_partitions.new_assignments == [[1, 2, 3]]
 
 
+def test_acl_resource():
+    good_resource = kafka.admin.AclResource("TOPIC", "ALL", "ALLOW", "foo",
+                                            "User:bar", "*", "LITERAL")
+    assert(good_resource.resource_type == kafka.admin.AclResourceType.TOPIC)
+    assert(good_resource.operation == kafka.admin.AclOperation.ALL)
+    assert(good_resource.permission_type == kafka.admin.AclPermissionType.ALLOW)
+    assert(good_resource.pattern_type == kafka.admin.AclResourcePatternType.LITERAL)
+
 def test_new_topic():
     with pytest.raises(IllegalArgumentError):
         bad_topic = kafka.admin.NewTopic('foo', -1, -1)


### PR DESCRIPTION
* Added protocols for ACLs
* Added KafkaAdmin methods for manipulating ACLs
* Added very basic test of the acl_resource module contents

I haven't been able to run the test suite locally for some reason, just small parts in isolation, like running the new test case with `pytest /test/test_admin.py`

I've tested this to some extent manually, both with a simple docker kafka setup (kafka v2.0), as well as with a more serious cluster secured with SSL/ACLs already (kafka v 1.1). Describing, Creating and Deleting ALCs seem to work with both v0 and v1 versions of the protocol.

Fixes #1638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1646)
<!-- Reviewable:end -->
