### PR TITLE
Remove unused/weird comment line

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -464,7 +464,6 @@ class KafkaProducer(object):
             assert timeout >= 0
 
         log.info("Closing the Kafka producer with %s secs timeout.", timeout)
-        #first_exception = AtomicReference() # this will keep track of the first encountered exception
         invoked_from_callback = bool(threading.current_thread() is self._sender)
         if timeout > 0:
             if invoked_from_callback:


### PR DESCRIPTION
This was originally committed to the repo this way, so I'm not sure if it is some kind of obtuse comment or an accidental oversight.

@dpkp any idea why this is here in the source?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1813)
<!-- Reviewable:end -->
