### PR TITLE
Fix typo in _fetch_all_topic_metadata function

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -552,7 +552,7 @@ class KafkaConsumer(six.Iterator):
                 committed = None
         return committed
 
-    def _fetch_all_topit_metadata(self):
+    def _fetch_all_topic_metadata(self):
         """A blocking call that fetches topic metadata for all topics in the
         cluster that the user is authorized to view.
         """


### PR DESCRIPTION
@jeffwidman wow, this is really embarrassing. I just noticed there's a typo in https://github.com/dpkp/kafka-python/pull/1781, so I corrected it.

It's weird it wasn't caught by any tests -- do we not do any testing for these methods?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1809)
<!-- Reviewable:end -->
