### PR TITLE
docs: note flush behaviour of producer's .close()

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -450,6 +450,9 @@ class KafkaProducer(object):
     def close(self, timeout=None):
         """Close this producer.
 
+        If a non-zero timeout is passed, this will also attempt to flush the buffer before
+        closing.
+
         Arguments:
             timeout (float, optional): timeout in seconds to wait for completion.
         """


### PR DESCRIPTION
A little note about the flushing behaviour of KafkaProducer.close.

I don't actually know for a fact if this is true, I just assumed it from the code I read. If anyone can double check that would be a good idea :)