### PR TITLE
Return explicitly after close in connect()

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -354,7 +354,7 @@ class BrokerConnection(object):
             next_lookup = self._next_afi_sockaddr()
             if not next_lookup:
                 self.close(Errors.KafkaConnectionError('DNS failure'))
-                return
+                return self.state
             else:
                 log.debug('%s: creating new socket', self)
                 self._sock_afi, self._sock_addr = next_lookup
@@ -409,6 +409,7 @@ class BrokerConnection(object):
                           ' Disconnecting.', self, ret)
                 errstr = errno.errorcode.get(ret, 'UNKNOWN')
                 self.close(Errors.KafkaConnectionError('{} {}'.format(ret, errstr)))
+                return self.state
 
             # Needs retry
             else:
@@ -442,6 +443,7 @@ class BrokerConnection(object):
             if time.time() > request_timeout + self.last_attempt:
                 log.error('Connection attempt to %s timed out', self)
                 self.close(Errors.KafkaConnectionError('timeout'))
+                return self.state
 
         return self.state
 


### PR DESCRIPTION
Minor cleanups. One fixup where we returned early w/o returning the state. Other changes are cosmetic, but I prefer the explicitness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1778)
<!-- Reviewable:end -->
