### PR TITLE
Do not block on sender thread join after timeout in producer.close()

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -444,7 +444,7 @@ class KafkaProducer(object):
         self._cleanup = None
 
     def __del__(self):
-        self.close(timeout=0)
+        self.close()
 
     def close(self, timeout=None):
         """Close this producer.

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -483,14 +483,10 @@ class KafkaProducer(object):
                     self._sender.join(timeout)
 
         if self._sender is not None and self._sender.is_alive():
-
             log.info("Proceeding to force close the producer since pending"
                      " requests could not be completed within timeout %s.",
                      timeout)
             self._sender.force_close()
-            # Only join the sender thread when not calling from callback.
-            if not invoked_from_callback:
-                self._sender.join()
 
         self._metrics.close()
         try:


### PR DESCRIPTION
Fix for #1931 -- python3.7 deadlock in logging producer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1974)
<!-- Reviewable:end -->
