### PR TITLE
Bug fix in _send_request_to_controller

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -332,7 +332,7 @@ class KafkaAdminClient(object):
             tries -= 1
             response = self._send_request_to_node(self._controller_id, request)
             # DeleteTopicsResponse returns topic_error_codes rather than topic_errors
-            for topic, error_code in getattr(response, "topic_errors", response.topic_error_codes):
+            for topic, error_code in map(lambda x: x[:2], getattr(response, "topic_errors", getattr(response, "topic_error_codes", None))):
                 error_type = Errors.for_code(error_code)
                 if tries and error_type is NotControllerError:
                     # No need to inspect the rest of the errors for


### PR DESCRIPTION
_send_request_to_controller throws errors for different responses. In some case response contains topic_errors and in some topic_error_codes. Fixed as checking for both attributes if none of them is present then only throws an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1678)
<!-- Reviewable:end -->
