### PR TITLE
consumer: Exit poll if consumer is closed

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -651,7 +651,7 @@ class KafkaConsumer(six.Iterator):
         # Poll for new data until the timeout expires
         start = time.time()
         remaining = timeout_ms
-        while True:
+        while not self._closed:
             records = self._poll_once(remaining, max_records, update_offsets=update_offsets)
             if records:
                 return records
@@ -660,7 +660,9 @@ class KafkaConsumer(six.Iterator):
             remaining = timeout_ms - elapsed_ms
 
             if remaining <= 0:
-                return {}
+                break
+
+        return {}
 
     def _poll_once(self, timeout_ms, max_records, update_offsets=True):
         """Do one round of polling. In addition to checking for new data, this does


### PR DESCRIPTION
Caller may invoke poll with long timeout and then end up closing the
consumer from another thread e.g. to stop the application. Previously
poll forcibly waited for the timeout before existing even though it
could do nothing but spin in busy loop for the remainder of the time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2152)
<!-- Reviewable:end -->
