### PR TITLE
Fix doc import paths

### DIFF
--- a/docs/apidoc/KafkaAdminClient.rst
+++ b/docs/apidoc/KafkaAdminClient.rst
@@ -1,5 +1,5 @@
 KafkaAdminClient
 ===========
 
-.. autoclass:: kafka.admin.KafkaAdminClient
+.. autoclass:: kafka.KafkaAdminClient
     :members:

--- a/docs/apidoc/KafkaClient.rst
+++ b/docs/apidoc/KafkaClient.rst
@@ -1,5 +1,5 @@
 KafkaClient
 ===========
 
-.. autoclass:: kafka.client.KafkaClient
+.. autoclass:: kafka.KafkaClient
     :members:


### PR DESCRIPTION
Since `SimpleClient` was deleted, the new `KafkaClient` currently resides at `kafka.client_async.KafkaClient`... that may get updated in the future, so instead just import the `KafkaClient` from the top-level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1933)
<!-- Reviewable:end -->
