### PR TITLE
Fix test_legacy_correct_metadata_response on x86 arch

### DIFF
--- a/test/record/test_legacy_records.py
+++ b/test/record/test_legacy_records.py
@@ -141,7 +141,7 @@ def test_legacy_correct_metadata_response(magic):
     assert meta.timestamp == (9999999 if magic else -1)
     assert meta.crc == (-2095076219 if magic else 278251978) & 0xffffffff
     assert repr(meta) == (
-        "LegacyRecordMetadata(offset=0, crc={}, size={}, "
+        "LegacyRecordMetadata(offset=0, crc={!r}, size={}, "
         "timestamp={})".format(meta.crc, meta.size, meta.timestamp)
     )
 


### PR DESCRIPTION
The problem is that the type of required operation result is
"long".

```
>>> type(278251978 & 0xffffffff)
<type 'long'>
```

However, by default "format" method uses __format__():

```
>>> (278251978 & 0xffffffff).__format__('')
'278251978'
```

So, let's compare things using the same engine:

```
>>> "{!r}".format(278251978 & 0xffffffff)
'278251978L'
```

Fixes: https://github.com/dpkp/kafka-python/issues/1717

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1718)
<!-- Reviewable:end -->
