### PR TITLE
kafka-python: Fixed crc32c availability on non-intel architectures.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,5 +12,5 @@ pylint==1.9.3
 pytest-pylint==0.12.3
 pytest-mock==1.10.0
 sphinx-rtd-theme==0.2.4
-crc32c==1.5
+crc32c==1.7
 py==1.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
 commands =
     py.test {posargs:--pylint --pylint-rcfile=pylint.rc --pylint-error-types=EF --cov=kafka --cov-config=.covrc}
 setenv =
+    CRC32C_SW_MODE = auto
     PROJECT_ROOT = {toxinidir}
 passenv = KAFKA_VERSION
 


### PR DESCRIPTION
requirements-dev.txt: The crc32c version mentioned in this file is 1.5, which fails to compile on non-intel archs. Refer https://github.com/ICRAR/crc32c/issues/6 . It has been fixed since version 1.6.

tox.ini: As mentioned in crc32c github page https://github.com/ICRAR/crc32c , all non-intel architectures have to use the software implementation of it since the hardware its specific to isn't available on non-intel archs. So, to successfully run the test cases, we need to set the environment variable `CRC32C_SW_MODE = auto` .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1904)
<!-- Reviewable:end -->
