### PR TITLE
Make NotEnoughReplicasError/NotEnoughReplicasAfterAppendError retriable

### DIFF
--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -268,6 +268,7 @@ class NotEnoughReplicasError(BrokerResponseError):
     description = ('Returned from a produce request when the number of in-sync'
                    ' replicas is lower than the configured minimum and'
                    ' requiredAcks is -1.')
+    retriable = True
 
 
 class NotEnoughReplicasAfterAppendError(BrokerResponseError):
@@ -276,6 +277,7 @@ class NotEnoughReplicasAfterAppendError(BrokerResponseError):
     description = ('Returned from a produce request when the message was'
                    ' written to the log, but with fewer in-sync replicas than'
                    ' required.')
+    retriable = True
 
 
 class InvalidRequiredAcksError(BrokerResponseError):


### PR DESCRIPTION
According to [kafka docs](https://kafka.apache.org/protocol.html#protocol_error_codes), both are supposed to be retriable errors, so this fix is to resolve that

See issue #1580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1722)
<!-- Reviewable:end -->
