### PR TITLE
Delay converting to seconds

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -591,9 +591,9 @@ class KafkaClient(object):
                     # if there are no requests in flight, do not block longer than the retry backoff
                     if self.in_flight_request_count() == 0:
                         timeout = min(timeout, self.config['retry_backoff_ms'])
-                    timeout = max(0, timeout / 1000)  # avoid negative timeouts
+                    timeout = max(0, timeout)  # avoid negative timeouts
 
-                self._poll(timeout)
+                self._poll(timeout / 1000)
 
                 responses.extend(self._fire_pending_completed_requests())
 


### PR DESCRIPTION
Delaying the conversion to seconds makes the code intent more clear.

Originally discussed in https://github.com/dpkp/kafka-python/pull/1823#discussion_r288426474.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1825)
<!-- Reviewable:end -->
