### PR TITLE
Allow the coordinator to auto-commit for api_version==0.8.1

### DIFF
--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -256,7 +256,7 @@ class ConsumerCoordinator(BaseCoordinator):
         ensures that the consumer has joined the group. This also handles
         periodic offset commits if they are enabled.
         """
-        if self.group_id is None or self.config['api_version'] < (0, 8, 2):
+        if self.group_id is None:
             return
 
         self._invoke_completed_offset_commit_callbacks()


### PR DESCRIPTION
Raised once in [https://github.com/dpkp/kafka-python/issues/1594](https://github.com/dpkp/kafka-python/issues/1594)

We're using `api_version=(0, 8, 1)` and `enable_auto_commit=True`. This had worked in `kafka-python==1.3.5` but fails now in `kafka-python==1.4.6`.

In 1.3.5 even though the documentation suggested that commits to ZooKeeper is not supported, we could see the commit reflected upon inspection with zkCli.

In 1.4.6 though, `KafkaConsumer` just doesn't function with the above configuration; because the early exit in `ConsumerCoordinator.poll()` prevents the coordinator from updating `next_auto_commit_deadline`. This stale value, in turn, causes `KafkaConsumer._message_generator()` to preempt the iteration of `self._fetcher` until `consumer_timeout` is reached.

If we allow for 0.8.1 in `ConsumerCoordinator.poll()`, then everything seems fine. Messages are yielded, and commits are written to ZK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1832)
<!-- Reviewable:end -->
