### PR TITLE
remove unused imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division
 
 import collections
 import copy
-import functools
 import logging
 import random
 import socket

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division
 import abc
 import copy
 import logging
-import sys
 import threading
 import time
 import weakref

--- a/kafka/scram.py
+++ b/kafka/scram.py
@@ -71,7 +71,6 @@ class ScramClient:
         )
 
     def final_message(self):
-        client_final_no_proof = 'c=biws,r=' + self.nonce
         return 'c=biws,r={},p={}'.format(self.nonce, base64.b64encode(self.client_proof).decode('utf-8'))
 
     def process_server_final_message(self, server_final_message):


### PR DESCRIPTION
Thanks for this great project!

I wanted to take a few minutes and make a small contribution, so I ran `flake8` over this codebase. A lot of the warnings generated are things that should only be done optionally by maintainers (like formatting and whitespace), but I think I found a few non-controversial changes that would be helpful.

In this PR, I'd like to propose removing a few unused imports and one local variable that is created but never used in `ScramClient`.

Thanks for your time and consideration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2046)
<!-- Reviewable:end -->
