### PR TITLE
Maintain shadow cluster metadata for bootstrapping

### DIFF
--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -40,7 +40,7 @@ class ClusterMetadata(object):
     DEFAULT_CONFIG = {
         'retry_backoff_ms': 100,
         'metadata_max_age_ms': 300000,
-        'bootstrap_servers': 'localhost',
+        'bootstrap_servers': [],
     }
 
     def __init__(self, **configs):


### PR DESCRIPTION
Fixes #1751 (and part of #1741, related to hostname verification). This PR puts bootstrap metadata into a shadow metadata "cluster", similar to the java client. This moves dns resolution for multi-interface hostnames into BrokerConnection.connect(). And it gives each bootstrap server a unique node-id (rather than all sharing a single node-id of `bootstrap`), which allows the KafkaClient to manage connection attempts more consistently using least-loaded-node, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1753)
<!-- Reviewable:end -->
