### PR TITLE
Remove deprecated `ConnectionError`

### DIFF
--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -468,10 +468,6 @@ class KafkaConnectionError(KafkaError):
     invalid_metadata = True
 
 
-class ConnectionError(KafkaConnectionError):
-    """Deprecated"""
-
-
 class ProtocolError(KafkaError):
     pass
 


### PR DESCRIPTION
This breaks backwards compatibility, probably best not to merge 'til `2.0` release
--
This has been deprecated for a bit in favor of `KafkaConnectionError`
because it conflicts with Python's built-in `ConnectionError`.

Time to remove it as part of cleaning up our old deprecated code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1816)
<!-- Reviewable:end -->
