### PR TITLE
Cleanup python nits in Range Assignor

### DIFF
--- a/kafka/coordinator/assignors/range.py
+++ b/kafka/coordinator/assignors/range.py
@@ -46,20 +46,18 @@ class RangePartitionAssignor(AbstractPartitionAssignor):
             if partitions is None:
                 log.warning('No partition metadata for topic %s', topic)
                 continue
-            partitions = sorted(list(partitions))
-            partitions_for_topic = len(partitions)
+            partitions = sorted(partitions)
             consumers_for_topic.sort()
 
             partitions_per_consumer = len(partitions) // len(consumers_for_topic)
             consumers_with_extra = len(partitions) % len(consumers_for_topic)
 
-            for i in range(len(consumers_for_topic)):
+            for i, member in enumerate(consumers_for_topic):
                 start = partitions_per_consumer * i
                 start += min(i, consumers_with_extra)
                 length = partitions_per_consumer
                 if not i + 1 > consumers_with_extra:
                     length += 1
-                member = consumers_for_topic[i]
                 assignment[member][topic] = partitions[start:start+length]
 
         protocol_assignment = {}


### PR DESCRIPTION
A little Python cleanup:

1. Remove unused variable: `partitions_for_topic`
2. No need to cast to list as `sorted()` already returns a list
3. Using `enumerate()` is cleaner than `range(len())` and handles assigning
`member`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1805)
<!-- Reviewable:end -->
