### PR TITLE
Dont wakeup during maybe_refresh_metadata -- it is only called by poll()

### DIFF
--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -332,7 +332,7 @@ def test_maybe_refresh_metadata_update(mocker, client):
     client._poll.assert_called_with(9999.999) # request_timeout_ms
     assert client._metadata_refresh_in_progress
     request = MetadataRequest[0]([])
-    send.assert_called_once_with('foobar', request)
+    send.assert_called_once_with('foobar', request, wakeup=False)
 
 
 def test_maybe_refresh_metadata_cant_send(mocker, client):
@@ -348,7 +348,7 @@ def test_maybe_refresh_metadata_cant_send(mocker, client):
     # first poll attempts connection
     client.poll(timeout_ms=12345678)
     client._poll.assert_called_with(2.222) # reconnect backoff
-    client.maybe_connect.assert_called_once_with('foobar')
+    client.maybe_connect.assert_called_once_with('foobar', wakeup=False)
 
     # poll while connecting should not attempt a new connection
     client._connecting.add('foobar')


### PR DESCRIPTION
This is a simplification of #1765 , intended to address / fix #1760 . The underlying issue here is that if the wakeup socket is full, and so will block on writes, we don't want anything within the poll() method to attempt to write to this socket. This PR updates _maybe_refresh_metadata() to not use wakeups. Because this method is only ever called within poll(), I have made the default wakeup=False. In the future, if the method were invoked from outside / another thread, we would want to pass wakeup=True.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1769)
<!-- Reviewable:end -->
