### PR TITLE
Fixes "TypeError: Population must be a sequence." using random.sample()

### DIFF
--- a/test/test_assignors.py
+++ b/test/test_assignors.py
@@ -655,7 +655,7 @@ def test_conflicting_previous_assignments(mocker):
     'execution_number,n_topics,n_consumers', [(i, randint(10, 20), randint(20, 40)) for i in range(100)]
 )
 def test_reassignment_with_random_subscriptions_and_changes(mocker, execution_number, n_topics, n_consumers):
-    all_topics = set(['t{}'.format(i) for i in range(1, n_topics + 1)])
+    all_topics = sorted(set(['t{}'.format(i) for i in range(1, n_topics + 1)]))
     partitions = dict([(t, set(range(1, i + 1))) for i, t in enumerate(all_topics)])
     cluster = create_cluster(mocker, topics=all_topics, topic_partitions_lambda=lambda t: partitions[t])
 


### PR DESCRIPTION
Hello, I am a kafka-python rpm packager.

I would like to fix "TypeError" in test/test_assignors.py using Python-3.11. The population of random.sample() must be a sequence and automatic conversion of sets to lists is no longer supported in Python-3.11.

```
<mock-chroot> sh-5.1# python3
Python 3.11.0b3 (main, Jun 24 2022, 00:00:00) [GCC 12.1.1 20220507 (Red Hat 12.1.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from random import Random
>>> r = Random()
>>> r.seed('test')
>>> r.sample({'t1', 't10', 't2', 't3', 't4', 't5'}, k=4)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.11/random.py", line 436, in sample
    raise TypeError("Population must be a sequence.  "
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
```

I think we should pass the data as an instance of list or sorted set.
```
>>> r.sample(sorted({'t1', 't10', 't2', 't3', 't4', 't5'}), k=4)
['t1', 't4', 't3', 't5']
```

### References:
* https://docs.python.org/3.11/library/random.html#random.sample
* https://bugs.python.org/issue?@action=redirect&bpo=42470
* https://src.fedoraproject.org/rpms/python-kafka

Thanks in advance,
Hirotaka Wakabayashi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2318)
<!-- Reviewable:end -->
