### PR TITLE
Fix conn lock release for gssapi/oauth

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -704,6 +704,9 @@ class BrokerConnection(object):
             error = Errors.KafkaConnectionError("%s: %s" % (self, e))
             self.close(error=error)
             return future.failure(error)
+        except Exception:
+            self._lock.release()
+            raise
 
         self._lock.release()
 

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -624,6 +624,7 @@ class BrokerConnection(object):
 
         self._lock.acquire()
         if not self._can_send_recv():
+            self._lock.release()
             return future.failure(Errors.NodeNotReadyError(str(self)))
         # Establish security context and negotiate protection level
         # For reference RFC 2222, section 7.2.1
@@ -687,6 +688,7 @@ class BrokerConnection(object):
         size = Int32.encode(len(msg))
         self._lock.acquire()
         if not self._can_send_recv():
+            self._lock.release()
             return future.failure(Errors.NodeNotReadyError(str(self)))
         try:
             # Send SASL OAuthBearer request with OAuth token


### PR DESCRIPTION
Simplified version of #1851 -- avoiding RLock due to concern of deadlock / client lock contention in close().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1854)
<!-- Reviewable:end -->
