### PR TITLE
Mock dns lookups in test_conn

### DIFF
--- a/test/test_conn.py
+++ b/test/test_conn.py
@@ -17,6 +17,13 @@ import kafka.errors as Errors
 
 
 @pytest.fixture
+def dns_lookup(mocker):
+    return mocker.patch('kafka.conn.dns_lookup',
+                        return_value=[(socket.AF_INET,
+                                       None, None, None,
+                                       ('localhost', 9092))])
+
+@pytest.fixture
 def _socket(mocker):
     socket = mocker.MagicMock()
     socket.connect_ex.return_value = 0
@@ -25,7 +32,7 @@ def _socket(mocker):
 
 
 @pytest.fixture
-def conn(_socket):
+def conn(_socket, dns_lookup):
     conn = BrokerConnection('localhost', 9092, socket.AF_INET)
     return conn
 


### PR DESCRIPTION
Small change to avoid doing dns resolution when running local connection tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1739)
<!-- Reviewable:end -->
