### PR TITLE
Use Popen.communicate() instead of Popen.wait()

### DIFF
--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -296,10 +296,12 @@ class KafkaFixture(Fixture):
         env = self.kafka_run_class_env()
         proc = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        if proc.wait() != 0 or proc.returncode != 0:
+        stdout, stderr = proc.communicate()
+
+        if proc.returncode != 0:
             self.out("Failed to create Zookeeper chroot node")
-            self.out(proc.stdout.read())
-            self.out(proc.stderr.read())
+            self.out(stdout)
+            self.out(stderr)
             raise RuntimeError("Failed to create Zookeeper chroot node")
         self.out("Kafka chroot created in Zookeeper!")
 
@@ -458,13 +460,12 @@ class KafkaFixture(Fixture):
                 args.append('--if-not-exists')
             env = self.kafka_run_class_env()
             proc = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            ret = proc.wait()
-            if ret != 0 or proc.returncode != 0:
-                output = proc.stdout.read()
-                if not 'kafka.common.TopicExistsException' in output:
+            stdout, stderr = proc.communicate()
+            if proc.returncode != 0:
+                if not 'kafka.common.TopicExistsException' in stdout:
                     self.out("Failed to create topic %s" % (topic_name,))
-                    self.out(output)
-                    self.out(proc.stderr.read())
+                    self.out(stdout)
+                    self.out(stderr)
                     raise RuntimeError("Failed to create topic %s" % (topic_name,))
 
     def create_topics(self, topic_names, num_partitions=None, replication_factor=None):


### PR DESCRIPTION
Popen objects may deadlock when using stdout=PIPE or stderr=PIPE
with Popen.wait(). Using Popen.communicate() avoids the issue.

I ran into this issue in a fork. This code should behave the same but avoids the possibility of deadlock described here: https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1689)
<!-- Reviewable:end -->
