### PR TITLE
Fix tests for Py3.11

### DIFF
--- a/test/test_assignors.py
+++ b/test/test_assignors.py
@@ -661,7 +661,7 @@ def test_reassignment_with_random_subscriptions_and_changes(mocker, execution_nu
 
     subscriptions = defaultdict(set)
     for i in range(n_consumers):
-        topics_sample = sample(all_topics, randint(1, len(all_topics) - 1))
+        topics_sample = sample(sorted(all_topics), randint(1, len(all_topics) - 1))
         subscriptions['C{}'.format(i)].update(topics_sample)
 
     member_metadata = make_member_metadata(subscriptions)
@@ -671,7 +671,7 @@ def test_reassignment_with_random_subscriptions_and_changes(mocker, execution_nu
 
     subscriptions = defaultdict(set)
     for i in range(n_consumers):
-        topics_sample = sample(all_topics, randint(1, len(all_topics) - 1))
+        topics_sample = sample(sorted(all_topics), randint(1, len(all_topics) - 1))
         subscriptions['C{}'.format(i)].update(topics_sample)
 
     member_metadata = {}


### PR DESCRIPTION
This fixes tests for Py3.11, otherwise they fail with following errors:
```
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[0-18-29] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[1-19-23] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[2-11-27] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[3-19-31] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[4-10-34] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[5-18-35] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[6-19-30] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[7-11-26] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[8-20-22] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[9-16-31] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[10-17-24] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[11-10-28] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[12-14-35] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[13-13-30] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[14-18-25] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[15-17-28] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[16-17-32] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[17-12-24] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[18-19-32] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[19-15-22] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[20-20-37] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[21-10-38] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[22-11-38] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[23-14-39] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[24-14-34] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[25-17-31] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[26-13-38] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[27-18-24] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[28-19-38] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[29-19-26] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[30-14-22] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[31-12-34] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[32-12-36] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[33-16-28] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[34-18-25] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[35-12-24] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[36-16-38] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[37-20-33] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[38-12-37] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[39-10-30] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[40-19-32] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[41-14-32] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[42-17-34] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[43-16-35] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[44-19-23] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[45-18-37] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[46-12-31] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[47-15-21] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[48-18-28] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[49-20-34] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[50-17-25] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[51-16-21] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[52-10-25] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[53-20-33] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[54-12-38] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[55-12-22] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[56-11-25] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[57-18-31] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[58-11-25] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[59-11-35] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[60-18-38] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[61-13-37] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[62-13-40] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[63-20-35] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[64-18-27] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[65-11-31] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[66-15-33] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[67-17-32] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[68-18-39] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[69-16-20] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[70-18-37] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[71-13-28] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[72-16-24] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[73-14-40] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[74-11-22] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[75-19-39] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[76-14-38] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[77-11-37] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[78-12-36] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[79-20-31] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[80-10-22] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[81-14-27] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[82-14-29] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[83-19-27] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[84-18-30] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[85-17-32] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[86-10-25] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[87-18-36] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[88-12-38] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[89-12-23] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[90-18-20] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[91-15-24] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[92-15-29] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[93-11-20] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[94-10-35] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[95-19-20] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[96-11-37] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[97-14-24] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[98-16-28] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
FAILED test/test_assignors.py::test_reassignment_with_random_subscriptions_and_changes[99-15-28] - TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
======================= 100 failed, 1100 passed, 43 skipped, 2 deselected, 2 warnings in 10.61s =======================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2358)
<!-- Reviewable:end -->
