### PR TITLE
bugfix: race among _connecting and cluster metadata

### DIFF
--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -71,13 +71,8 @@ def test_can_connect(cli, conn):
 
 
 def test_maybe_connect(cli, conn):
-    try:
-        # Node not in metadata, raises AssertionError
-        cli._maybe_connect(2)
-    except AssertionError:
-        pass
-    else:
-        assert False, 'Exception not raised'
+    # Node not in metadata should be ignored
+    cli._maybe_connect(2)
 
     # New node_id creates a conn object
     assert 0 not in cli._conns


### PR DESCRIPTION
Fixes https://github.com/dpkp/kafka-python/issues/2188

A call to `maybe_connect` can be performed while the cluster metadata is
being updated. If that happens, the assumption that every entry in
`_connecting` has metadata won't hold. The existing assert will then
raise on every subsequent call to `poll` driving the client instance
unusable.

This fixes the issue by ignoring connetion request to nodes that do not
have the metadata available anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2189)
<!-- Reviewable:end -->
