### PR TITLE
Reset reconnect backoff on SSL connection

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -423,6 +423,7 @@ class BrokerConnection(object):
                 else:
                     log.info('%s: Connection complete.', self)
                     self.state = ConnectionStates.CONNECTED
+                    self._reset_reconnect_backoff()
                 self.config['state_change_callback'](self)
 
         if self.state is ConnectionStates.AUTHENTICATING:


### PR DESCRIPTION
I noticed a call to reset_reconnect_backoff was missing from the connection path for pure SSL (no SASL). Fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1777)
<!-- Reviewable:end -->
