### PR TITLE
Reduce client poll timeout when no IFRs

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -588,6 +588,9 @@ class KafkaClient(object):
                         metadata_timeout_ms,
                         idle_connection_timeout_ms,
                         self.config['request_timeout_ms'])
+                    # if there are no requests in flight, do not block longer than the retry backoff
+                    if self.in_flight_request_count() == 0:
+                        timeout = min(timeout, self.config['retry_backoff_ms'])
                     timeout = max(0, timeout / 1000)  # avoid negative timeouts
 
                 self._poll(timeout)


### PR DESCRIPTION
When there are no IFRs, client.poll can potentially block up to the full request timeout ms. For consumers, this would also prevent the heartbeat thread from acquiring the client lock and therefore prevent the heartbeat loop from proceeding. By reducing the poll timeout to the retry timeout (typically 100ms), we should help prevent lock contention and enable the heartbeat thread to loop more freely. Note that when there is an IFR, we may still block for the full request timeout, so this isn't a general solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1823)
<!-- Reviewable:end -->
