### PR TITLE
Recheck connecting nodes sooner when refreshing metadata

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -825,9 +825,7 @@ class KafkaClient(object):
         # the client from unnecessarily connecting to additional nodes while a previous connection
         # attempt has not been completed.
         if self._connecting:
-            # Strictly the timeout we should return here is "connect timeout", but as we don't
-            # have such application level configuration, using request timeout instead.
-            return self.config['request_timeout_ms']
+            return self.config['reconnect_backoff_ms']
 
         if self.maybe_connect(node_id):
             log.debug("Initializing connection to node %s for metadata request", node_id)

--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -376,7 +376,7 @@ def test_maybe_refresh_metadata_cant_send(mocker, client):
     client._connecting.add('foobar')
     client._can_connect.reset_mock()
     client.poll(timeout_ms=12345678)
-    client._poll.assert_called_with(9999.999) # connection timeout (request timeout)
+    client._poll.assert_called_with(2.222) # connection timeout (reconnect timeout)
     assert not client._can_connect.called
 
     assert not client._metadata_refresh_in_progress


### PR DESCRIPTION
This is a small, non-critical fixup that should reduce the forced connection delay when refreshing metadata.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1737)
<!-- Reviewable:end -->
