### PR TITLE
Ignore lookup_coordinator result in commit_offsets_async

### DIFF
--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division
 
 import collections
 import copy
+import functools
 import logging
 import time
 
@@ -457,7 +458,7 @@ class ConsumerCoordinator(BaseCoordinator):
             # same order that they were added. Note also that BaseCoordinator
             # prevents multiple concurrent coordinator lookup requests.
             future = self.lookup_coordinator()
-            future.add_callback(self._do_commit_offsets_async, offsets, callback)
+            future.add_callback(lambda r: functools.partial(self._do_commit_offsets_async, offsets, callback))
             if callback:
                 future.add_errback(lambda e: self.completed_offset_commits.appendleft((callback, offsets, e)))
 

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -458,7 +458,7 @@ class ConsumerCoordinator(BaseCoordinator):
             # same order that they were added. Note also that BaseCoordinator
             # prevents multiple concurrent coordinator lookup requests.
             future = self.lookup_coordinator()
-            future.add_callback(lambda r: functools.partial(self._do_commit_offsets_async, offsets, callback))
+            future.add_callback(lambda r: functools.partial(self._do_commit_offsets_async, offsets, callback)())
             if callback:
                 future.add_errback(lambda e: self.completed_offset_commits.appendleft((callback, offsets, e)))
 


### PR DESCRIPTION
Fixes an issue where if commit_offsets_async has to lookup the coordinator before actually sending the offset_commit_request, the request will fail with the following error:
```
Error processing callback
Traceback (most recent call last):
  File "/home/runner/pipeline.runfiles/kafka_python_git/kafka/future.py", line 79, in _call_backs
    f(value)
TypeError: _do_commit_offsets_async() takes from 2 to 3 positional arguments but 4 were given
```

This is because the current logic directly adds the invocation of _do_commit_offsets_async as a callback to the invocation of lookup_coordinator, but _do_commit_offsets_async has no use for that value, and has no parameter to receive it, resulting in the above error. This PR just passes a wrapper lambda as the actual callback to the invocation of lookup_coordinator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1712)
<!-- Reviewable:end -->
