### PR TITLE
Avoid more cases of client wakeup when sending from sender / same thread

### DIFF
--- a/kafka/producer/sender.py
+++ b/kafka/producer/sender.py
@@ -157,7 +157,7 @@ class Sender(threading.Thread):
         # difference between now and its linger expiry time; otherwise the
         # select time will be the time difference between now and the
         # metadata expiry time
-        self._client.poll(poll_timeout_ms)
+        self._client.poll(poll_timeout_ms, wakeup=False)
 
     def initiate_close(self):
         """Start closing the sender (won't complete until all data is sent)."""


### PR DESCRIPTION
Extra fixes for https://github.com/dpkp/kafka-python/issues/1760.

Note that I don't pretend to fully understand the threading/socket setup here - just extending the fix from https://github.com/dpkp/kafka-python/pull/1761 to cover more cases, as my code seems to be hitting the `_maybe_refresh_metadata()` path, and I spotted a few others that looked similar.

I've done a couple of long running tests with this fix, and haven't run into any more `KafkaTimeoutError`s on `wakeup()`.

This still only covers producer calls. Is this issue/fix relevant to the consumer as well, or any other users of `KafkaClient`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1765)
<!-- Reviewable:end -->
