### PR TITLE
Rely on socket selector to detect completed connection attempts

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -267,9 +267,9 @@ class KafkaClient(object):
                 if node_id not in self._connecting:
                     self._connecting.add(node_id)
                 try:
-                    self._selector.register(sock, selectors.EVENT_WRITE)
+                    self._selector.register(sock, selectors.EVENT_WRITE, conn)
                 except KeyError:
-                    self._selector.modify(sock, selectors.EVENT_WRITE)
+                    self._selector.modify(sock, selectors.EVENT_WRITE, conn)
 
                 if self.cluster.is_bootstrap(node_id):
                     self._last_bootstrap = time.time()
@@ -624,6 +624,9 @@ class KafkaClient(object):
                 self._clear_wake_fd()
                 continue
             elif not (events & selectors.EVENT_READ):
+                conn = key.data
+                if conn.node_id in self._connecting:
+                    self._maybe_connect(conn.node_id)
                 continue
             conn = key.data
             processed.add(conn)

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -623,10 +623,11 @@ class KafkaClient(object):
             if key.fileobj is self._wake_r:
                 self._clear_wake_fd()
                 continue
-            elif not (events & selectors.EVENT_READ):
+            if events & selectors.EVENT_WRITE:
                 conn = key.data
-                if conn.node_id in self._connecting:
-                    self._maybe_connect(conn.node_id)
+                if conn.connecting():
+                    conn.connect()
+            if not (events & selectors.EVENT_READ):
                 continue
             conn = key.data
             processed.add(conn)

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -769,16 +769,16 @@ class BrokerConnection(object):
         """
         Return the number of milliseconds to wait, based on the connection
         state, before attempting to send data. When disconnected, this respects
-        the reconnect backoff time. When connecting, returns 0 to allow
-        non-blocking connect to finish. When connected, returns a very large
-        number to handle slow/stalled connections.
+        the reconnect backoff time. When connecting or connected, returns a very
+        large number to handle slow/stalled connections.
         """
         time_waited = time.time() - (self.last_attempt or 0)
         if self.state is ConnectionStates.DISCONNECTED:
             return max(self._reconnect_backoff - time_waited, 0) * 1000
-        elif self.connecting():
-            return 0
         else:
+            # When connecting or connected, we should be able to delay
+            # indefinitely since other events (connection or data acked) will
+            # cause a wakeup once data can be sent.
             return float('inf')
 
     def connected(self):

--- a/kafka/producer/sender.py
+++ b/kafka/producer/sender.py
@@ -157,7 +157,7 @@ class Sender(threading.Thread):
         # difference between now and its linger expiry time; otherwise the
         # select time will be the time difference between now and the
         # metadata expiry time
-        self._client.poll(poll_timeout_ms)
+        self._client.poll(timeout_ms=poll_timeout_ms)
 
     def initiate_close(self):
         """Start closing the sender (won't complete until all data is sent)."""

--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -94,7 +94,7 @@ def test_conn_state_change(mocker, cli, conn):
     sock = conn._sock
     cli._conn_state_change(node_id, sock, conn)
     assert node_id in cli._connecting
-    sel.register.assert_called_with(sock, selectors.EVENT_WRITE)
+    sel.register.assert_called_with(sock, selectors.EVENT_WRITE, conn)
 
     conn.state = ConnectionStates.CONNECTED
     cli._conn_state_change(node_id, sock, conn)

--- a/test/test_conn.py
+++ b/test/test_conn.py
@@ -85,7 +85,7 @@ def test_connection_delay(conn):
         conn.last_attempt = 1000
         assert conn.connection_delay() == conn.config['reconnect_backoff_ms']
         conn.state = ConnectionStates.CONNECTING
-        assert conn.connection_delay() == 0
+        assert conn.connection_delay() == float('inf')
         conn.state = ConnectionStates.CONNECTED
         assert conn.connection_delay() == float('inf')
 


### PR DESCRIPTION
Fix for #1907 - Since we are registering connecting sockets in the selector to wake on EVENT_WRITE, we should not need to set any timeout to handle connecting. This is how the java client works, and makes more sense for kafka-python as we continue to improve the networking model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1909)
<!-- Reviewable:end -->
