### PR TITLE
Fix possible AttribueError during conn._close_socket

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -769,7 +769,7 @@ class BrokerConnection(object):
             log.debug('%s: reconnect backoff %s after %s failures', self, self._reconnect_backoff, self._failures)
 
     def _close_socket(self):
-        if self._sock:
+        if hasattr(self, '_sock') and self._sock is not None:
             self._sock.close()
             self._sock = None
 


### PR DESCRIPTION
Found via StackOverflow -- if user misconfigures BrokerConnection (for example attempts to use gssapi w/o module installed), we raise an exception immediately. But the configuration checks happen before `_sock` is initialized, and the following gc call to `__del__` calls `_close_socket` which crashes on AttributeError. So this is a quick fix for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1776)
<!-- Reviewable:end -->
