### PR TITLE
Fix describe config for multi-broker clusters

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -826,7 +826,7 @@ class KafkaAdminClient(object):
         self._wait_for_futures(futures)
 
         # Use one of the results as the general response and add all other resources to it
-        response = copy.copy(futures[0])
+        response = copy.copy(futures[0].value)
         response.resources = []
 
         for future in futures:

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -820,19 +820,10 @@ class KafkaAdminClient(object):
                 ))
         else:
             raise NotImplementedError(
-                "Support for DescribeConfigs v{} has not yet been added to KafkaAdminClient."
-                    .format(version))
+                "Support for DescribeConfigs v{} has not yet been added to KafkaAdminClient.".format(version))
 
         self._wait_for_futures(futures)
-
-        # Use one of the results as the general response and add all other resources to it
-        response = copy.copy(futures[0].value)
-        response.resources = []
-
-        for future in futures:
-            response.resources.extend(future.value.resources)
-
-        return response
+        return [f.value for f in futures]
 
     @staticmethod
     def _convert_alter_config_resource_request(config_resource):

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -5,6 +5,7 @@ import copy
 import logging
 import socket
 
+from . import ConfigResourceType
 from kafka.vendor import six
 
 from kafka.client_async import KafkaClient, selectors
@@ -763,28 +764,74 @@ class KafkaAdminClient(object):
             supported by all versions. Default: False.
         :return: Appropriate version of DescribeConfigsResponse class.
         """
+
+        # Break up requests by type - a broker config request must be sent to the specific broker.
+        # All other (currently just topic resources) can be sent to any broker.
+        broker_resources = []
+        topic_resources = []
+
+        for config_resource in config_resources:
+            if config_resource.resource_type == ConfigResourceType.BROKER:
+                broker_resources.append(self._convert_describe_config_resource_request(config_resource))
+            else:
+                topic_resources.append(self._convert_describe_config_resource_request(config_resource))
+
+        futures = []
         version = self._matching_api_version(DescribeConfigsRequest)
         if version == 0:
             if include_synonyms:
                 raise IncompatibleBrokerVersion(
                     "include_synonyms requires DescribeConfigsRequest >= v1, which is not supported by Kafka {}."
-                    .format(self.config['api_version']))
-            request = DescribeConfigsRequest[version](
-                resources=[self._convert_describe_config_resource_request(config_resource) for config_resource in config_resources]
-            )
+                        .format(self.config['api_version']))
+
+            if len(broker_resources) > 0:
+                for broker_resource in broker_resources:
+                    try:
+                        futures.append(self._send_request_to_node(
+                            int(broker_resource[1]),
+                            DescribeConfigsRequest[version](resources=[broker_resource])
+                        ))
+                    except ValueError:
+                        raise ValueError("Broker resource names must be an integer or a string represented integer")
+
+            if len(topic_resources) > 0:
+                futures.append(self._send_request_to_node(
+                    self._client.least_loaded_node(),
+                    DescribeConfigsRequest[version](resources=topic_resources)
+                ))
+
         elif version == 1:
-            request = DescribeConfigsRequest[version](
-                resources=[self._convert_describe_config_resource_request(config_resource) for config_resource in config_resources],
-                include_synonyms=include_synonyms
-            )
+            if len(broker_resources) > 0:
+                for broker_resource in broker_resources:
+                    try:
+                        futures.append(self._send_request_to_node(
+                            int(broker_resource[1]),
+                            DescribeConfigsRequest[version](
+                                resources=[broker_resource],
+                                include_synonyms=include_synonyms)
+                        ))
+                    except ValueError:
+                        raise ValueError("Broker resource names must be an integer or a string represented integer")
+
+            if len(topic_resources) > 0:
+                futures.append(self._send_request_to_node(
+                    self._client.least_loaded_node(),
+                    DescribeConfigsRequest[version](resources=topic_resources, include_synonyms=include_synonyms)
+                ))
         else:
             raise NotImplementedError(
                 "Support for DescribeConfigs v{} has not yet been added to KafkaAdminClient."
-                .format(version))
-        future = self._send_request_to_node(self._client.least_loaded_node(), request)
+                    .format(version))
 
-        self._wait_for_futures([future])
-        response = future.value
+        self._wait_for_futures(futures)
+
+        # Use one of the results as the general response and add all other resources to it
+        response = copy.copy(futures[0])
+        response.resources = []
+
+        for future in futures:
+            response.resources.extend(future.value.resources)
+
         return response
 
     @staticmethod

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -787,12 +787,14 @@ class KafkaAdminClient(object):
             if len(broker_resources) > 0:
                 for broker_resource in broker_resources:
                     try:
-                        futures.append(self._send_request_to_node(
-                            int(broker_resource[1]),
-                            DescribeConfigsRequest[version](resources=[broker_resource])
-                        ))
+                        broker_id = int(broker_resource[1])
                     except ValueError:
                         raise ValueError("Broker resource names must be an integer or a string represented integer")
+
+                    futures.append(self._send_request_to_node(
+                        broker_id,
+                        DescribeConfigsRequest[version](resources=[broker_resource])
+                    ))
 
             if len(topic_resources) > 0:
                 futures.append(self._send_request_to_node(
@@ -804,14 +806,16 @@ class KafkaAdminClient(object):
             if len(broker_resources) > 0:
                 for broker_resource in broker_resources:
                     try:
-                        futures.append(self._send_request_to_node(
-                            int(broker_resource[1]),
-                            DescribeConfigsRequest[version](
-                                resources=[broker_resource],
-                                include_synonyms=include_synonyms)
-                        ))
+                        broker_id = int(broker_resource[1])
                     except ValueError:
                         raise ValueError("Broker resource names must be an integer or a string represented integer")
+
+                    futures.append(self._send_request_to_node(
+                        broker_id,
+                        DescribeConfigsRequest[version](
+                            resources=[broker_resource],
+                            include_synonyms=include_synonyms)
+                    ))
 
             if len(topic_resources) > 0:
                 futures.append(self._send_request_to_node(

--- a/test/test_admin_integration.py
+++ b/test/test_admin_integration.py
@@ -97,7 +97,7 @@ def test_describe_configs_broker_resource_returns_configs(kafka_admin_client):
 
 
 @pytest.mark.skipif(env_kafka_version() < (0, 11), reason="Describe config features require broker >=0.11")
-def test_describe_configs_topic_resource_returns_configs(kafka_admin_client, topic):
+def test_describe_configs_topic_resource_returns_configs(topic, kafka_admin_client):
     """Tests that describe config returns configs for topic
     """
     configs = kafka_admin_client.describe_configs([ConfigResource(ConfigResourceType.TOPIC, topic)])
@@ -109,7 +109,7 @@ def test_describe_configs_topic_resource_returns_configs(kafka_admin_client, top
 
 
 @pytest.mark.skipif(env_kafka_version() < (0, 11), reason="Describe config features require broker >=0.11")
-def test_describe_configs_mixed_resources_returns_configs(kafka_admin_client, topic):
+def test_describe_configs_mixed_resources_returns_configs(topic, kafka_admin_client):
     """Tests that describe config returns configs for mixed resource types (topic + broker)
     """
     broker_id = kafka_admin_client._client.cluster._brokers[0].nodeId


### PR DESCRIPTION
Currently all describe config requests are sent to "least loaded node". Requests for broker configs must, however, be sent to the specific broker, otherwise an error is returned. Only topic requests can be handled by any node.

This changes the logic to send all describe config requests to the specific broker.

Same should be done for alter configs (there is already a comment stating this should be done - I'll be happy to send a PR for this soon'ish).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1869)
<!-- Reviewable:end -->
