### PR TITLE
Support loading cas from memory.

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -107,6 +107,8 @@ class KafkaAdminClient(object):
         ssl_check_hostname (bool): Flag to configure whether SSL handshake
             should verify that the certificate matches the broker's hostname.
             Default: True.
+        ssl_cadata (str): optional ca filecontent to use in certificate
+            verification. default: None.
         ssl_cafile (str): Optional filename of CA file to use in certificate
             verification. Default: None.
         ssl_certfile (str): Optional filename of file in PEM format containing
@@ -168,6 +170,7 @@ class KafkaAdminClient(object):
         'security_protocol': 'PLAINTEXT',
         'ssl_context': None,
         'ssl_check_hostname': True,
+        'ssl_cadata': None,
         'ssl_cafile': None,
         'ssl_certfile': None,
         'ssl_keyfile': None,

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -110,6 +110,8 @@ class KafkaClient(object):
         ssl_check_hostname (bool): Flag to configure whether SSL handshake
             should verify that the certificate matches the broker's hostname.
             Default: True.
+        ssl_cadata (str): optional ca filecontent to use in certificate
+            verification. default: None.
         ssl_cafile (str): Optional filename of CA file to use in certificate
             verification. Default: None.
         ssl_certfile (str): Optional filename of file in PEM format containing
@@ -176,6 +178,7 @@ class KafkaClient(object):
         'security_protocol': 'PLAINTEXT',
         'ssl_context': None,
         'ssl_check_hostname': True,
+        'ssl_cadata': None,
         'ssl_cafile': None,
         'ssl_certfile': None,
         'ssl_keyfile': None,

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -144,6 +144,8 @@ class BrokerConnection(object):
         ssl_check_hostname (bool): flag to configure whether ssl handshake
             should verify that the certificate matches the brokers hostname.
             default: True.
+        ssl_cadata (str): optional ca filecontent to use in certificate
+            verification. default: None.
         ssl_cafile (str): optional filename of ca file to use in certificate
             verification. default: None.
         ssl_certfile (str): optional filename of file in pem format containing
@@ -208,6 +210,7 @@ class BrokerConnection(object):
         'security_protocol': 'PLAINTEXT',
         'ssl_context': None,
         'ssl_check_hostname': True,
+        'ssl_cadata': None,
         'ssl_cafile': None,
         'ssl_certfile': None,
         'ssl_keyfile': None,
@@ -468,9 +471,12 @@ class BrokerConnection(object):
             self._ssl_context.verify_mode = ssl.CERT_OPTIONAL
             if self.config['ssl_check_hostname']:
                 self._ssl_context.check_hostname = True
-            if self.config['ssl_cafile']:
-                log.info('%s: Loading SSL CA from %s', self, self.config['ssl_cafile'])
-                self._ssl_context.load_verify_locations(self.config['ssl_cafile'])
+            if self.config['ssl_cafile'] or self.config['ssl_cadata']:
+                if self.config['ssl_cafile']:
+                    log.info('%s: Loading SSL CA from %s', self, self.config['ssl_cafile'])
+                else:
+                    log.info('%s: Loading SSL CA from cadata', self)
+                self._ssl_context.load_verify_locations(self.config['ssl_cafile'], cadata=self.config['ssl_cadata'])
                 self._ssl_context.verify_mode = ssl.CERT_REQUIRED
             else:
                 log.info('%s: Loading system default SSL CAs from %s', self, ssl.get_default_verify_paths())

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -175,6 +175,8 @@ class KafkaConsumer(six.Iterator):
         ssl_check_hostname (bool): Flag to configure whether ssl handshake
             should verify that the certificate matches the brokers hostname.
             Default: True.
+        ssl_cadata (str): optional ca filecontent to use in certificate
+            verification. default: None.
         ssl_cafile (str): Optional filename of ca file to use in certificate
             verification. Default: None.
         ssl_certfile (str): Optional filename of file in pem format containing
@@ -285,6 +287,7 @@ class KafkaConsumer(six.Iterator):
         'security_protocol': 'PLAINTEXT',
         'ssl_context': None,
         'ssl_check_hostname': True,
+        'ssl_cadata': None,
         'ssl_cafile': None,
         'ssl_certfile': None,
         'ssl_keyfile': None,

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -232,6 +232,8 @@ class KafkaProducer(object):
         ssl_check_hostname (bool): flag to configure whether ssl handshake
             should verify that the certificate matches the brokers hostname.
             default: true.
+        ssl_cadata (str): optional ca filecontent to use in certificate
+            verification. default: None.
         ssl_cafile (str): optional filename of ca file to use in certificate
             verification. default: none.
         ssl_certfile (str): optional filename of file in pem format containing
@@ -316,6 +318,7 @@ class KafkaProducer(object):
         'security_protocol': 'PLAINTEXT',
         'ssl_context': None,
         'ssl_check_hostname': True,
+        'ssl_cadata': None,
         'ssl_cafile': None,
         'ssl_certfile': None,
         'ssl_keyfile': None,


### PR DESCRIPTION
Passes along cadata to SSL library.
This removes the need to unnecessarily persist CA files when already
present in memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2237)
<!-- Reviewable:end -->
