### PR TITLE
Use isinstance in builtin crc32

### DIFF
--- a/kafka/record/_crc32c.py
+++ b/kafka/record/_crc32c.py
@@ -105,7 +105,7 @@ def crc_update(crc, data):
     Returns:
         32-bit updated CRC-32C as long.
     """
-    if type(data) != array.array or data.itemsize != 1:
+    if not isinstance(data, array.array) or data.itemsize != 1:
         buf = array.array("B", data)
     else:
         buf = data


### PR DESCRIPTION
I'm in the process of building a dynamic analysis tool for python, I ran it on this repo and found a potential improvement.

Right now the builtin crc32 module uses `type(data) != array.array`.
However, using `not isinstance(data, array.array)` has a number of advantages:

- `array.array` subtypes are supported
- follows [PEP-008](https://peps.python.org/pep-0008/#programming-recommendations) recommendations
- better readability
- performance improvement

I measured the performance as follows:
``` bash
$ python3.9 -m timeit -s "from _crc32c import crc_update_faster; import array" -u nsec "crc_update_faster(0, array.array('B', b''))"
500000 loops, best of 5: 576 nsec per loop
$ python3.9 -m timeit -s "from _crc32c import crc_update; import array" -u nsec "crc_update(0, array.array('B', b''))"
500000 loops, best of 5: 622 nsec per loop
$ python3.9 --version
Python 3.9.14
```
where `crc_update_faster` uses `not isinstance(data, array.array)`.

You can find a more detailed explanation why `isinstance` might be better in this [blogpost](https://switowski.com/blog/type-vs-isinstance).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2329)
<!-- Reviewable:end -->
