### PR TITLE
Default bootstrap servers config to the default if `falsy value`  is provided

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -201,7 +201,11 @@ class KafkaClient(object):
         for key in self.config:
             if key in configs:
                 self.config[key] = configs[key]
-
+        if not self.config['bootstrap_servers']:
+            new_config = self.DEFAULT_CONFIG['bootstrap_servers']
+            log.warning('bootstrap servers config reset to default "%s", "%s" was set',
+                        new_config, self.config['bootstrap_servers'])
+            self.config['bootstrap_servers'] = new_config
         self.cluster = ClusterMetadata(**self.config)
         self._topics = set()  # empty set will fetch all topic metadata
         self._metadata_refresh_in_progress = False

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -1481,9 +1481,13 @@ def collect_hosts(hosts, randomize=True):
         hosts = hosts.strip().split(',')
 
     result = []
+    if not hosts:
+        return result
+        
     afi = socket.AF_INET
     for host_port in hosts:
-
+        if not host_port:
+            continue
         host, port, afi = get_ip_port_afi(host_port)
 
         if port < 0:

--- a/test/test_conn.py
+++ b/test/test_conn.py
@@ -221,6 +221,41 @@ def test_collect_hosts__happy_path():
     ])
 
 
+def test_collect_hosts__from_iterable():
+    hosts = ['127.0.0.1:1234', '127.0.0.1']
+    results = collect_hosts(hosts)
+    assert set(results) == set([
+        ('127.0.0.1', 1234, socket.AF_INET),
+        ('127.0.0.1', 9092, socket.AF_INET),
+    ])
+
+
+def test_collect_hosts__invalid_iterable():
+    hosts = ['127.0.0.1:1234', None]
+    results = collect_hosts(hosts)
+    assert set(results) == set([
+        ('127.0.0.1', 1234, socket.AF_INET)
+    ])
+
+
+def test_collect_hosts__invalid_hosts():
+    hosts = None
+    results = collect_hosts(hosts)
+    assert set(results) == set()
+
+
+def test_collect_hosts__empty_hosts_string():
+    hosts = ',,,,'
+    results = collect_hosts(hosts)
+    assert set(results) == set()
+
+
+def test_collect_hosts__empty_hosts_iterable():
+    hosts = ['', '', '']
+    results = collect_hosts(hosts)
+    assert set(results) == set()
+
+
 def test_collect_hosts__ipv6():
     hosts = "[localhost]:1234,[2001:1000:2000::1],[2001:1000:2000::1]:1234"
     results = collect_hosts(hosts)


### PR DESCRIPTION
## What does this PR do?

Fixes KafkaClient failing when a `falsy` value is passed in the config for the bootstrap server.
This will default the bootstrap server value to the value from the default config dictionary when a `falsy` value is passed

Passing a `falsy` value return the error 
```
producer = KafkaProducer(bootstrap_servers=None)
File "/opt/ns/nsenv/lib/python2.7/site-packages/kafka/consumer/group.py", line 355, in __init__
    self._client = KafkaClient(metrics=self._metrics, **self.config)
  File "/opt/ns/nsenv/lib/python2.7/site-packages/kafka/client_async.py", line 205, in __init__
    self.cluster = ClusterMetadata(**self.config)
  File "/opt/ns/nsenv/lib/python2.7/site-packages/kafka/cluster.py", line 67, in __init__
    self._bootstrap_brokers = self._generate_bootstrap_brokers()
  File "/opt/ns/nsenv/lib/python2.7/site-packages/kafka/cluster.py", line 72, in _generate_bootstrap_brokers
    bootstrap_hosts = collect_hosts(self.config['bootstrap_servers'])
  File "/opt/ns/nsenv/lib/python2.7/site-packages/kafka/conn.py", line 1485, in collect_hosts
    for host_port in hosts:
TypeError: 'NoneType' object is not iterable
Exception ignored in: <function KafkaClient.__del__ at 0x104330b70>
Traceback (most recent call last):
  File "/opt/ns/nsenv/lib/python2.7/site-packages/kafka/client_async.py", line 441, in __del__
    self._close()
  File "/opt/ns/nsenv/lib/python2.7/site-packages/kafka/client_async.py", line 415, in _close
    if not self._closed:
AttributeError: 'KafkaClient' object has no attribute '_closed'
```
Found that this is because collect_hosts function doesn't check when the host list is empty so the iterator fails with a `TypeError`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/1991)
<!-- Reviewable:end -->
