### PR TITLE
Handle OSError to properly recycle SSL connection

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -508,7 +508,6 @@ class BrokerConnection(object):
         except (SSLWantReadError, SSLWantWriteError):
             pass
         except (SSLZeroReturnError, ConnectionError, TimeoutError, SSLEOFError, ssl.SSLError, OSError) as e:
-            log.exception(e)
             log.warning('SSL connection closed by server during handshake.')
             self.close(Errors.KafkaConnectionError('SSL connection closed by server during handshake'))
         # Other SSLErrors will be raised to user

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -507,7 +507,7 @@ class BrokerConnection(object):
         # old ssl in python2.6 will swallow all SSLErrors here...
         except (SSLWantReadError, SSLWantWriteError):
             pass
-        except (SSLZeroReturnError, ConnectionError, TimeoutError, SSLEOFError):
+        except (SSLZeroReturnError, ConnectionError, TimeoutError, SSLEOFError, OSError):
             log.warning('SSL connection closed by server during handshake.')
             self.close(Errors.KafkaConnectionError('SSL connection closed by server during handshake'))
         # Other SSLErrors will be raised to user

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -507,7 +507,8 @@ class BrokerConnection(object):
         # old ssl in python2.6 will swallow all SSLErrors here...
         except (SSLWantReadError, SSLWantWriteError):
             pass
-        except (SSLZeroReturnError, ConnectionError, TimeoutError, SSLEOFError, OSError):
+        except (SSLZeroReturnError, ConnectionError, TimeoutError, SSLEOFError, ssl.SSLError, OSError) as e:
+            log.exception(e)
             log.warning('SSL connection closed by server during handshake.')
             self.close(Errors.KafkaConnectionError('SSL connection closed by server during handshake'))
         # Other SSLErrors will be raised to user


### PR DESCRIPTION
Here's a stack trace we had our logs flooded with. 

> [07/15/2020 08:51:14.799: ERROR/kafka.producer.sender] Uncaught error in kafka producer I/O thread
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/kafka/producer/sender.py", line 60, in run
    self.run_once()
  File "/usr/local/lib/python3.6/site-packages/kafka/producer/sender.py", line 160, in run_once
    self._client.poll(timeout_ms=poll_timeout_ms)
  File "/usr/local/lib/python3.6/site-packages/kafka/client_async.py", line 580, in poll
    self._maybe_connect(node_id)
  File "/usr/local/lib/python3.6/site-packages/kafka/client_async.py", line 390, in _maybe_connect
    conn.connect()
  File "/usr/local/lib/python3.6/site-packages/kafka/conn.py", line 426, in connect
    if self._try_handshake():
  File "/usr/local/lib/python3.6/site-packages/kafka/conn.py", line 505, in _try_handshake
    self._sock.do_handshake()
  File "/usr/local/lib/python3.6/ssl.py", line 1077, in do_handshake
    self._sslobj.do_handshake()
  File "/usr/local/lib/python3.6/ssl.py", line 689, in do_handshake
    self._sslobj.do_handshake()
OSError: [Errno 0] Error

The problem is Python 3.6 is returning OSError, which is not expected. Such exception is propagated to the caller and code making recycling of such connection is not executed. Therefore, Producer is guaranteed to get the same exception on a next call to `poll()`.

Throwing of OSError doesn't seem to be documented even in latest Python docs. See [3.8 docs](https://docs.python.org/3.8/library/ssl.html), but there are signs of it in [3.8 source code](https://github.com/python/cpython/blob/3.8/Modules/_ssl.c).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2097)
<!-- Reviewable:end -->
