### PR TITLE
Update KafkaAdminClient Docs

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -91,7 +91,8 @@ class KafkaAdminClient(object):
             partition leadership changes to proactively discover any new
             brokers or partitions. Default: 300000
         security_protocol (str): Protocol used to communicate with brokers.
-            Valid values are: PLAINTEXT, SSL. Default: PLAINTEXT.
+            Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
+            Default: PLAINTEXT.
         ssl_context (ssl.SSLContext): Pre-configured SSLContext for wrapping
             socket connections. If provided, all other ssl_* configurations
             will be ignored. Default: None.


### PR DESCRIPTION
Updated to include SASL_PLAINTEXT and SASL_SSL as options for security_protocol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1849)
<!-- Reviewable:end -->
