### PR TITLE
Sanity test for consumer.topics() and consumer.partitions_for_topic()

### DIFF
--- a/test/test_consumer_group.py
+++ b/test/test_consumer_group.py
@@ -29,6 +29,15 @@ def test_consumer(kafka_broker, topic, version):
     assert consumer._client._conns[node_id].state is ConnectionStates.CONNECTED
     consumer.close()
 
+@pytest.mark.skipif(not version(), reason="No KAFKA_VERSION set")
+def test_consumer_topics(kafka_broker, topic, version):
+    consumer = KafkaConsumer(bootstrap_servers=get_connect_str(kafka_broker))
+    # Necessary to drive the IO
+    consumer.poll(500)
+    consumer_topics = consumer.topics()
+    assert topic in consumer_topics
+    assert len(consumer.partitions_for_topic(topic)) > 0
+    consumer.close()
 
 @pytest.mark.skipif(version() < (0, 9), reason='Unsupported Kafka Version')
 @pytest.mark.skipif(not version(), reason="No KAFKA_VERSION set")


### PR DESCRIPTION
This should hopefully address https://github.com/dpkp/kafka-python/issues/1810. A really simple sanity check for the two methods (I guess it's also a sanity check for `subscribe()` as well)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1829)
<!-- Reviewable:end -->
