### PR TITLE
Dont treat popped conn.close() as failure in state change callback

### DIFF
--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -93,6 +93,7 @@ def test_conn_state_change(mocker, cli, conn):
     sel = mocker.patch.object(cli, '_selector')
 
     node_id = 0
+    cli._conns[node_id] = conn
     conn.state = ConnectionStates.CONNECTING
     cli._conn_state_change(node_id, conn)
     assert node_id in cli._connecting
@@ -180,8 +181,8 @@ def test_close(mocker, cli, conn):
     # All node close
     cli._maybe_connect(1)
     cli.close()
-    # +3 close: node 0, node 1, node bootstrap
-    call_count += 3
+    # +2 close: node 1, node bootstrap (node 0 already closed)
+    call_count += 2
     assert conn.close.call_count == call_count
 
 


### PR DESCRIPTION
Small change to KafkaClient's state_change_callback to attempt to avoid re-fetching Metadata or increasing bootstrap failure count after an intentional disconnect / conn.close()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1773)
<!-- Reviewable:end -->
