### PR TITLE
Retry bootstrapping after backoff when necessary

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -223,7 +223,7 @@ class KafkaClient(object):
                                                self.config['metric_group_prefix'],
                                                weakref.proxy(self._conns))
 
-        self._bootstrap_hosts = len(collect_hosts(self.config['bootstrap_servers']))
+        self._num_bootstrap_hosts = len(collect_hosts(self.config['bootstrap_servers']))
 
         # Check Broker Version if not set explicitly
         if self.config['api_version'] is None:
@@ -231,7 +231,7 @@ class KafkaClient(object):
             self.config['api_version'] = self.check_version(timeout=check_timeout)
 
     def _can_bootstrap(self):
-        effective_failures = self._bootstrap_fails // self._bootstrap_hosts
+        effective_failures = self._bootstrap_fails // self._num_bootstrap_hosts
         backoff_factor = 2 ** effective_failures
         backoff_ms = min(self.config['reconnect_backoff_ms'] * backoff_factor,
                          self.config['reconnect_backoff_max_ms'])

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -784,10 +784,9 @@ class KafkaClient(object):
             return self.config['reconnect_backoff_ms']
 
         if self._can_send_request(node_id):
-            if node_id == 'bootstrap':
+            topics = list(self._topics)
+            if not topics and node_id == 'bootstrap':
                 topics = list(self.config['bootstrap_topics_filter'])
-            else:
-                topics = list(self._topics)
 
             if self.cluster.need_all_topic_metadata or not topics:
                 topics = [] if self.config['api_version'] < (0, 10) else None

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -56,7 +56,7 @@ class KafkaClient(object):
 
     Keyword Arguments:
         bootstrap_servers: 'host[:port]' string (or list of 'host[:port]'
-            strings) that the consumer should contact to bootstrap initial
+            strings) that the client should contact to bootstrap initial
             cluster metadata. This does not have to be the full node list.
             It just needs to have at least one broker that will respond to a
             Metadata API Request. Default port is 9092. If no servers are
@@ -223,76 +223,34 @@ class KafkaClient(object):
                                                self.config['metric_group_prefix'],
                                                weakref.proxy(self._conns))
 
-        self._bootstrap(collect_hosts(self.config['bootstrap_servers']))
+        self._bootstrap_hosts = len(collect_hosts(self.config['bootstrap_servers']))
 
         # Check Broker Version if not set explicitly
         if self.config['api_version'] is None:
             check_timeout = self.config['api_version_auto_timeout_ms'] / 1000
             self.config['api_version'] = self.check_version(timeout=check_timeout)
 
-    def _bootstrap(self, hosts):
-        log.info('Bootstrapping cluster metadata from %s', hosts)
-        # Exponential backoff if bootstrap fails
-        backoff_ms = self.config['reconnect_backoff_ms'] * 2 ** self._bootstrap_fails
+    def _can_bootstrap(self):
+        effective_failures = self._bootstrap_fails // self._bootstrap_hosts
+        backoff_factor = 2 ** effective_failures
+        backoff_ms = min(self.config['reconnect_backoff_ms'] * backoff_factor,
+                         self.config['reconnect_backoff_max_ms'])
+
+        backoff_ms *= random.uniform(0.8, 1.2)
+
         next_at = self._last_bootstrap + backoff_ms / 1000.0
-        self._refresh_on_disconnects = False
         now = time.time()
         if next_at > now:
-            log.debug("Sleeping %0.4f before bootstrapping again", next_at - now)
-            time.sleep(next_at - now)
-        self._last_bootstrap = time.time()
-
-        if self.config['api_version'] is None or self.config['api_version'] < (0, 10):
-            if self.config['bootstrap_topics_filter']:
-                metadata_request = MetadataRequest[0](list(self.config['bootstrap_topics_filter']))
-            else:
-                metadata_request = MetadataRequest[0]([])
-        else:
-            if self.config['bootstrap_topics_filter']:
-                metadata_request = MetadataRequest[1](list(self.config['bootstrap_topics_filter']))
-            else:
-                metadata_request = MetadataRequest[1](None)
-
-        for host, port, afi in hosts:
-            log.debug("Attempting to bootstrap via node at %s:%s", host, port)
-            cb = functools.partial(WeakMethod(self._conn_state_change), 'bootstrap')
-            bootstrap = BrokerConnection(host, port, afi,
-                                         state_change_callback=cb,
-                                         node_id='bootstrap',
-                                         **self.config)
-            if not bootstrap.connect_blocking():
-                bootstrap.close()
-                continue
-            future = bootstrap.send(metadata_request)
-            while not future.is_done:
-                self._selector.select(1)
-                for r, f in bootstrap.recv():
-                    f.success(r)
-            if future.failed():
-                bootstrap.close()
-                continue
-            self.cluster.update_metadata(future.value)
-            log.info('Bootstrap succeeded: found %d brokers and %d topics.',
-                     len(self.cluster.brokers()), len(self.cluster.topics()))
-
-            # A cluster with no topics can return no broker metadata
-            # in that case, we should keep the bootstrap connection
-            if not len(self.cluster.brokers()):
-                self._conns['bootstrap'] = bootstrap
-            else:
-                bootstrap.close()
-            self._bootstrap_fails = 0
-            break
-        # No bootstrap found...
-        else:
-            log.error('Unable to bootstrap from %s', hosts)
-            # Max exponential backoff is 2^12, x4000 (50ms -> 200s)
-            self._bootstrap_fails = min(self._bootstrap_fails + 1, 12)
-        self._refresh_on_disconnects = True
+            return False
+        return True
 
     def _can_connect(self, node_id):
         if node_id not in self._conns:
-            if self.cluster.broker_metadata(node_id):
+            # cluster.broker_metadata() is stateful when called w/ 'bootstrap'
+            # (it cycles through all of the bootstrap servers)
+            # so we short-circuit here and assume that we should always have
+            # some bootstrap_servers config to power bootstrap broker_metadata
+            if node_id == 'bootstrap' or self.cluster.broker_metadata(node_id):
                 return True
             return False
         conn = self._conns[node_id]
@@ -309,6 +267,9 @@ class KafkaClient(object):
                 except KeyError:
                     self._selector.modify(conn._sock, selectors.EVENT_WRITE)
 
+                if node_id == 'bootstrap':
+                    self._last_bootstrap = time.time()
+
             elif conn.connected():
                 log.debug("Node %s connected", node_id)
                 if node_id in self._connecting:
@@ -324,12 +285,12 @@ class KafkaClient(object):
 
                 self._idle_expiry_manager.update(node_id)
 
-                if 'bootstrap' in self._conns and node_id != 'bootstrap':
+                if node_id == 'bootstrap':
+                    self._bootstrap_fails = 0
+
+                elif 'bootstrap' in self._conns:
                     bootstrap = self._conns.pop('bootstrap')
-                    # XXX: make conn.close() require error to cause refresh
-                    self._refresh_on_disconnects = False
                     bootstrap.close()
-                    self._refresh_on_disconnects = True
 
             # Connection failures imply that our metadata is stale, so let's refresh
             elif conn.state is ConnectionStates.DISCONNECTING:
@@ -348,7 +309,10 @@ class KafkaClient(object):
                     idle_disconnect = True
                 self._idle_expiry_manager.remove(node_id)
 
-                if self._refresh_on_disconnects and not self._closed and not idle_disconnect:
+                if node_id == 'bootstrap':
+                    self._bootstrap_fails += 1
+
+                elif self._refresh_on_disconnects and not self._closed and not idle_disconnect:
                     log.warning("Node %s connection failed -- refreshing metadata", node_id)
                     self.cluster.request_update()
 
@@ -363,13 +327,40 @@ class KafkaClient(object):
             return True
         return False
 
+    def _should_recycle_connection(self, conn):
+        # Never recycle unless disconnected
+        if not conn.disconnected():
+            return False
+
+        # Always recycled disconnected bootstraps
+        elif conn.node_id == 'bootstrap':
+            return True
+
+        # Otherwise, only recycle when broker metadata has changed
+        broker = self.cluster.broker_metadata(conn.node_id)
+        if broker is None:
+            return False
+
+        host, _, afi = get_ip_port_afi(broker.host)
+        if conn.host != host or conn.port != broker.port:
+            log.info("Broker metadata change detected for node %s"
+                     " from %s:%s to %s:%s", conn.node_id, conn.host, conn.port,
+                     broker.host, broker.port)
+            return True
+
+        return False
+
     def _maybe_connect(self, node_id):
         """Idempotent non-blocking connection attempt to the given node id."""
         with self._lock:
-            broker = self.cluster.broker_metadata(node_id)
             conn = self._conns.get(node_id)
 
             if conn is None:
+                # Note that when bootstrapping, each call to broker_metadata may
+                # return a different host/port. So we need to be careful to only
+                # call when necessary to avoid skipping some possible bootstrap
+                # source.
+                broker = self.cluster.broker_metadata(node_id)
                 assert broker, 'Broker id %s not in current metadata' % (node_id,)
 
                 log.debug("Initiating connection to node %s at %s:%s",
@@ -383,17 +374,9 @@ class KafkaClient(object):
                 self._conns[node_id] = conn
 
             # Check if existing connection should be recreated because host/port changed
-            elif conn.disconnected() and broker is not None:
-                host, _, __ = get_ip_port_afi(broker.host)
-                if conn.host != host or conn.port != broker.port:
-                    log.info("Broker metadata change detected for node %s"
-                             " from %s:%s to %s:%s", node_id, conn.host, conn.port,
-                             broker.host, broker.port)
-
-                    # Drop old connection object.
-                    # It will be recreated on next _maybe_connect
-                    self._conns.pop(node_id)
-                    return False
+            elif self._should_recycle_connection(conn):
+                self._conns.pop(node_id)
+                return False
 
             elif conn.connected():
                 return True
@@ -713,7 +696,8 @@ class KafkaClient(object):
         This method will prefer a node with an existing connection and no
         in-flight-requests. If no such node is found, a node will be chosen
         randomly from disconnected nodes that are not "blacked out" (i.e.,
-        are not subject to a reconnect backoff).
+        are not subject to a reconnect backoff). If no node metadata has been
+        obtained, will return 'bootstrap' (subject to exponential backoff).
 
         Returns:
             node_id or None if no suitable node was found
@@ -740,12 +724,8 @@ class KafkaClient(object):
         if found is not None:
             return found
 
-        # some broker versions return an empty list of broker metadata
-        # if there are no topics created yet. the bootstrap process
-        # should detect this and keep a 'bootstrap' node alive until
-        # a non-bootstrap node is connected and non-empty broker
-        # metadata is available
-        elif 'bootstrap' in self._conns:
+        elif not nodes and self._can_bootstrap():
+            self._last_bootstrap = time.time()
             return 'bootstrap'
 
         return None
@@ -804,7 +784,11 @@ class KafkaClient(object):
             return self.config['reconnect_backoff_ms']
 
         if self._can_send_request(node_id):
-            topics = list(self._topics)
+            if node_id == 'bootstrap':
+                topics = list(self.config['bootstrap_topics_filter'])
+            else:
+                topics = list(self._topics)
+
             if self.cluster.need_all_topic_metadata or not topics:
                 topics = [] if self.config['api_version'] < (0, 10) else None
             api_version = 0 if self.config['api_version'] < (0, 10) else 1

--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -163,22 +163,26 @@ def test_is_ready(mocker, cli, conn):
 def test_close(mocker, cli, conn):
     mocker.patch.object(cli, '_selector')
 
-    init_count = conn.close.call_count
+    call_count = conn.close.call_count
 
     # Unknown node - silent
     cli.close(2)
+    call_count += 0
+    assert conn.close.call_count == call_count
 
     # Single node close
     cli._maybe_connect(0)
-    assert conn.close.call_count == init_count
+    assert conn.close.call_count == call_count
     cli.close(0)
-    assert conn.close.call_count == init_count + 1
+    call_count += 1
+    assert conn.close.call_count == call_count
 
     # All node close
     cli._maybe_connect(1)
     cli.close()
     # +3 close: node 0, node 1, node bootstrap
-    assert conn.close.call_count == init_count + 4
+    call_count += 3
+    assert conn.close.call_count == call_count
 
 
 def test_is_disconnected(cli, conn):

--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -23,56 +23,32 @@ from kafka.structs import BrokerMetadata
 
 
 @pytest.fixture
-def cli(conn):
-    return KafkaClient(api_version=(0, 9))
+def cli(mocker, conn):
+    mocker.patch('kafka.cluster.dns_lookup',
+                 return_value=[(socket.AF_INET, None, None, None, ('localhost', 9092))])
+    client = KafkaClient(api_version=(0, 9))
+    client.poll(future=client.cluster.request_update())
+    return client
 
 
-@pytest.mark.parametrize("bootstrap,expected_hosts", [
-    (None, [('localhost', 9092, socket.AF_UNSPEC)]),
-    ('foobar:1234', [('foobar', 1234, socket.AF_UNSPEC)]),
-    ('fizzbuzz', [('fizzbuzz', 9092, socket.AF_UNSPEC)]),
-    ('foo:12,bar:34', [('foo', 12, socket.AF_UNSPEC), ('bar', 34, socket.AF_UNSPEC)]),
-    (['fizz:56', 'buzz'], [('fizz', 56, socket.AF_UNSPEC), ('buzz', 9092, socket.AF_UNSPEC)]),
-])
-def test_bootstrap_servers(mocker, bootstrap, expected_hosts):
-    mocker.patch.object(KafkaClient, '_bootstrap')
-    if bootstrap is None:
-        KafkaClient(api_version=(0, 9)) # pass api_version to skip auto version checks
-    else:
-        KafkaClient(bootstrap_servers=bootstrap, api_version=(0, 9))
-
-    # host order is randomized internally, so resort before testing
-    (hosts,), _ = KafkaClient._bootstrap.call_args  # pylint: disable=no-member
-    assert sorted(hosts) == sorted(expected_hosts)
-
-
-def test_bootstrap_success(conn):
+def test_bootstrap(mocker, conn):
     conn.state = ConnectionStates.CONNECTED
+    mocker.patch('kafka.cluster.dns_lookup',
+                 return_value=[(socket.AF_INET, None, None, None, ('localhost', 9092))])
     cli = KafkaClient(api_version=(0, 9))
+    future = cli.cluster.request_update()
+    cli.poll(future=future)
+
+    assert future.succeeded()
     args, kwargs = conn.call_args
     assert args == ('localhost', 9092, socket.AF_UNSPEC)
     kwargs.pop('state_change_callback')
     kwargs.pop('node_id')
     assert kwargs == cli.config
-    conn.connect_blocking.assert_called_with()
-    conn.send.assert_called_once_with(MetadataRequest[0]([]))
+    conn.send.assert_called_once_with(MetadataRequest[0]([]), blocking=False)
     assert cli._bootstrap_fails == 0
     assert cli.cluster.brokers() == set([BrokerMetadata(0, 'foo', 12, None),
                                          BrokerMetadata(1, 'bar', 34, None)])
-
-
-def test_bootstrap_failure(conn):
-    conn.connect_blocking.return_value = False
-    cli = KafkaClient(api_version=(0, 9))
-    args, kwargs = conn.call_args
-    assert args == ('localhost', 9092, socket.AF_UNSPEC)
-    kwargs.pop('state_change_callback')
-    kwargs.pop('node_id')
-    assert kwargs == cli.config
-    conn.connect_blocking.assert_called_with()
-    conn.close.assert_called_with()
-    assert cli._bootstrap_fails == 1
-    assert cli.cluster.brokers() == set()
 
 
 def test_can_connect(cli, conn):
@@ -187,22 +163,22 @@ def test_is_ready(mocker, cli, conn):
 def test_close(mocker, cli, conn):
     mocker.patch.object(cli, '_selector')
 
-    # bootstrap connection should have been closed
-    assert conn.close.call_count == 1
+    init_count = conn.close.call_count
 
     # Unknown node - silent
     cli.close(2)
 
     # Single node close
     cli._maybe_connect(0)
-    assert conn.close.call_count == 1
+    assert conn.close.call_count == init_count
     cli.close(0)
-    assert conn.close.call_count == 2
+    assert conn.close.call_count == init_count + 1
 
     # All node close
     cli._maybe_connect(1)
     cli.close()
-    assert conn.close.call_count == 4
+    # +3 close: node 0, node 1, node bootstrap
+    assert conn.close.call_count == init_count + 4
 
 
 def test_is_disconnected(cli, conn):
@@ -249,7 +225,6 @@ def test_send(cli, conn):
 
 
 def test_poll(mocker):
-    mocker.patch.object(KafkaClient, '_bootstrap')
     metadata = mocker.patch.object(KafkaClient, '_maybe_refresh_metadata')
     _poll = mocker.patch.object(KafkaClient, '_poll')
     cli = KafkaClient(api_version=(0, 9))
@@ -309,7 +284,6 @@ def test_set_topics(mocker):
 
 @pytest.fixture
 def client(mocker):
-    mocker.patch.object(KafkaClient, '_bootstrap')
     _poll = mocker.patch.object(KafkaClient, '_poll')
 
     cli = KafkaClient(request_timeout_ms=9999999,


### PR DESCRIPTION
The current client attempts to bootstrap once during initialization, but if it fails there is no second attempt and the client will be inoperable. This can happen, for example, if an entire cluster is down at the time a long-running client starts execution.

This PR attempts to fix this by removing the synchronous bootstrapping from KafkaClient init, and instead merges bootstrap metadata with the cluster metadata. The java client uses a similar approach. This allows us to continue falling back to bootstrap data when necessary throughout the life of a long-running consumer or producer.

Fixes #1670

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1736)
<!-- Reviewable:end -->
