### PR TITLE
Avoid race condition on client._conns in send()

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -516,14 +516,15 @@ class KafkaClient(object):
         Returns:
             Future: resolves to Response struct or Error
         """
-        if not self._can_send_request(node_id):
+        conn = self._conns.get(node_id)
+        if not conn or not self._can_send_request(node_id):
             self.maybe_connect(node_id, wakeup=wakeup)
             return Future().failure(Errors.NodeNotReadyError(node_id))
 
         # conn.send will queue the request internally
         # we will need to call send_pending_requests()
         # to trigger network I/O
-        future = self._conns[node_id].send(request, blocking=False)
+        future = conn.send(request, blocking=False)
 
         # Wakeup signal is useful in case another thread is
         # blocked waiting for incoming network traffic while holding


### PR DESCRIPTION
There was a very small possibility that between checking `self._can_send_request(node_id)` and grabbing the connection object via `self._conns[node_id]` that the connection could get closed / recycled / removed from _conns and cause a KeyError. This PR should prevent such a KeyError. In the case where the connection is disconnected by the time we call send(), we should expect conn.send() simply to fail the request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1772)
<!-- Reviewable:end -->
