### PR TITLE
Update python-package.yml to publish to PyPi for every release

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -177,3 +177,21 @@ jobs:
       uses: re-actors/alls-green@release/v1
       with:
         jobs: ${{ toJSON(needs) }}
+  publish:
+    name: 📦 Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-sdist]
+    permissions:
+      id-token: write
+    environment: pypi
+    if: github.event_name == 'release' && github.event.action == 'created'
+    steps:
+      - name: Download the sdist artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
I know that the typical release is uploaded to PyPi manually, however I figure I'd draft a PR with these changes because having the option to start doing this is worthwhile. More info can be found on https://github.com/pypa/gh-action-pypi-publish.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2381)
<!-- Reviewable:end -->
