### PR TITLE
Bugfix  #1681 - add `.copy()` in metrics() method to avoid thread safety issues

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -903,10 +903,10 @@ class KafkaConsumer(six.Iterator):
             releases without warning.
         """
         if raw:
-            return self._metrics.metrics
+            return self._metrics.metrics.copy()
 
         metrics = {}
-        for k, v in six.iteritems(self._metrics.metrics):
+        for k, v in six.iteritems(self._metrics.metrics.copy()):
             if k.group not in metrics:
                 metrics[k.group] = {}
             if k.name not in metrics[k.group]:

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -716,10 +716,10 @@ class KafkaProducer(object):
             releases without warning.
         """
         if raw:
-            return self._metrics.metrics
+            return self._metrics.metrics.copy()
 
         metrics = {}
-        for k, v in six.iteritems(self._metrics.metrics):
+        for k, v in six.iteritems(self._metrics.metrics.copy()):
             if k.group not in metrics:
                 metrics[k.group] = {}
             if k.name not in metrics[k.group]:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1682)
<!-- Reviewable:end -->
