### PR TITLE
Remove string support in `api_version`

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -340,16 +340,6 @@ class KafkaConsumer(six.Iterator):
         self._metrics = Metrics(metric_config, reporters)
         # TODO _metrics likely needs to be passed to KafkaClient, etc.
 
-        # api_version was previously a str. Accept old format for now
-        if isinstance(self.config['api_version'], str):
-            str_version = self.config['api_version']
-            if str_version == 'auto':
-                self.config['api_version'] = None
-            else:
-                self.config['api_version'] = tuple(map(int, str_version.split('.')))
-            log.warning('use api_version=%s [tuple] -- "%s" as str is deprecated',
-                        str(self.config['api_version']), str_version)
-
         self._client = KafkaClient(metrics=self._metrics, **self.config)
 
         # Get auto-discovered version from client if necessary

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -358,16 +358,6 @@ class KafkaProducer(object):
         if self.config['acks'] == 'all':
             self.config['acks'] = -1
 
-        # api_version was previously a str. accept old format for now
-        if isinstance(self.config['api_version'], str):
-            deprecated = self.config['api_version']
-            if deprecated == 'auto':
-                self.config['api_version'] = None
-            else:
-                self.config['api_version'] = tuple(map(int, deprecated.split('.')))
-            log.warning('use api_version=%s [tuple] -- "%s" as str is deprecated',
-                        str(self.config['api_version']), deprecated)
-
         # Configure metrics
         metrics_tags = {'client-id': self.config['client_id']}
         metric_config = MetricConfig(samples=self.config['metrics_num_samples'],

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -73,9 +73,9 @@ def test_end_to_end(kafka_broker, compression):
 def test_kafka_producer_gc_cleanup():
     gc.collect()
     threads = threading.active_count()
-    producer = KafkaProducer(api_version='0.9') # set api_version explicitly to avoid auto-detection
+    producer = KafkaProducer(api_version=(0, 9))  # set api_version explicitly to avoid auto-detection
     assert threading.active_count() == threads + 1
-    del(producer)
+    del producer
     gc.collect()
     assert threading.active_count() == threads
 


### PR DESCRIPTION
This breaks backwards compatibility, probably best not to merge 'til `2.0` release
--
A long time ago, `api_version` supported strings. That has been
deprecated for years in favor of tuples. Time to remove support for the
strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1814)
<!-- Reviewable:end -->
