### PR TITLE
Differentiate between client and broker version errors

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -814,6 +814,8 @@ class KafkaClient(object):
     def get_api_versions(self):
         """Return the ApiVersions map, if available.
 
+        # TODO if I update the BrokerConnection.get_api_versions(), also update
+        # this docstring
         Note: A call to check_version must previously have succeeded and returned
         version 0.10.0 or later
 

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -876,7 +876,11 @@ class BrokerConnection(object):
     def get_api_versions(self):
         version = self.check_version()
         if version < (0, 10, 0):
-            raise Errors.UnsupportedVersionError(
+            # TODO this currently blocks using various KafkaAdmin methods
+            # against older brokers that are supported, such as
+            # list_consumer_groups(), list_consumer_group_offsets(),
+            # describe_consumer_groups(), and _find_group_coordinator()
+            raise Errors.IncompatibleBrokerVersion(
                 "ApiVersion not supported by cluster version {} < 0.10.0"
                 .format(version))
         # _api_versions is set as a side effect of check_versions() on a cluster

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -5,7 +5,7 @@ import logging
 import socket
 import time
 
-from kafka.errors import KafkaConfigurationError, UnsupportedVersionError
+from kafka.errors import KafkaConfigurationError, IncompatibleBrokerVersion
 
 from kafka.vendor import six
 
@@ -943,12 +943,12 @@ class KafkaConsumer(six.Iterator):
 
         Raises:
             ValueError: If the target timestamp is negative
-            UnsupportedVersionError: If the broker does not support looking
-                up the offsets by timestamp.
+            IncompatibleBrokerVersion: Raised by kafka-python when it does not
+                think the broker supports looking up the offsets by timestamp.
             KafkaTimeoutError: If fetch failed in request_timeout_ms
         """
         if self.config['api_version'] <= (0, 10, 0):
-            raise UnsupportedVersionError(
+            raise IncompatibleBrokerVersion(
                 "offsets_for_times API not supported for cluster version {}"
                 .format(self.config['api_version']))
         for tp, ts in six.iteritems(timestamps):
@@ -978,8 +978,8 @@ class KafkaConsumer(six.Iterator):
             given partitions.
 
         Raises:
-            UnsupportedVersionError: If the broker does not support looking
-                up the offsets by timestamp.
+            IncompatibleBrokerVersion: Raised by kafka-python when it does not
+                think the broker supports looking up the offsets by timestamp.
             KafkaTimeoutError: If fetch failed in request_timeout_ms.
         """
         offsets = self._fetcher.beginning_offsets(
@@ -1005,8 +1005,8 @@ class KafkaConsumer(six.Iterator):
             ``{TopicPartition: int}``: The end offsets for the given partitions.
 
         Raises:
-            UnsupportedVersionError: If the broker does not support looking
-                up the offsets by timestamp.
+            IncompatibleBrokerVersion: Raised by kafka-python when it does not
+                think the broker supports looking up the offsets by timestamp.
             KafkaTimeoutError: If fetch failed in request_timeout_ms
         """
         offsets = self._fetcher.end_offsets(

--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -59,10 +59,18 @@ class MetadataEmptyBrokerList(KafkaError):
 
 
 class UnrecognizedBrokerVersion(KafkaError):
+    # Cannot determine the broker version
     pass
 
 
 class IncompatibleBrokerVersion(KafkaError):
+    # TODO convert this first comment to the default exception message... need to check message vs description is used when assembling the exception string
+    # kafka-python thinks the broker version is incompatible with this Kafka
+    # protocol message format and does not even try to send the message.
+
+    # See also UnsupportedBrokerVersion for the broker-side equivalent.
+    # Although the error is the same, we want to be able to differentiate
+    # between client-side and broker-side errors for easier debugging.
     pass
 
 
@@ -377,9 +385,16 @@ class IllegalSaslStateError(BrokerResponseError):
 
 
 class UnsupportedVersionError(BrokerResponseError):
+    # See also IncompatibleBrokerVersion for the client-side equivalent.
+    # Although the error is the same, we want to be able to differentiate
+    # between client-side and broker-side errors for easier debugging.
     errno = 35
     message = 'UNSUPPORTED_VERSION'
-    description = 'The version of API is not supported.'
+    description = 'The version of API is not supported. If you encounter this '
+                  'error while using normal kafka-python methods and not
+                  'directly using the low-level protocol structs, please file '
+                  'an issue as we would prefer to identify the error '
+                  'client-side and raise an IncompatibleBrokerVersion.'
 
 
 class TopicAlreadyExistsError(BrokerResponseError):


### PR DESCRIPTION
do not merge yet--I plan to continue fleshing this out later tonight... it is blocking me using `KafkaAdmin.list_consumer_group_offsets()` against brokers < 0.10.0.0

While both indicate a mismatch between the broker and client, we want to
be able to differentiate between whether the error is thrown by the
client vs the broker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1655)
<!-- Reviewable:end -->
