### PR TITLE
Catch thrown OSError by python 3.7 when creating a connection

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -467,6 +467,9 @@ class BrokerConnection(object):
         # old ssl in python2.6 will swallow all SSLErrors here...
         except (SSLWantReadError, SSLWantWriteError):
             pass
+        # python 3.7 throws OSError
+        except OSError:
+            pass
         except (SSLZeroReturnError, ConnectionError, SSLEOFError):
             log.warning('SSL connection closed by server during handshake.')
             self.close(Errors.KafkaConnectionError('SSL connection closed by server during handshake'))


### PR DESCRIPTION
This is needed to use kafka-python with python 3.7.

It builds on #1669 and the solution is a slightly modified version of a comment on #1661

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1694)
<!-- Reviewable:end -->
