### PR TITLE
Fix benchmarks to use pyperf

### DIFF
--- a/benchmarks/README
+++ b/benchmarks/README
@@ -1,4 +1,4 @@
 The `record_batch_*` benchmarks in this section are written using
-``perf`` library, created by Viktor Stinner. For more information on how to get
-reliable results of test runs please consult
-https://perf.readthedocs.io/en/latest/run_benchmark.html.
+``pyperf`` library, created by Victor Stinner. For more information on
+how to get reliable results of test runs please consult
+https://pyperf.readthedocs.io/en/latest/run_benchmark.html.

--- a/benchmarks/record_batch_compose.py
+++ b/benchmarks/record_batch_compose.py
@@ -5,7 +5,7 @@ import itertools
 import os
 import random
 
-import perf
+import pyperf
 
 from kafka.record.memory_records import MemoryRecordsBuilder
 
@@ -52,7 +52,7 @@ def func(loops, magic):
     results = []
 
     # Main benchmark code.
-    t0 = perf.perf_counter()
+    t0 = pyperf.perf_counter()
     for _ in range(loops):
         batch = MemoryRecordsBuilder(
             magic, batch_size=DEFAULT_BATCH_SIZE, compression_type=0)
@@ -64,14 +64,14 @@ def func(loops, magic):
         batch.close()
         results.append(batch.buffer())
 
-    res = perf.perf_counter() - t0
+    res = pyperf.perf_counter() - t0
 
     finalize(results)
 
     return res
 
 
-runner = perf.Runner()
+runner = pyperf.Runner()
 runner.bench_time_func('batch_append_v0', func, 0)
 runner.bench_time_func('batch_append_v1', func, 1)
 runner.bench_time_func('batch_append_v2', func, 2)

--- a/benchmarks/record_batch_read.py
+++ b/benchmarks/record_batch_read.py
@@ -5,7 +5,7 @@ import itertools
 import os
 import random
 
-import perf
+import pyperf
 
 from kafka.record.memory_records import MemoryRecords, MemoryRecordsBuilder
 
@@ -61,7 +61,7 @@ def func(loops, magic):
 
     # Main benchmark code.
     batch_data = next(precomputed_samples)
-    t0 = perf.perf_counter()
+    t0 = pyperf.perf_counter()
     for _ in range(loops):
         records = MemoryRecords(batch_data)
         while records.has_next():
@@ -70,13 +70,13 @@ def func(loops, magic):
             for record in batch:
                 results.append(record.value)
 
-    res = perf.perf_counter() - t0
+    res = pyperf.perf_counter() - t0
     finalize(results)
 
     return res
 
 
-runner = perf.Runner()
+runner = pyperf.Runner()
 runner.bench_time_func('batch_read_v0', func, 0)
 runner.bench_time_func('batch_read_v1', func, 1)
 runner.bench_time_func('batch_read_v2', func, 2)

--- a/benchmarks/varint_speed.py
+++ b/benchmarks/varint_speed.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
-import perf
+import pyperf
 from kafka.vendor import six
 
 
@@ -398,7 +398,7 @@ _assert_valid_dec(decode_varint_3)
 # import dis
 # dis.dis(decode_varint_3)
 
-runner = perf.Runner()
+runner = pyperf.Runner()
 # Encode algorithms returning a bytes result
 for bench_func in [
         encode_varint_1,


### PR DESCRIPTION
I suppose perf is renamed to pyperf now. Update benchmarks to reflect this change.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1986)
<!-- Reviewable:end -->
