### PR TITLE
Revert 703f0659 / fix 0.8.2 protocol quick detection

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -240,9 +240,6 @@ class BrokerConnection(object):
 
         self.node_id = self.config.pop('node_id')
 
-        if self.config['api_version'] is None:
-            self.config['api_version'] = self.DEFAULT_CONFIG['api_version']
-
         if self.config['receive_buffer_bytes'] is not None:
             self.config['socket_options'].append(
                 (socket.SOL_SOCKET, socket.SO_RCVBUF,


### PR DESCRIPTION
commit 703f0659 was attempting to fix version detection on 0.8.2 brokers, which have a quirky correlation id response for GroupCoordinator requests when there are no topics created. But setting the BrokerConn api_version to 0.8.2 prematurely inadvertently broke SASL authentication, which checks that the api_version is either unset (None) or >= 0.10 . This PR should fix both issues by also handling the 0.8.2 protocol quirk when the api_version is unset / None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1763)
<!-- Reviewable:end -->
