### PR TITLE
Allow disabling thread wakeup in send_request_to_node

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -355,13 +355,14 @@ class KafkaAdminClient(object):
         }
         return groups_coordinators
 
-    def _send_request_to_node(self, node_id, request):
+    def _send_request_to_node(self, node_id, request, wakeup=True):
         """Send a Kafka protocol message to a specific broker.
 
         Returns a future that may be polled for status and results.
 
         :param node_id: The broker id to which to send the message.
         :param request: The message to send.
+        :param wakeup: Optional flag to disable thread-wakeup.
         :return: A future object that may be polled for status and results.
         :exception: The exception if the message could not be sent.
         """
@@ -369,7 +370,7 @@ class KafkaAdminClient(object):
             # poll until the connection to broker is ready, otherwise send()
             # will fail with NodeNotReadyError
             self._client.poll()
-        return self._client.send(node_id, request)
+        return self._client.send(node_id, request, wakeup)
 
     def _send_request_to_controller(self, request):
         """Send a Kafka protocol message to the cluster controller.


### PR DESCRIPTION
The Datadog kafka_consumer check uses the `kafka-python` client library to collect metrics. On very large clusters, it sometimes gets a `KafkaTimeoutError` similar to the one [here](https://github.com/dpkp/kafka-python/issues/2286). We've been able to [work around this](https://github.com/DataDog/integrations-core/pull/13221) by disabling the socket wakeup since our check runs in a single thread (after looking at [this old Github issue](https://github.com/dpkp/kafka-python/pull/1761) that was meant to fix the issue). However, we needed to re-implement some parts of the `_send_request_to_node()` function since the library's version always runs a socket wakeup. 

This PR just adds the `wakeup` argument to `_send_request_to_node()` to make it easier to skip socket wakeup. 

I saw that there's a few other places in the code that calls `_client.send()` where adding a `wakeup` argument can be possible (examples: [1](https://github.com/dpkp/kafka-python/blob/f19e4238fb47ae2619f18731f0e0e9a3762cfa11/kafka/coordinator/consumer.py#L627), [2](https://github.com/dpkp/kafka-python/blob/f19e4238fb47ae2619f18731f0e0e9a3762cfa11/kafka/coordinator/consumer.py#L747)), but wasn't sure if those would necessarily be useful. 

Let me know if I should do anything else for this PR!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2335)
<!-- Reviewable:end -->
