### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/test/test_coordinator.py
+++ b/test/test_coordinator.py
@@ -55,7 +55,7 @@ def test_autocommit_enable_api_version(client, api_version):
 
 
 def test_protocol_type(coordinator):
-    assert coordinator.protocol_type() is 'consumer'
+    assert coordinator.protocol_type() == 'consumer'
 
 
 def test_group_protocols(coordinator):


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise __SyntaxWarnings__ so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

% __python__
```
>>> consumer = "cons"
>>> consumer += "umer"
>>> consumer == "consumer"
True
>>> consumer is "consumer"
False
>>> 0 == 0.0
True
>>> 0 is 0.0
False
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1984)
<!-- Reviewable:end -->
