### PR TITLE
Drop dependency on sphinxcontrib-napoleon

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 sphinx
-sphinxcontrib-napoleon
 sphinx_rtd_theme
 
 # Install kafka-python in editable mode


### PR DESCRIPTION
Since 1.3b1 (released Oct 10, 2014) Sphinx has support for NumPy and
Google style docstring support via sphinx.ext.napoleon extension.
The latter is already used, but sphinxcontrib-napoleon requirement
still presents.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1715)
<!-- Reviewable:end -->
