### PR TITLE
Hotfix: TypeError: object of type 'dict_itemiterator' has no len()

### DIFF
--- a/kafka/protocol/types.py
+++ b/kafka/protocol/types.py
@@ -181,9 +181,10 @@ class Array(AbstractType):
     def encode(self, items):
         if items is None:
             return Int32.encode(-1)
+        encoded_items = [self.array_of.encode(item) for item in items]
         return b''.join(
-            [Int32.encode(len(list(items)))] +
-            [self.array_of.encode(item) for item in items]
+            [Int32.encode(len(encoded_items))] +
+            encoded_items
         )
 
     def decode(self, data):

--- a/kafka/protocol/types.py
+++ b/kafka/protocol/types.py
@@ -182,7 +182,7 @@ class Array(AbstractType):
         if items is None:
             return Int32.encode(-1)
         return b''.join(
-            [Int32.encode(len(items))] +
+            [Int32.encode(len(list(items)))] +
             [self.array_of.encode(item) for item in items]
         )
 


### PR DESCRIPTION
Solution for a TypeError we encountered in release 2.0.2. We migrated from 2.0.1 because of Sticky Assignor support and found the issue (Python 3.8).

```
    data = self.consumer.poll(timeout_ms=self.timeout, max_records=max_records)
  File "/usr/local/lib/python3.8/dist-packages/kafka/consumer/group.py", line 655, in poll
    records = self._poll_once(remaining, max_records, update_offsets=update_offsets)
  File "/usr/local/lib/python3.8/dist-packages/kafka/consumer/group.py", line 675, in _poll_once
    self._coordinator.poll()
  File "/usr/local/lib/python3.8/dist-packages/kafka/coordinator/consumer.py", line 289, in poll
    self.ensure_active_group()
  File "/usr/local/lib/python3.8/dist-packages/kafka/coordinator/base.py", line 390, in ensure_active_group
    future = self._send_join_group_request()
  File "/usr/local/lib/python3.8/dist-packages/kafka/coordinator/base.py", line 453, in _send_join_group_request
    for protocol, metadata in self.group_protocols()
  File "/usr/local/lib/python3.8/dist-packages/kafka/coordinator/consumer.py", line 154, in group_protocols
    metadata = assignor.metadata(self._joined_subscription)
  File "/usr/local/lib/python3.8/dist-packages/kafka/coordinator/assignors/sticky/sticky_assignor.py", line 660, in metadata
    user_data = data.encode()
  File "/usr/local/lib/python3.8/dist-packages/kafka/util.py", line 50, in __call__
    return self.method()(self.target(), *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/kafka/protocol/struct.py", line 42, in _encode_self
    return self.SCHEMA.encode(
  File "/usr/local/lib/python3.8/dist-packages/kafka/protocol/types.py", line 146, in encode
    return b''.join([
  File "/usr/local/lib/python3.8/dist-packages/kafka/protocol/types.py", line 147, in <listcomp>
    field.encode(item[i])
  File "/usr/local/lib/python3.8/dist-packages/kafka/protocol/types.py", line 185, in encode
    [Int32.encode(len(items))] +
TypeError: object of type 'dict_itemiterator' has no len()
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2167)
<!-- Reviewable:end -->
