### PR TITLE
Implemented the return type of the send function;

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -15,7 +15,7 @@ from kafka.client_async import KafkaClient, selectors
 from kafka.codec import has_gzip, has_snappy, has_lz4, has_zstd
 from kafka.metrics import MetricConfig, Metrics
 from kafka.partitioner.default import DefaultPartitioner
-from kafka.producer.future import FutureRecordMetadata, FutureProduceResult
+from kafka.producer.future import FutureRecordMetadata, FutureProduceResult, RecordMetadata
 from kafka.producer.record_accumulator import AtomicInteger, RecordAccumulator
 from kafka.producer.sender import Sender
 from kafka.record.default_records import DefaultRecordBatchBuilder
@@ -538,7 +538,7 @@ class KafkaProducer(object):
             return LegacyRecordBatchBuilder.estimate_size_in_bytes(
                 magic, self.config['compression_type'], key, value)
 
-    def send(self, topic, value=None, key=None, headers=None, partition=None, timestamp_ms=None):
+    def send(self, topic, value=None, key=None, headers=None, partition=None, timestamp_ms=None) -> RecordMetadata:
         """Publish a message to a topic.
 
         Arguments:

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -538,7 +538,8 @@ class KafkaProducer(object):
             return LegacyRecordBatchBuilder.estimate_size_in_bytes(
                 magic, self.config['compression_type'], key, value)
 
-    def send(self, topic, value=None, key=None, headers=None, partition=None, timestamp_ms=None) -> RecordMetadata:
+    def send(self, topic, value=None, key=None, headers=None, partition=None, timestamp_ms=None):
+        # type: (str, bytes, bytes, list, int, int) -> RecordMetadata
         """Publish a message to a topic.
 
         Arguments:


### PR DESCRIPTION
It would be nice to have an accessible and easy way to know the returns of the send functions, as the Documentation doesn't have a index for RecordMetadata;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2231)
<!-- Reviewable:end -->
