### PR TITLE
Dont recheck version if api_versions data is already cached

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -912,6 +912,9 @@ class BrokerConnection(object):
         return self._api_versions
 
     def get_api_versions(self):
+        if self._api_versions is not None:
+            return self._api_versions
+
         version = self.check_version()
         if version < (0, 10, 0):
             raise Errors.UnsupportedVersionError(


### PR DESCRIPTION
I noticed during local testing that version probing was happening twice when connecting to newer broker versions. This was because we call check_version() once explicitly, and then again implicitly within get_api_versions(). But once we have _api_versions data cached, we can just return it and avoid probing versions a second time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1738)
<!-- Reviewable:end -->
