### PR TITLE
Support SASL OAuthBearer Authentication

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -133,20 +133,8 @@ class KafkaAdminClient(object):
             Default: None
         sasl_kerberos_service_name (str): Service name to include in GSSAPI
             sasl mechanism handshake. Default: 'kafka'
-        sasl_oauth_token_provider (Object): OAuthBearer token provider instance.
-            THE FOLLOWING INTERFACE MUST BE FULFILLED:
-            (required) #token(): Returns an ID/Access Token to be sent to the Kafka
-                client. The implementation should ensure token reuse so that multiple
-                calls at connect time do not create multiple tokens. The implementation
-                should also periodically refresh the token in order to guarantee
-                that each call returns an unexpired token. A timeout error should
-                be returned after a short period of inactivity so that the
-                broker can log debugging info and retry.
-            (OPTIONAL) #extensions() - Returns a map of key-value pairs that can
-                be sent with the SASL/OAUTHBEARER initial client request. If
-                not provided, the values are ignored. This feature is only available
-                in Kafka >= 2.1.0.
-            Default: None
+        sasl_oauth_token_provider (AbstractTokenProvider): OAuthBearer token provider
+            instance. (See kafka.oauth.abstract). Default: None
 
     """
     DEFAULT_CONFIG = {

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -133,6 +133,20 @@ class KafkaAdminClient(object):
             Default: None
         sasl_kerberos_service_name (str): Service name to include in GSSAPI
             sasl mechanism handshake. Default: 'kafka'
+        sasl_oauth_token_provider (Object): OAuthBearer token provider instance.
+            THE FOLLOWING INTERFACE MUST BE FULFILLED:
+            (required) #token(): Returns an ID/Access Token to be sent to the Kafka
+                client. The implementation should ensure token reuse so that multiple
+                calls at connect time do not create multiple tokens. The implementation
+                should also periodically refresh the token in order to guarantee
+                that each call returns an unexpired token. A timeout error should
+                be returned after a short period of inactivity so that the
+                broker can log debugging info and retry.
+            (OPTIONAL) #extensions() - Returns a map of key-value pairs that can
+                be sent with the SASL/OAUTHBEARER initial client request. If
+                not provided, the values are ignored. This feature is only available
+                in Kafka >= 2.1.0.
+            Default: None
 
     """
     DEFAULT_CONFIG = {
@@ -166,6 +180,7 @@ class KafkaAdminClient(object):
         'sasl_plain_username': None,
         'sasl_plain_password': None,
         'sasl_kerberos_service_name': 'kafka',
+        'sasl_oauth_token_provider': None,
 
         # metrics configs
         'metric_reporters': [],

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -146,20 +146,8 @@ class KafkaClient(object):
             sasl mechanism handshake. Default: 'kafka'
         sasl_kerberos_domain_name (str): kerberos domain name to use in GSSAPI
             sasl mechanism handshake. Default: one of bootstrap servers
-        sasl_oauth_token_provider (Object): OAuthBearer token provider instance.
-            THE FOLLOWING INTERFACE MUST BE FULFILLED:
-            (required) #token(): Returns an ID/Access Token to be sent to the Kafka
-                client. The implementation should ensure token reuse so that multiple
-                calls at connect time do not create multiple tokens. The implementation
-                should also periodically refresh the token in order to guarantee
-                that each call returns an unexpired token. A timeout error should
-                be returned after a short period of inactivity so that the
-                broker can log debugging info and retry.
-            (OPTIONAL) #extensions() - Returns a map of key-value pairs that can
-                be sent with the SASL/OAUTHBEARER initial client request. If
-                not provided, the values are ignored. This feature is only available
-                in Kafka >= 2.1.0.
-            Default: None
+        sasl_oauth_token_provider (AbstractTokenProvider): OAuthBearer token provider
+            instance. (See kafka.oauth.abstract). Default: None
     """
 
     DEFAULT_CONFIG = {

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -146,6 +146,20 @@ class KafkaClient(object):
             sasl mechanism handshake. Default: 'kafka'
         sasl_kerberos_domain_name (str): kerberos domain name to use in GSSAPI
             sasl mechanism handshake. Default: one of bootstrap servers
+        sasl_oauth_token_provider (Object): OAuthBearer token provider instance.
+            THE FOLLOWING INTERFACE MUST BE FULFILLED:
+            (required) #token(): Returns an ID/Access Token to be sent to the Kafka
+                client. The implementation should ensure token reuse so that multiple
+                calls at connect time do not create multiple tokens. The implementation
+                should also periodically refresh the token in order to guarantee
+                that each call returns an unexpired token. A timeout error should
+                be returned after a short period of inactivity so that the
+                broker can log debugging info and retry.
+            (OPTIONAL) #extensions() - Returns a map of key-value pairs that can
+                be sent with the SASL/OAUTHBEARER initial client request. If
+                not provided, the values are ignored. This feature is only available
+                in Kafka >= 2.1.0.
+            Default: None
     """
 
     DEFAULT_CONFIG = {
@@ -182,7 +196,8 @@ class KafkaClient(object):
         'sasl_plain_username': None,
         'sasl_plain_password': None,
         'sasl_kerberos_service_name': 'kafka',
-        'sasl_kerberos_domain_name': None
+        'sasl_kerberos_domain_name': None,
+        'sasl_oauth_token_provider': None
     }
 
     def __init__(self, **configs):

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -264,7 +264,7 @@ class BrokerConnection(object):
             if self.config['sasl_mechanism'] == 'OAUTHBEARER':
                 token_provider = self.config['sasl_oauth_token_provider']
                 assert token_provider is not None, 'sasl_oauth_token_provider required for OAUTHBEARER sasl'
-                assert isinstance(token_provider, AbstractTokenProvider), 'sasl_oauth_token_provider must implement AbstractTokenProvider'
+                assert callable(getattr(token_provider, "token", None)), 'sasl_oauth_token_provider must implement method #token()'
         # This is not a general lock / this class is not generally thread-safe yet
         # However, to avoid pushing responsibility for maintaining
         # per-connection locks to the upstream client, we will use this lock to

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -707,7 +707,7 @@ class BrokerConnection(object):
 
         # Only run if the #extensions() method is implemented by the clients Token Provider class
         # Builds up a string separated by \x01 via a dict of key value pairs
-        if callable(getattr(token_provider, "extensions", None)):
+        if callable(getattr(token_provider, "extensions", None)) and len(token_provider.extensions()) > 0:
             msg = "\x01".join(["{}={}".format(k, v) for k, v in token_provider.extensions().items()])
             return "\x01" + msg
         else:

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -179,6 +179,21 @@ class BrokerConnection(object):
             sasl mechanism handshake. Default: 'kafka'
         sasl_kerberos_domain_name (str): kerberos domain name to use in GSSAPI
             sasl mechanism handshake. Default: one of bootstrap servers
+        sasl_oauth_token_provider (Object): OAuthBearer token provider instance
+            that implements method 'token'.
+            THE FOLLOWING INTERFACE MUST BE FULFILLED:
+            (required) #token(): Returns an ID/Access Token to be sent to the Kafka
+                client. The implementation should ensure token reuse so that multiple
+                calls at connect time do not create multiple tokens. The implementation
+                should also periodically refresh the token in order to guarantee
+                that each call returns an unexpired token. A timeout error should
+                be returned after a short period of inactivity so that the
+                broker can log debugging info and retry.
+            (OPTIONAL) #extensions() - Returns a map of key-value pairs that can
+                be sent with the SASL/OAUTHBEARER initial client request. If
+                not provided, the values are ignored. This feature is only available
+                in Kafka >= 2.1.0.
+            Default: None
     """
 
     DEFAULT_CONFIG = {
@@ -210,10 +225,11 @@ class BrokerConnection(object):
         'sasl_plain_username': None,
         'sasl_plain_password': None,
         'sasl_kerberos_service_name': 'kafka',
-        'sasl_kerberos_domain_name': None
+        'sasl_kerberos_domain_name': None,
+        'sasl_oauth_token_provider': None
     }
     SECURITY_PROTOCOLS = ('PLAINTEXT', 'SSL', 'SASL_PLAINTEXT', 'SASL_SSL')
-    SASL_MECHANISMS = ('PLAIN', 'GSSAPI')
+    SASL_MECHANISMS = ('PLAIN', 'GSSAPI', 'OAUTHBEARER')
 
     def __init__(self, host, port, afi, **configs):
         self.host = host
@@ -257,7 +273,10 @@ class BrokerConnection(object):
             if self.config['sasl_mechanism'] == 'GSSAPI':
                 assert gssapi is not None, 'GSSAPI lib not available'
                 assert self.config['sasl_kerberos_service_name'] is not None, 'sasl_kerberos_service_name required for GSSAPI sasl'
-
+            if self.config['sasl_mechanism'] == 'OAUTHBEARER':
+                token_provider = self.config['sasl_oauth_token_provider']
+                assert token_provider is not None, 'sasl_oauth_token_provider required for OAUTHBEARER sasl'
+                assert callable(getattr(token_provider, "token", None)), 'sasl_oauth_token_provider must implement method #token()'
         # This is not a general lock / this class is not generally thread-safe yet
         # However, to avoid pushing responsibility for maintaining
         # per-connection locks to the upstream client, we will use this lock to
@@ -536,6 +555,8 @@ class BrokerConnection(object):
             return self._try_authenticate_plain(future)
         elif self.config['sasl_mechanism'] == 'GSSAPI':
             return self._try_authenticate_gssapi(future)
+        elif self.config['sasl_mechanism'] == 'OAUTHBEARER':
+            return self._try_authenticate_oauth(future)
         else:
             return future.failure(
                 Errors.UnsupportedSaslMechanismError(
@@ -658,6 +679,51 @@ class BrokerConnection(object):
 
         log.info('%s: Authenticated as %s via GSSAPI', self, gssapi_name)
         return future.success(True)
+
+    def _try_authenticate_oauth(self, future):
+        data = b''
+        # Send PLAIN credentials per RFC-4616
+        msg = bytes(self._build_oauth_client_request().encode("utf-8"))
+        size = Int32.encode(len(msg))
+        try:
+            # Send SASL OAuthBearer request with OAuth token
+            self._send_bytes_blocking(size + msg)
+
+            # The server will send a zero sized message (that is Int32(0)) on success.
+            # The connection is closed on failure
+            data = self._recv_bytes_blocking(4)
+
+        except ConnectionError as e:
+            log.exception("%s: Error receiving reply from server", self)
+            error = Errors.KafkaConnectionError("%s: %s" % (self, e))
+            self.close(error=error)
+            return future.failure(error)
+
+        if data != b'\x00\x00\x00\x00':
+            error = Errors.AuthenticationFailedError('Unrecognized response during authentication')
+            return future.failure(error)
+
+        log.info('%s: Authenticated via OAuth', self)
+        return future.success(True)
+
+    def _build_oauth_client_request(self):
+        token_provider = self.config['sasl_oauth_token_provider']
+        return "n,,\x01auth=Bearer {}{}\x01\x01".format(token_provider.token(), self._token_extensions())
+
+    def _token_extensions(self):
+        """
+        Return a string representation of the OPTIONAL key-value pairs that can be sent with an OAUTHBEARER
+        initial request.
+        """
+        token_provider = self.config['sasl_oauth_token_provider']
+
+        # Only run if the #extensions() method is implemented by the clients Token Provider class
+        # Builds up a string separated by \x01 via a dict of key value pairs
+        if callable(getattr(token_provider, "extensions", None)):
+            msg = "\x01".join(["{}={}".format(k, v) for k, v in token_provider.extensions().items()])
+            return "\x01" + msg
+        else:
+            return ""
 
     def blacked_out(self):
         """

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -235,20 +235,8 @@ class KafkaConsumer(six.Iterator):
             sasl mechanism handshake. Default: 'kafka'
         sasl_kerberos_domain_name (str): kerberos domain name to use in GSSAPI
             sasl mechanism handshake. Default: one of bootstrap servers
-        sasl_oauth_token_provider (Object): OAuthBearer token provider instance.
-            THE FOLLOWING INTERFACE MUST BE FULFILLED:
-            (required) #token(): Returns an ID/Access Token to be sent to the Kafka
-                client. The implementation should ensure token reuse so that multiple
-                calls at connect time do not create multiple tokens. The implementation
-                should also periodically refresh the token in order to guarantee
-                that each call returns an unexpired token. A timeout error should
-                be returned after a short period of inactivity so that the
-                broker can log debugging info and retry.
-            (OPTIONAL) #extensions() - Returns a map of key-value pairs that can
-                be sent with the SASL/OAUTHBEARER initial client request. If
-                not provided, the values are ignored. This feature is only available
-                in Kafka >= 2.1.0.
-            Default: None
+        sasl_oauth_token_provider (AbstractTokenProvider): OAuthBearer token provider
+            instance. (See kafka.oauth.abstract). Default: None
 
     Note:
         Configuration parameters are described in more detail at

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -235,6 +235,20 @@ class KafkaConsumer(six.Iterator):
             sasl mechanism handshake. Default: 'kafka'
         sasl_kerberos_domain_name (str): kerberos domain name to use in GSSAPI
             sasl mechanism handshake. Default: one of bootstrap servers
+        sasl_oauth_token_provider (Object): OAuthBearer token provider instance.
+            THE FOLLOWING INTERFACE MUST BE FULFILLED:
+            (required) #token(): Returns an ID/Access Token to be sent to the Kafka
+                client. The implementation should ensure token reuse so that multiple
+                calls at connect time do not create multiple tokens. The implementation
+                should also periodically refresh the token in order to guarantee
+                that each call returns an unexpired token. A timeout error should
+                be returned after a short period of inactivity so that the
+                broker can log debugging info and retry.
+            (OPTIONAL) #extensions() - Returns a map of key-value pairs that can
+                be sent with the SASL/OAUTHBEARER initial client request. If
+                not provided, the values are ignored. This feature is only available
+                in Kafka >= 2.1.0.
+            Default: None
 
     Note:
         Configuration parameters are described in more detail at
@@ -293,7 +307,8 @@ class KafkaConsumer(six.Iterator):
         'sasl_plain_username': None,
         'sasl_plain_password': None,
         'sasl_kerberos_service_name': 'kafka',
-        'sasl_kerberos_domain_name': None
+        'sasl_kerberos_domain_name': None,
+        'sasl_oauth_token_provider': None
     }
     DEFAULT_SESSION_TIMEOUT_MS_0_9 = 30000
 

--- a/kafka/oauth/__init__.py
+++ b/kafka/oauth/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from kafka.oauth.abstract import AbstractTokenProvider

--- a/kafka/oauth/abstract.py
+++ b/kafka/oauth/abstract.py
@@ -9,7 +9,7 @@ class AbstractTokenProvider(ABC):
     """
     A Token Provider must be used for the SASL OAuthBearer protocol.
 
-    The implementation shsould ensure token reuse so that multiple
+    The implementation should ensure token reuse so that multiple
     calls at connect time do not create multiple tokens. The implementation
     should also periodically refresh the token in order to guarantee
     that each call returns an unexpired token. A timeout error should
@@ -17,12 +17,6 @@ class AbstractTokenProvider(ABC):
     broker can log debugging info and retry.
 
     Token Providers MUST be implemented from this ABC.
-
-    An optional method that may be implemented if the user chooses is:
-    #extensions() - Returns a map of key-value pairs that can
-        be sent with the SASL/OAUTHBEARER initial client request. If
-        not provided, the values are ignored. This feature is only available
-        in Kafka >= 2.1.0.
     """
 
     def __init__(self, **config):
@@ -36,3 +30,13 @@ class AbstractTokenProvider(ABC):
         """
         pass
 
+    def extensions(self):
+        """
+        This is an OPTIONAL method that may be implemented.
+
+        Returns a map of key-value pairs that can
+        be sent with the SASL/OAUTHBEARER initial client request. If
+        not implemented, the values are ignored. This feature is only available
+        in Kafka >= 2.1.0.
+        """
+        pass

--- a/kafka/oauth/abstract.py
+++ b/kafka/oauth/abstract.py
@@ -16,7 +16,7 @@ class AbstractTokenProvider(ABC):
     be returned after a short period of inactivity so that the
     broker can log debugging info and retry.
 
-    Token Providers MUST be implemented from this ABC.
+    Token Providers MUST implement the token() method
     """
 
     def __init__(self, **config):

--- a/kafka/oauth/abstract.py
+++ b/kafka/oauth/abstract.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+import abc
+
+# This statement is compatible with both Python 2.7 & 3+
+ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
+
+class AbstractTokenProvider(ABC):
+    """
+    A Token Provider must be used for the SASL OAuthBearer protocol.
+
+    The implementation shsould ensure token reuse so that multiple
+    calls at connect time do not create multiple tokens. The implementation
+    should also periodically refresh the token in order to guarantee
+    that each call returns an unexpired token. A timeout error should
+    be returned after a short period of inactivity so that the
+    broker can log debugging info and retry.
+
+    Token Providers MUST be implemented from this ABC.
+
+    An optional method that may be implemented if the user chooses is:
+    #extensions() - Returns a map of key-value pairs that can
+        be sent with the SASL/OAUTHBEARER initial client request. If
+        not provided, the values are ignored. This feature is only available
+        in Kafka >= 2.1.0.
+    """
+
+    def __init__(self, **config):
+        pass
+
+    @abc.abstractmethod
+    def token(self):
+        """
+        Returns a (str) ID/Access Token to be sent to the Kafka
+        client.
+        """
+        pass
+

--- a/kafka/oauth/abstract.py
+++ b/kafka/oauth/abstract.py
@@ -39,4 +39,4 @@ class AbstractTokenProvider(ABC):
         not implemented, the values are ignored. This feature is only available
         in Kafka >= 2.1.0.
         """
-        pass
+        return {}

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -272,6 +272,20 @@ class KafkaProducer(object):
             sasl mechanism handshake. Default: 'kafka'
         sasl_kerberos_domain_name (str): kerberos domain name to use in GSSAPI
             sasl mechanism handshake. Default: one of bootstrap servers
+        sasl_oauth_token_provider (Object): OAuthBearer token provider instance.
+            THE FOLLOWING INTERFACE MUST BE FULFILLED:
+            (required) #token(): Returns an ID/Access Token to be sent to the Kafka
+                client. The implementation should ensure token reuse so that multiple
+                calls at connect time do not create multiple tokens. The implementation
+                should also periodically refresh the token in order to guarantee
+                that each call returns an unexpired token. A timeout error should
+                be returned after a short period of inactivity so that the
+                broker can log debugging info and retry.
+            (OPTIONAL) #extensions() - Returns a map of key-value pairs that can
+                be sent with the SASL/OAUTHBEARER initial client request. If
+                not provided, the values are ignored. This feature is only available
+                in Kafka >= 2.1.0.
+            Default: None
 
     Note:
         Configuration parameters are described in more detail at
@@ -322,7 +336,8 @@ class KafkaProducer(object):
         'sasl_plain_username': None,
         'sasl_plain_password': None,
         'sasl_kerberos_service_name': 'kafka',
-        'sasl_kerberos_domain_name': None
+        'sasl_kerberos_domain_name': None,
+        'sasl_oauth_token_provider': None
     }
 
     _COMPRESSORS = {

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -272,20 +272,8 @@ class KafkaProducer(object):
             sasl mechanism handshake. Default: 'kafka'
         sasl_kerberos_domain_name (str): kerberos domain name to use in GSSAPI
             sasl mechanism handshake. Default: one of bootstrap servers
-        sasl_oauth_token_provider (Object): OAuthBearer token provider instance.
-            THE FOLLOWING INTERFACE MUST BE FULFILLED:
-            (required) #token(): Returns an ID/Access Token to be sent to the Kafka
-                client. The implementation should ensure token reuse so that multiple
-                calls at connect time do not create multiple tokens. The implementation
-                should also periodically refresh the token in order to guarantee
-                that each call returns an unexpired token. A timeout error should
-                be returned after a short period of inactivity so that the
-                broker can log debugging info and retry.
-            (OPTIONAL) #extensions() - Returns a map of key-value pairs that can
-                be sent with the SASL/OAUTHBEARER initial client request. If
-                not provided, the values are ignored. This feature is only available
-                in Kafka >= 2.1.0.
-            Default: None
+        sasl_oauth_token_provider (AbstractTokenProvider): OAuthBearer token provider
+            instance. (See kafka.oauth.abstract). Default: None
 
     Note:
         Configuration parameters are described in more detail at


### PR DESCRIPTION
This PR adds support for OAuthBearer as a method of SASL Authentication as described in [KIP-255](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=75968876) and https://github.com/dpkp/kafka-python/issues/1710.

When initializing the client, the user must pass in an instance of a class that implements a **token** method, which returns an ID or Access Token. The interface is described in the documentation for every class where `sasl_oauth_token_provider` should be configured. I am open to better ideas of where to store the required interface details! 

**Example:**
```python
class TokenProvider(object):
    def token(self):
        return "some_token_id"

producer = KafkaProducer(
    bootstrap_servers='127.0.0.1:9094',
    ...
    security_protocol='SASL_PLAINTEXT',
    sasl_oauth_token_provider=TokenProvider(),
    sasl_mechanism='OAUTHBEARER'
)
```

Tested with a local Kafka cluster and ID Token, and successfully authenticated with the example client initialization above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1750)
<!-- Reviewable:end -->
