### PR TITLE
Bugfix: Always set this_groups_coordinator_id

### DIFF
--- a/kafka/admin/kafka.py
+++ b/kafka/admin/kafka.py
@@ -593,7 +593,9 @@ class KafkaAdmin(object):
         group_descriptions = []
         version = self._matching_api_version(DescribeGroupsRequest)
         for group_id in group_ids:
-            if group_coordinator_id is None:
+            if group_coordinator_id is not None:
+                this_groups_coordinator_id = group_coordinator_id
+            else:
                 this_groups_coordinator_id = self._find_group_coordinator_id(group_id)
             if version <= 1:
                 # Note: KAFKA-6788 A potential optimization is to group the


### PR DESCRIPTION
Bugfix of something I missed in https://github.com/dpkp/kafka-python/pull/1642

Hat tip to @ulrikjohansson for [noticing this](https://github.com/dpkp/kafka-python/commit/8dab14b6d73d8f1717fdeb46c79807827169fd2d#r31354023).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1650)
<!-- Reviewable:end -->
