### PR TITLE
[FIX] suitablt for the high vresion python.

### DIFF
--- a/kafka/vendor/selectors34.py
+++ b/kafka/vendor/selectors34.py
@@ -16,7 +16,10 @@ from __future__ import absolute_import
 
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from errno import EINTR
 import math
 import select

--- a/kafka/vendor/selectors34.py
+++ b/kafka/vendor/selectors34.py
@@ -15,7 +15,8 @@ The following code adapted from trollius.selectors.
 from __future__ import absolute_import
 
 from abc import ABCMeta, abstractmethod
-from collections import namedtuple, Mapping
+from collections import namedtuple
+from collections.abc import Mapping
 from errno import EINTR
 import math
 import select


### PR DESCRIPTION
it won't import Mapping from collections at python3.11. 
tested it worked from python3.6 to 3.11.2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2394)
<!-- Reviewable:end -->
