### PR TITLE
Update python-package.yml to expect 3.12 tests to pass and extend experimental tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,11 +65,12 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         experimental: [ false ]
         include:
           - python-version: "pypy3.9"
             experimental: true
-          - python-version: "~3.12.0-0"
+          - python-version: "~3.13.0-0"
             experimental: true
     steps:
       - name: Checkout the source code


### PR DESCRIPTION
Let's start testing for 3.13 since it's available in https://github.com/actions/python-versions/blob/main/versions-manifest.json now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2406)
<!-- Reviewable:end -->
