### PR TITLE
Wrap consumer.poll() for KafkaConsumer iteration

### DIFF
--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -321,10 +321,14 @@ class BaseCoordinator(object):
                 self.heartbeat.poll()
 
     def time_to_next_heartbeat(self):
+        """Returns seconds (float) remaining before next heartbeat should be sent
+
+        Note: Returns infinite if group is not joined
+        """
         with self._lock:
             # if we have not joined the group, we don't need to send heartbeats
             if self.state is MemberState.UNJOINED:
-                return sys.maxsize
+                return float('inf')
             return self.heartbeat.time_to_next_heartbeat()
 
     def _handle_join_success(self, member_assignment_bytes):


### PR DESCRIPTION
Now that heartbeats have been moved to a background thread, the pythonic iterator can just wrap `consumer.poll()` and no longer needs to worry about breaking from iteration to support sending background requests. With this approach, some consumers may need to tweak `max_poll_records` and/or `max_poll_interval_ms`, such that consumer's average per-record processing time * max_poll_records < max_poll_interval_ms. Defaults remain at 500 max_poll_records and 5mins for max_poll_interval. This should be sufficient for the vast majority of consumers.

My local testing suggests that this change fixes consumer performance issues reported in #1888 .

Given the reduction in overall complexity, this change may also improve #1672 (though won't completely fix).

Because this is a relatively significant change to internals, I have added a configuration option to allow reverting back to the <= 1.4.6 iterator logic:
```
consumer = KafkaConsumer(bootstrap_servers=[...], legacy_iterator=True, ...)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1902)
<!-- Reviewable:end -->
