### PR TITLE
Set SSLContext minimum version to TLSv1_2

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -463,6 +463,7 @@ class BrokerConnection(object):
         if self._ssl_context is None:
             log.debug('%s: configuring default SSL Context', self)
             self._ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)  # pylint: disable=no-member
+            self._ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
             self._ssl_context.options |= ssl.OP_NO_SSLv2  # pylint: disable=no-member
             self._ssl_context.options |= ssl.OP_NO_SSLv3  # pylint: disable=no-member
             self._ssl_context.verify_mode = ssl.CERT_OPTIONAL


### PR DESCRIPTION
This change should enforce usage of stronger cryptographic protocols. More information is available at https://cwe.mitre.org/data/definitions/327.html.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2383)
<!-- Reviewable:end -->
