### PR TITLE
producer/kafka: Disable logging during object destruction

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -445,6 +445,14 @@ class KafkaProducer(object):
         self._cleanup = None
 
     def __del__(self):
+        # Disable logger during destruction to avoid touching dangling references
+        class NullLogger(object):
+            def __getattr__(self, name):
+                return lambda *args: None
+
+        global log
+        log = NullLogger()
+
         self.close()
 
     def close(self, timeout=None):


### PR DESCRIPTION
Logging in an object destructor leads to crashes like the following

```
Exception ignored in: <bound method KafkaProducer.__del__ of 
    <kafka.producer.kafka.KafkaProducer object at 0x7f0c47309b38>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/kafka/producer/kafka.py", line 447, in __del__
  File "/usr/local/lib/python3.6/site-packages/kafka/producer/kafka.py", line 460, in close
  File "/usr/local/lib/python3.6/logging/__init__.py", line 1305, in info
  File "/usr/local/lib/python3.6/logging/__init__.py", line 1546, in isEnabledFor
TypeError: '>=' not supported between instances of 'int' and 'NoneType'
```

In closing PR #1445, @dpkp made it clear that producers should be closed while they are being destructed.

This commit does not modify the existing architecture and code structure, and preserves all the logging calls in `close`. At the same time, by "nullifying" the logger, it fixes the crash that is inherent in the use of logging methods during the destruction of an object.

Fixes #1218.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2043)
<!-- Reviewable:end -->
