### PR TITLE
Remove pylint workaround since upstream fixed

### DIFF
--- a/kafka/record/_crc32c.py
+++ b/kafka/record/_crc32c.py
@@ -139,7 +139,5 @@ def crc(data):
 
 if __name__ == "__main__":
     import sys
-    # TODO remove the pylint disable once pylint fixes
-    # https://github.com/PyCQA/pylint/issues/2571
-    data = sys.stdin.read()  # pylint: disable=assignment-from-no-return
+    data = sys.stdin.read()
     print(hex(crc(data)))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ flake8==3.8.3
 lz4==3.1.0
 mock==4.0.2
 py==1.9.0
-pylint==2.6.0
+pylint==2.9.6
 pytest==6.0.2
 pytest-cov==2.10.1
 pytest-mock==3.3.1


### PR DESCRIPTION
Supposedly this is fixed upstream now:
https://github.com/PyCQA/pylint/issues/2571#issuecomment-893686260

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2252)
<!-- Reviewable:end -->
