### PR TITLE
Add the optional compression libs to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "crc32c": ["crc32c"],
         "lz4": ["lz4"],
         "snappy": ["python-snappy"],
-        "zstandard": ["python-zstandard"],
+        "zstd": ["python-zstandard"],
     },
     cmdclass={"test": Tox},
     packages=find_packages(exclude=['test']),

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,11 @@ setup(
     version=__version__,
 
     tests_require=test_require,
-    extras_require={"crc32c": ["crc32c"]},
+    extras_require={
+        "crc32c": ["crc32c"],
+        "lz4": ["lz4"],
+        "snappy": ["python-snappy"],
+    },
     cmdclass={"test": Tox},
     packages=find_packages(exclude=['test']),
     author="Dana Powers",

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "crc32c": ["crc32c"],
         "lz4": ["lz4"],
         "snappy": ["python-snappy"],
+        "zstandard": ["python-zstandard"],
     },
     cmdclass={"test": Tox},
     packages=find_packages(exclude=['test']),


### PR DESCRIPTION
As noted in https://kafka-python.readthedocs.io/en/master/install.html these are some additional optional libs that we should be specifying in `extras_require` so that callers can specify them if desired.

Fix #2122. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2123)
<!-- Reviewable:end -->
