### PR TITLE
Do not use wakeup when sending fetch requests from consumer

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -123,7 +123,7 @@ class Fetcher(six.Iterator):
         for node_id, request in six.iteritems(self._create_fetch_requests()):
             if self._client.ready(node_id):
                 log.debug("Sending FetchRequest to node %s", node_id)
-                future = self._client.send(node_id, request)
+                future = self._client.send(node_id, request, wakeup=False)
                 future.add_callback(self._handle_fetch_response, request, time.time())
                 future.add_errback(log.error, 'Fetch to node %s failed: %s', node_id)
                 futures.append(future)

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -81,7 +81,7 @@ def test_send_fetches(fetcher, topic, mocker):
 
     ret = fetcher.send_fetches()
     for node, request in enumerate(fetch_requests):
-        fetcher._client.send.assert_any_call(node, request)
+        fetcher._client.send.assert_any_call(node, request, wakeup=False)
     assert len(ret) == len(fetch_requests)
 
 


### PR DESCRIPTION
Attempt to improve wakeup socket issues reported in #1837 #1842

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1911)
<!-- Reviewable:end -->
