### PR TITLE
Fix crc32c deprecation warning

### DIFF
--- a/kafka/record/util.py
+++ b/kafka/record/util.py
@@ -2,7 +2,7 @@ import binascii
 
 from kafka.record._crc32c import crc as crc32c_py
 try:
-    from crc32c import crc32 as crc32c_c
+    from crc32c import crc32c as crc32c_c
 except ImportError:
     crc32c_c = None
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,5 +13,5 @@ pylint==2.5.3
 pytest-pylint==0.17.0
 pytest-mock==1.10.0
 sphinx-rtd-theme==0.2.4
-crc32c==1.7
+crc32c==2.1
 py==1.8.0


### PR DESCRIPTION
Fix a deprecation warning in the newest version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2128)
<!-- Reviewable:end -->
