### PR TITLE
Add Envy functionality

### DIFF
--- a/.envyfile
+++ b/.envyfile
@@ -1,0 +1,30 @@
+environment:
+  base:
+    image: python:3.7.3
+  system-packages:
+    - recipe: python-dev
+    - recipe: libsnappy-dev
+  setup-steps:
+    - name: python-deps
+      label: "Installing python dependencies"
+      type: script
+      as_user: false
+      run:
+        - "pip install -r requirements-dev.txt"
+        - "pip install -Ue ."
+      triggers:
+        files:
+          - requirements-dev.txt
+actions:
+  - name: test37
+    script: 'make test37'
+    help: 'Lint and run tests with Python 3.7'
+  - name: test27
+    script: 'make test27'
+    help: 'Lint and run tests with Python 2.7'
+  - name: gen-docs
+    script: 'make doc'
+    help: 'Run Sphinx to generate documentation'
+  - name: check-readme
+    script: 'make check-readme'
+    help: 'Check for syntax errors in README'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 *.pyc
 .tox
+.envy
 build
 dist
 MANIFEST

--- a/README.rst
+++ b/README.rst
@@ -159,3 +159,9 @@ testing, probing, and general experimentation. The protocol support is
 leveraged to enable a KafkaClient.check_version() method that
 probes a kafka broker and attempts to identify which version it is running
 (0.8.0 to 2.4+).
+
+Contributing
+************
+To get up and running quickly, you can use the [ENVy](http://envy-project.github.io/) environment
+manager to get your environment set up quickly. Simply run `envy up` and you should be ready to go
+with development.


### PR DESCRIPTION
Hello!
​
We (@magmastonealex, @omstrumpf, @gbateman, @Tim-Willard) have been working on a tool called ENVy.
​
ENVy is an environment manager to make working on disparate projects easier. You don't need to worry about what a system package is called on your Linux distribution, or figure out how to build for Mac from scratch.
​
Setup with ENVy is as simple as typing `envy up` for any project you want to work on. Running `envy nuke` removes all traces of that environment.
With ENVy, you don't need to hunt down a lint command or how you run the tests. `envy -h` shows you all the commands you can run - or just jump into a shell with `envy shell`.
​
You can read more about ENVy [here](http://envy-project.github.io/), but the short version is that we think it'll make it easier for contributors to help out. 
​
This PR adds an `ENVyfile`, the file that describes a development environment and contains the commands to run. This should help manage the two python versions that kafka-python supports, without requiring the contributor to install both on their host machine. We used kafka-python while developing in order to test ENVy, and we hoped you'd consider committing this file to help out casual contributors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2007)
<!-- Reviewable:end -->
