### PR TITLE
Fix typo: veriication -> verification

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -233,7 +233,7 @@ class KafkaProducer(object):
             should verify that the certificate matches the brokers hostname.
             default: true.
         ssl_cafile (str): optional filename of ca file to use in certificate
-            veriication. default: none.
+            verification. default: none.
         ssl_certfile (str): optional filename of file in pem format containing
             the client certificate, as well as any ca certificates needed to
             establish the certificate's authenticity. default: none.


### PR DESCRIPTION
PR for #2200 


This commit fixes typo below: `veriication` -> `verification`.

https://github.com/dpkp/kafka-python/blob/9feeb79140ed10e3a7f2036491fc07573740c231/kafka/producer/kafka.py#L235-L236


Thx to @jeffwidman for providing guidelines for PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2207)
<!-- Reviewable:end -->
