### PR TITLE
Enable testing for Python 3.12 in GH Workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -69,8 +69,8 @@ jobs:
         include:
           - python-version: "pypy3.9"
             experimental: true
-#          - python-version: "~3.12.0-0"
-#            experimental: true
+          - python-version: "~3.12.0-0"
+            experimental: true
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v3


### PR DESCRIPTION
I don't expect this to work yet since I know 3.12 is in an incomplete state, but here goes nothing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2379)
<!-- Reviewable:end -->
