### PR TITLE
Fix a link to snappy

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -58,7 +58,7 @@ Optional Snappy install
 Install Development Libraries
 =============================
 
-Download and build Snappy from https://google.github.io/snappy/
+Download and build Snappy from https://github.com/google/snappy
 
 Ubuntu:
 


### PR DESCRIPTION
The current link leads to HTTP 404.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2296)
<!-- Reviewable:end -->
