### PR TITLE
Use test.fixtures.version not test.conftest.version to avoid warnings

### DIFF
--- a/test/test_consumer_group.py
+++ b/test/test_consumer_group.py
@@ -11,8 +11,7 @@ from kafka.consumer.group import KafkaConsumer
 from kafka.coordinator.base import MemberState, Generation
 from kafka.structs import TopicPartition
 
-from test.conftest import version
-from test.fixtures import random_string
+from test.fixtures import random_string, version
 
 
 def get_connect_str(kafka_broker):

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -23,8 +23,7 @@ from kafka.structs import (
     ProduceRequestPayload, TopicPartition, OffsetAndTimestamp
 )
 
-from test.conftest import version
-from test.fixtures import ZookeeperFixture, KafkaFixture, random_string
+from test.fixtures import ZookeeperFixture, KafkaFixture, random_string, version
 from test.testutil import KafkaIntegrationTestCase, kafka_versions, Timer
 
 

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -7,8 +7,7 @@ import pytest
 
 from kafka import KafkaConsumer, KafkaProducer, TopicPartition
 from kafka.producer.buffer import SimpleBufferPool
-from test.conftest import version
-from test.fixtures import random_string
+from test.fixtures import random_string, version
 
 
 def test_buffer_pool():

--- a/test/test_producer_integration.py
+++ b/test/test_producer_integration.py
@@ -15,8 +15,7 @@ from kafka.errors import UnknownTopicOrPartitionError, LeaderNotAvailableError
 from kafka.producer.base import Producer
 from kafka.structs import FetchRequestPayload, ProduceRequestPayload
 
-from test.conftest import version
-from test.fixtures import ZookeeperFixture, KafkaFixture
+from test.fixtures import ZookeeperFixture, KafkaFixture, version
 from test.testutil import KafkaIntegrationTestCase, kafka_versions, current_offset
 
 


### PR DESCRIPTION
Fixes pytest warning:
```
RemovedInPytest4Warning: Fixture "version" called directly.

Fixtures are not meant to be called directly, are created automatically
when test functions request them as parameters.
See https://docs.pytest.org/en/latest/fixture.html for more information.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1731)
<!-- Reviewable:end -->
