### PR TITLE
SASL SCRAM support

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -665,11 +665,11 @@ class BrokerConnection(object):
         err = None
         close = False
         with self._lock:
-            if not self._can_send_recv():
-                raise Errors.NodeNotReadyError(str(self))
-
-            # SCRAM authentication as defined in RFC 5802
             try:
+                if not self._can_send_recv():
+                    raise Errors.NodeNotReadyError(str(self))
+
+                # SCRAM authentication as defined in RFC 5802
                 rand = SystemRandom()
                 client_nonce = "".join([rand.choice(string.ascii_letters + string.digits) for i in range(32)])
                 gs2_header = "n,,"
@@ -740,7 +740,6 @@ class BrokerConnection(object):
                     err_msg = "failed to validate server signature"
                     raise Errors.AuthenticationFailedError(err_msg)
             except Errors.NodeNotReadyError as e:
-                log.exception("%s: %s", self, e.message)
                 err = e
                 close = False
             except Errors.AuthenticationFailedError as e:


### PR DESCRIPTION
It looks like someone beat me to a pull request by a few hours, but I thought I'd submit this in case this code is useful.

I've used against Kafka 2.2.1 and 2.3.0 with Python 2.7.15 and 3.6.8. I've only used security mechanism of SCRAM-SHA-512 (not SCRAM-SHA-256). I've tried it with security protocols of SASL_PLAINTEXT and SASL_SSL.

The code re-uses sasl_plain_username and sasl_plain_password. That makes these names a little inaccurate, but having separate sasl_scram_username and sasl_scram_password didn’t seem like a great option, either. Another option would be to introduce sasl_username and sasl_password that both mechanisms use and deprecate sasl_plain_*

I didn’t follow the exact style of conn._try_authentiate_plain and conn._try_authenticate_gssapi because there are more errors that can occur. I relied on exceptions more than in those functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1920)
<!-- Reviewable:end -->
