### PR TITLE
Remove deprecated `'smallest'`/`'largest'`

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -315,13 +315,6 @@ class KafkaConsumer(six.Iterator):
         self.config = copy.copy(self.DEFAULT_CONFIG)
         self.config.update(configs)
 
-        deprecated = {'smallest': 'earliest', 'largest': 'latest'}
-        if self.config['auto_offset_reset'] in deprecated:
-            new_config = deprecated[self.config['auto_offset_reset']]
-            log.warning('use auto_offset_reset=%s (%s is deprecated)',
-                        new_config, self.config['auto_offset_reset'])
-            self.config['auto_offset_reset'] = new_config
-
         connections_max_idle_ms = self.config['connections_max_idle_ms']
         request_timeout_ms = self.config['request_timeout_ms']
         fetch_max_wait_ms = self.config['fetch_max_wait_ms']


### PR DESCRIPTION
This breaks backwards compatibility, probably best not to merge 'til `2.0` release
--
These have been deprecated in favor of `'earliest'` and `'latest'` for a
while.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1815)
<!-- Reviewable:end -->
