### PR TITLE
docs: Fix a few typos

### DIFF
--- a/kafka/codec.py
+++ b/kafka/codec.py
@@ -187,7 +187,7 @@ def _detect_xerial_stream(payload):
         The version is the version of this format as written by xerial,
         in the wild this is currently 1 as such we only support v1.
 
-        Compat is there to claim the miniumum supported version that
+        Compat is there to claim the minimum supported version that
         can read a xerial block stream, presently in the wild this is
         1.
     """

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -952,7 +952,7 @@ class HeartbeatThread(threading.Thread):
                 # disable here to prevent propagating an exception to this
                 # heartbeat thread
                 # must get client._lock, or maybe deadlock at heartbeat 
-                # failure callbak in consumer poll
+                # failure callback in consumer poll
                 self.coordinator._client.poll(timeout_ms=0)
 
         with self.coordinator._lock:

--- a/kafka/record/abc.py
+++ b/kafka/record/abc.py
@@ -85,7 +85,7 @@ class ABCRecordBatchBuilder(object):
 
 
 class ABCRecordBatch(object):
-    """ For v2 incapsulates a RecordBatch, for v0/v1 a single (maybe
+    """ For v2 encapsulated a RecordBatch, for v0/v1 a single (maybe
         compressed) message.
     """
     __metaclass__ = abc.ABCMeta

--- a/kafka/record/abc.py
+++ b/kafka/record/abc.py
@@ -85,7 +85,7 @@ class ABCRecordBatchBuilder(object):
 
 
 class ABCRecordBatch(object):
-    """ For v2 encapsulated a RecordBatch, for v0/v1 a single (maybe
+    """ For v2 encapsulates a RecordBatch, for v0/v1 a single (maybe
         compressed) message.
     """
     __metaclass__ = abc.ABCMeta

--- a/kafka/record/legacy_records.py
+++ b/kafka/record/legacy_records.py
@@ -263,7 +263,7 @@ class LegacyRecordBatch(ABCRecordBatch, LegacyRecordBase):
 
                 # When magic value is greater than 0, the timestamp
                 # of a compressed message depends on the
-                # typestamp type of the wrapper message:
+                # timestamp type of the wrapper message:
                 if timestamp_type == self.LOG_APPEND_TIME:
                     timestamp = self._timestamp
 


### PR DESCRIPTION
There are small typos in:
- kafka/codec.py
- kafka/coordinator/base.py
- kafka/record/abc.py
- kafka/record/legacy_records.py

Fixes:
- Should read `timestamp` rather than `typestamp`.
- Should read `minimum` rather than `miniumum`.
- Should read `encapsulates` rather than `incapsulates`.
- Should read `callback` rather than `callbak`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2319)
<!-- Reviewable:end -->
