### PR TITLE
Fix slots usage and use more slots

### DIFF
--- a/kafka/record/abc.py
+++ b/kafka/record/abc.py
@@ -4,6 +4,7 @@ import abc
 
 class ABCRecord(object):
     __metaclass__ = abc.ABCMeta
+    __slots__ = ()
 
     @abc.abstractproperty
     def offset(self):
@@ -45,6 +46,7 @@ class ABCRecord(object):
 
 class ABCRecordBatchBuilder(object):
     __metaclass__ = abc.ABCMeta
+    __slots__ = ()
 
     @abc.abstractmethod
     def append(self, offset, timestamp, key, value, headers=None):
@@ -87,6 +89,7 @@ class ABCRecordBatch(object):
         compressed) message.
     """
     __metaclass__ = abc.ABCMeta
+    __slots__ = ()
 
     @abc.abstractmethod
     def __iter__(self):
@@ -97,6 +100,7 @@ class ABCRecordBatch(object):
 
 class ABCRecords(object):
     __metaclass__ = abc.ABCMeta
+    __slots__ = ()
 
     @abc.abstractmethod
     def __init__(self, buffer):

--- a/kafka/record/default_records.py
+++ b/kafka/record/default_records.py
@@ -70,6 +70,8 @@ import kafka.codec as codecs
 
 class DefaultRecordBase(object):
 
+    __slots__ = ()
+
     HEADER_STRUCT = struct.Struct(
         ">q"  # BaseOffset => Int64
         "i"  # Length => Int32
@@ -115,6 +117,9 @@ class DefaultRecordBase(object):
 
 
 class DefaultRecordBatch(DefaultRecordBase, ABCRecordBatch):
+
+    __slots__ = ("_buffer", "_header_data", "_pos", "_num_records",
+                 "_next_record_index", "_decompressed")
 
     def __init__(self, buffer):
         self._buffer = bytearray(buffer)
@@ -357,6 +362,11 @@ class DefaultRecordBatchBuilder(DefaultRecordBase, ABCRecordBatchBuilder):
     # excluding key, value and headers:
     # 5 bytes length + 10 bytes timestamp + 5 bytes offset + 1 byte attributes
     MAX_RECORD_OVERHEAD = 21
+
+    __slots__ = ("_magic", "_compression_type", "_batch_size", "_is_transactional",
+                 "_producer_id", "_producer_epoch", "_base_sequence",
+                 "_first_timestamp", "_max_timestamp", "_last_offset", "_num_records",
+                 "_buffer")
 
     def __init__(
             self, magic, compression_type, is_transactional,

--- a/kafka/record/legacy_records.py
+++ b/kafka/record/legacy_records.py
@@ -57,6 +57,8 @@ from kafka.errors import CorruptRecordException, UnsupportedCodecError
 
 class LegacyRecordBase(object):
 
+    __slots__ = ()
+
     HEADER_STRUCT_V0 = struct.Struct(
         ">q"  # BaseOffset => Int64
         "i"  # Length => Int32
@@ -126,6 +128,9 @@ class LegacyRecordBase(object):
 
 
 class LegacyRecordBatch(ABCRecordBatch, LegacyRecordBase):
+
+    __slots__ = ("_buffer", "_magic", "_offset", "_crc", "_timestamp",
+                 "_attributes", "_decompressed")
 
     def __init__(self, buffer, magic):
         self._buffer = memoryview(buffer)
@@ -335,6 +340,8 @@ class LegacyRecord(ABCRecord):
 
 
 class LegacyRecordBatchBuilder(ABCRecordBatchBuilder, LegacyRecordBase):
+
+    __slots__ = ("_magic", "_compression_type", "_batch_size", "_buffer")
 
     def __init__(self, magic, compression_type, batch_size):
         self._magic = magic

--- a/kafka/record/memory_records.py
+++ b/kafka/record/memory_records.py
@@ -37,6 +37,8 @@ class MemoryRecords(ABCRecords):
     # Minimum space requirements for Record V0
     MIN_SLICE = LOG_OVERHEAD + LegacyRecordBatch.RECORD_OVERHEAD_V0
 
+    __slots__ = ("_buffer", "_pos", "_next_slice", "_remaining_bytes")
+
     def __init__(self, bytes_data):
         self._buffer = bytes_data
         self._pos = 0
@@ -109,6 +111,9 @@ class MemoryRecords(ABCRecords):
 
 
 class MemoryRecordsBuilder(object):
+
+    __slots__ = ("_builder", "_batch_size", "_buffer", "_next_offset", "_closed",
+                 "_bytes_written")
 
     def __init__(self, magic, compression_type, batch_size):
         assert magic in [0, 1, 2], "Not supported magic"


### PR DESCRIPTION
Use empty slots for ABC classes, otherwise classes which inherit from them will still have `__dict__`. Also use `__slots__` for more classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1987)
<!-- Reviewable:end -->
