### PR TITLE
Fixes KafkaAdminClient returning `IncompatibleBrokerVersion` when passing an `api_version`

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -233,6 +233,7 @@ class KafkaAdminClient(object):
         :param operation: A list of protocol operation versions from kafka.protocol.
         :return: The max matching version number between client and broker.
         """
+        self._client.check_version()
         broker_api_versions = self._client.get_api_versions()
         api_key = operation[0].API_KEY
         if broker_api_versions is None or api_key not in broker_api_versions:

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -203,6 +203,7 @@ class KafkaAdminClient(object):
         self._client = KafkaClient(metrics=self._metrics,
                                    metric_group_prefix='admin',
                                    **self.config)
+        self._client.check_version()
 
         # Get auto-discovered version from client if necessary
         if self.config['api_version'] is None:
@@ -233,7 +234,6 @@ class KafkaAdminClient(object):
         :param operation: A list of protocol operation versions from kafka.protocol.
         :return: The max matching version number between client and broker.
         """
-        self._client.check_version()
         broker_api_versions = self._client.get_api_versions()
         api_key = operation[0].API_KEY
         if broker_api_versions is None or api_key not in broker_api_versions:


### PR DESCRIPTION
**What does this PR do?**

Fixes KafkaAdminClient always returning `IncompatibleBrokerVersion` when passing an `api_version`.
This will calls `check_version()` on init before `get_api_versions()` get called by `_matching_api_version`.

---

Passing an `api_version` to `KafkaAdminClient` seem to always raise `IncompatibleBrokerVersion` line 240

Found that this is because `broker_api_versions = self._client.get_api_versions()` always returns None apparently because `check_version()` had not been called previously.

Per the note from `get_api_versions()`,
> A call to check_version must previously have succeeded and returned

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1953)
<!-- Reviewable:end -->
