### PR TITLE
bugfix: don't allow encoding None in String, Bytes

### DIFF
--- a/kafka/protocol/types.py
+++ b/kafka/protocol/types.py
@@ -96,7 +96,7 @@ class String(AbstractType):
 
     def encode(self, value):
         if value is None:
-            return Int16.encode(-1)
+            raise ValueError("value cannot be None")
         value = str(value).encode(self.encoding)
         return Int16.encode(len(value)) + value
 
@@ -114,7 +114,7 @@ class Bytes(AbstractType):
     @classmethod
     def encode(cls, value):
         if value is None:
-            return Int32.encode(-1)
+            raise ValueError("value cannot be None")
         else:
             return Int32.encode(len(value)) + value
 

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1,0 +1,9 @@
+import pytest
+
+from kafka.protocol.types import Bytes, String
+
+
+@pytest.mark.parametrize("type_obj", [String(), Bytes()])
+def test_none_value_encode(type_obj):
+    with pytest.raises(ValueError):
+        type_obj.encode(None)


### PR DESCRIPTION
This commit makes `String`, `Bytes` method `encode` not allow `None` as input. This aligns it with how Kafka Java library handles this (https://github.com/apache/kafka/blob/57cef765f55fa1b9bab99cf4c71cf40f64533656/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java#L406, https://github.com/apache/kafka/blob/57cef765f55fa1b9bab99cf4c71cf40f64533656/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java#L636).

Please note that `Array` and the compact versions of these types are not altered, since in those cases nullability is valid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2203)
<!-- Reviewable:end -->
