### PR TITLE
Update setup.py to install zstandard instead of python-zstandard

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "crc32c": ["crc32c"],
         "lz4": ["lz4"],
         "snappy": ["python-snappy"],
-        "zstd": ["python-zstandard"],
+        "zstd": ["zstandard"],
     },
     cmdclass={"test": Tox},
     packages=find_packages(exclude=['test']),


### PR DESCRIPTION
Closes https://github.com/dpkp/kafka-python/issues/2350, since it's a valid security concern.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2387)
<!-- Reviewable:end -->
