### PR TITLE
Do not block writing to wake socket

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -377,7 +377,6 @@ class KafkaProducer(object):
         self._metrics = Metrics(metric_config, reporters)
 
         client = KafkaClient(metrics=self._metrics, metric_group_prefix='producer',
-                             wakeup_timeout_ms=self.config['max_block_ms'],
                              **self.config)
 
         # Get auto-discovered version from client if necessary


### PR DESCRIPTION
Fixes #1760 . We do not need to block on writes to the wakeup socket pair. This should avoid the root cause of #1760, which is that the socket buffer gets full and blocks the thread that is responsible for reading / draining it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1767)
<!-- Reviewable:end -->
