### PR TITLE
Feature/multithreading

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -624,7 +624,7 @@ class KafkaAdminClient(object):
                 "Support for DescribeGroups v{} has not yet been added to KafkaAdminClient."
                 .format(version))
 
-    def describe_consumer_groups(self, group_ids, group_coordinator_id=None):
+    def describe_consumer_groups(self, group_ids, group_coordinator_id=None, timeout=None):
         """Describe a set of consumer groups.
 
         Any errors are immediately raised.
@@ -651,7 +651,7 @@ class KafkaAdminClient(object):
             t.start()
 
         for thread in threads:
-            thread.join(timeout=None)
+            thread.join(timeout=timeout)
         return group_descriptions
 
     def list_broker_consumer_offsets(self, broker_id, consumer_groups, request):
@@ -664,7 +664,7 @@ class KafkaAdminClient(object):
 
         consumer_groups.update(response.groups)
 
-    def list_consumer_groups(self, broker_ids=None):
+    def list_consumer_groups(self, broker_ids=None, timeout=None):
         """List all consumer groups known to the cluster.
 
         This returns a list of Consumer Group tuples. The tuples are
@@ -708,7 +708,7 @@ class KafkaAdminClient(object):
                 t.start()
 
             for thread in threads:
-                thread.join(timeout=None)
+                thread.join(timeout=timeout)
         else:
             raise NotImplementedError(
                 "Support for ListGroups v{} has not yet been added to KafkaAdminClient."

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -588,7 +588,7 @@ class KafkaAdminClient(object):
     # describe delegation_token protocol not yet implemented
     # Note: send the request to the least_loaded_node()
 
-    def describe_broker_consumer_group(self, group_coordinator_id, group_descriptions, group_id, version, request):
+    def describe_broker_consumer_group(self, group_coordinator_id, group_descriptions, group_id, version):
         if group_coordinator_id is not None:
             this_groups_coordinator_id = group_coordinator_id
         else:
@@ -644,9 +644,9 @@ class KafkaAdminClient(object):
         """
         group_descriptions = []
         version = self._matching_api_version(DescribeGroupsRequest)
-        thread = []
+        threads = []
         for group_id in group_ids:
-            t = Thread(target=self.describe_broker_consumer_group, args=(group_coordinator_id, group_descriptions, group_id, version, request))
+            t = Thread(target=self.describe_broker_consumer_group, args=(group_coordinator_id, group_descriptions, group_id, version))
             threads.append(t)
             t.start()
 

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -646,7 +646,8 @@ class KafkaAdminClient(object):
         version = self._matching_api_version(DescribeGroupsRequest)
         threads = []
         for group_id in group_ids:
-            t = Thread(target=self.describe_broker_consumer_group, args=(group_coordinator_id, group_descriptions, group_id, version))
+            t = Thread(target=self.describe_broker_consumer_group,
+                       args=(group_coordinator_id, group_descriptions, group_id, version))
             threads.append(t)
             t.start()
 
@@ -703,7 +704,8 @@ class KafkaAdminClient(object):
             threads = []
 
             for broker_id in broker_ids:
-                t = Thread(target=self.list_broker_consumer_offsets, args=(broker_id, consumer_groups, request))
+                t = Thread(target=self.list_broker_consumer_offsets,
+                           args=(broker_id, consumer_groups, request))
                 threads.append(t)
                 t.start()
 


### PR DESCRIPTION
This allows multithreading for list_consumer_groups() and describe_consumer_groups(), so brokers are access in parallel rather than sequentially, greatly improving performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1801)
<!-- Reviewable:end -->
