### PR TITLE
Update some RST documentation syntax

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build artifacts
         run: python -m build
       - name: Upload built artifacts for testing
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.sdist-artifact }}
           # NOTE: Exact expected file names are specified here
@@ -66,10 +66,9 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "pypy3.9"
         experimental: [ false ]
         include:
-          - python-version: "pypy3.9"
-            experimental: true
           - python-version: "~3.13.0-0"
             experimental: true
     steps:
@@ -115,11 +114,11 @@ jobs:
     needs:
       - build-sdist
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         kafka-version:
-          - "0.8.2.2"
           - "0.9.0.1"
           - "0.10.2.2"
           - "0.11.0.2"
@@ -128,6 +127,11 @@ jobs:
           - "2.4.0"
           - "2.5.0"
           - "2.6.0"
+        experimental: [false]
+        include:
+          - kafka-version: '0.8.2.2'
+            experimental: true
+    continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4
@@ -187,11 +191,11 @@ jobs:
     environment: pypi
     if: github.event_name == 'release' && github.event.action == 'created'
     steps:
-      - name: Download the sdist artifact
-        uses: actions/download-artifact@v3
+      - name: Download the artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: artifact
-          path: dist
+          name: ${{ env.sdist-artifact }}
+          path: dist/${{ env.sdist-name }}
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -68,9 +68,6 @@ jobs:
           - "3.12"
           - "pypy3.9"
         experimental: [ false ]
-        include:
-          - python-version: "~3.13.0-0"
-            experimental: true
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4
@@ -110,7 +107,7 @@ jobs:
           KAFKA_VERSION: ${{ env.KAFKA_LATEST }}
 
   test-kafka:
-    name: Tests for Kafka ${{ matrix.kafka-version }}
+    name: Tests for Kafka ${{ matrix.kafka-version }} (Python ${{ matrix.python-version }})
     needs:
       - build-sdist
     runs-on: ubuntu-latest
@@ -127,10 +124,17 @@ jobs:
           - "2.4.0"
           - "2.5.0"
           - "2.6.0"
+        python-version: ['3.12']
         experimental: [false]
         include:
           - kafka-version: '0.8.2.2'
             experimental: true
+            python-version: "3.12"
+          - kafka-version: '0.8.2.2'
+            experimental: false
+            python-version: "3.10"
+    env:
+      PYTHON_LATEST: ${{ matrix.python-version }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout the source code
@@ -145,7 +149,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_LATEST }}
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
             requirements-dev.txt

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -413,7 +413,7 @@ Some of the major changes include:
 * SASL authentication is working (we think)
 * Removed several circular references to improve gc on close()
 
-Thanks to all contributors -- the state of the kafka-python community is strong!
+Thanks to all contributors -- the state of the kafka-python-ng community is strong!
 
 Detailed changelog are listed below:
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ cov-local: build-integration
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 # Check the readme for syntax errors, which can lead to invalid formatting on
-# PyPi homepage (https://pypi.python.org/pypi/kafka-python)
+# PyPi homepage (https://pypi.python.org/pypi/kafka-python-ng)
 check-readme:
 	python setup.py check -rms
 

--- a/README.rst
+++ b/README.rst
@@ -32,13 +32,15 @@ check code (perhaps using zookeeper or consul). For older brokers, you can
 achieve something similar by manually assigning different partitions to each
 consumer instance with config management tools like chef, ansible, etc. This
 approach will work fine, though it does not support rebalancing on failures.
-See <https://kafka-python.readthedocs.io/en/master/compatibility.html>
+See https://kafka-python.readthedocs.io/en/master/compatibility.html
 for more details.
 
 Please note that the master branch may contain unreleased features. For release
 documentation, please see readthedocs and/or python's inline help.
 
->>> pip install kafka-python
+.. code-block:: bash 
+
+    $ pip install kafka-python
 
 
 KafkaConsumer
@@ -48,42 +50,54 @@ KafkaConsumer is a high-level message consumer, intended to operate as similarly
 as possible to the official java client. Full support for coordinated
 consumer groups requires use of kafka brokers that support the Group APIs: kafka v0.9+.
 
-See <https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html>
+See https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html
 for API and configuration details.
 
 The consumer iterator returns ConsumerRecords, which are simple namedtuples
 that expose basic message attributes: topic, partition, offset, key, and value:
 
->>> from kafka import KafkaConsumer
->>> consumer = KafkaConsumer('my_favorite_topic')
->>> for msg in consumer:
-...     print (msg)
+.. code-block:: python
 
->>> # join a consumer group for dynamic partition assignment and offset commits
->>> from kafka import KafkaConsumer
->>> consumer = KafkaConsumer('my_favorite_topic', group_id='my_favorite_group')
->>> for msg in consumer:
-...     print (msg)
+    from kafka import KafkaConsumer
+    consumer = KafkaConsumer('my_favorite_topic')
+    for msg in consumer:
+        print (msg)
 
->>> # manually assign the partition list for the consumer
->>> from kafka import TopicPartition
->>> consumer = KafkaConsumer(bootstrap_servers='localhost:1234')
->>> consumer.assign([TopicPartition('foobar', 2)])
->>> msg = next(consumer)
+.. code-block:: python
 
->>> # Deserialize msgpack-encoded values
->>> consumer = KafkaConsumer(value_deserializer=msgpack.loads)
->>> consumer.subscribe(['msgpackfoo'])
->>> for msg in consumer:
-...     assert isinstance(msg.value, dict)
+    # join a consumer group for dynamic partition assignment and offset commits
+    from kafka import KafkaConsumer
+    consumer = KafkaConsumer('my_favorite_topic', group_id='my_favorite_group')
+    for msg in consumer:
+        print (msg)
 
->>> # Access record headers. The returned value is a list of tuples
->>> # with str, bytes for key and value
->>> for msg in consumer:
-...     print (msg.headers)
+.. code-block:: python
 
->>> # Get consumer metrics
->>> metrics = consumer.metrics()
+    # manually assign the partition list for the consumer
+    from kafka import TopicPartition
+    consumer = KafkaConsumer(bootstrap_servers='localhost:1234')
+    consumer.assign([TopicPartition('foobar', 2)])
+    msg = next(consumer)
+
+.. code-block:: python
+
+    # Deserialize msgpack-encoded values
+    consumer = KafkaConsumer(value_deserializer=msgpack.loads)
+    consumer.subscribe(['msgpackfoo'])
+    for msg in consumer:
+        assert isinstance(msg.value, dict)
+
+.. code-block:: python
+
+    # Access record headers. The returned value is a list of tuples
+    # with str, bytes for key and value
+    for msg in consumer:
+        print (msg.headers)
+
+.. code-block:: python
+
+    # Get consumer metrics
+    metrics = consumer.metrics()
 
 
 KafkaProducer
@@ -91,46 +105,64 @@ KafkaProducer
 
 KafkaProducer is a high-level, asynchronous message producer. The class is
 intended to operate as similarly as possible to the official java client.
-See <https://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html>
+See https://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html
 for more details.
 
->>> from kafka import KafkaProducer
->>> producer = KafkaProducer(bootstrap_servers='localhost:1234')
->>> for _ in range(100):
-...     producer.send('foobar', b'some_message_bytes')
+.. code-block:: python
 
->>> # Block until a single message is sent (or timeout)
->>> future = producer.send('foobar', b'another_message')
->>> result = future.get(timeout=60)
+    from kafka import KafkaProducer
+    producer = KafkaProducer(bootstrap_servers='localhost:1234')
+    for _ in range(100):
+        producer.send('foobar', b'some_message_bytes')
 
->>> # Block until all pending messages are at least put on the network
->>> # NOTE: This does not guarantee delivery or success! It is really
->>> # only useful if you configure internal batching using linger_ms
->>> producer.flush()
+.. code-block:: python
 
->>> # Use a key for hashed-partitioning
->>> producer.send('foobar', key=b'foo', value=b'bar')
+    # Block until a single message is sent (or timeout)
+    future = producer.send('foobar', b'another_message')
+    result = future.get(timeout=60)
 
->>> # Serialize json messages
->>> import json
->>> producer = KafkaProducer(value_serializer=lambda v: json.dumps(v).encode('utf-8'))
->>> producer.send('fizzbuzz', {'foo': 'bar'})
+.. code-block:: python
 
->>> # Serialize string keys
->>> producer = KafkaProducer(key_serializer=str.encode)
->>> producer.send('flipflap', key='ping', value=b'1234')
+    # Block until all pending messages are at least put on the network
+    # NOTE: This does not guarantee delivery or success! It is really
+    # only useful if you configure internal batching using linger_ms
+    producer.flush()
 
->>> # Compress messages
->>> producer = KafkaProducer(compression_type='gzip')
->>> for i in range(1000):
-...     producer.send('foobar', b'msg %d' % i)
+.. code-block:: python
 
->>> # Include record headers. The format is list of tuples with string key
->>> # and bytes value.
->>> producer.send('foobar', value=b'c29tZSB2YWx1ZQ==', headers=[('content-encoding', b'base64')])
+    # Use a key for hashed-partitioning
+    producer.send('foobar', key=b'foo', value=b'bar')
 
->>> # Get producer performance metrics
->>> metrics = producer.metrics()
+.. code-block:: python
+
+    # Serialize json messages
+    import json
+    producer = KafkaProducer(value_serializer=lambda v: json.dumps(v).encode('utf-8'))
+    producer.send('fizzbuzz', {'foo': 'bar'})
+
+.. code-block:: python
+
+    # Serialize string keys
+    producer = KafkaProducer(key_serializer=str.encode)
+    producer.send('flipflap', key='ping', value=b'1234')
+
+.. code-block:: python
+
+    # Compress messages
+    producer = KafkaProducer(compression_type='gzip')
+    for i in range(1000):
+        producer.send('foobar', b'msg %d' % i)
+
+.. code-block:: python
+
+    # Include record headers. The format is list of tuples with string key
+    # and bytes value.
+    producer.send('foobar', value=b'c29tZSB2YWx1ZQ==', headers=[('content-encoding', b'base64')])
+
+.. code-block:: python
+
+    # Get producer performance metrics
+    metrics = producer.metrics()
 
 
 Thread safety
@@ -154,7 +186,7 @@ kafka-python supports the following compression formats:
 - Zstandard (zstd)
 
 gzip is supported natively, the others require installing additional libraries.
-See <https://kafka-python.readthedocs.io/en/master/install.html> for more information.
+See https://kafka-python.readthedocs.io/en/master/install.html for more information.
 
 
 Optimized CRC32 Validation
@@ -163,7 +195,7 @@ Optimized CRC32 Validation
 Kafka uses CRC32 checksums to validate messages. kafka-python includes a pure
 python implementation for compatibility. To improve performance for high-throughput
 applications, kafka-python will use `crc32c` for optimized native code if installed.
-See <https://kafka-python.readthedocs.io/en/master/install.html> for installation instructions.
+See https://kafka-python.readthedocs.io/en/master/install.html for installation instructions.
 See https://pypi.org/project/crc32c/ for details on the underlying crc32c lib.
 
 

--- a/README.rst
+++ b/README.rst
@@ -2,27 +2,27 @@ Kafka Python client
 ------------------------
 
 .. image:: https://img.shields.io/badge/kafka-2.6%2C%202.5%2C%202.4%2C%202.3%2C%202.2%2C%202.1%2C%202.0%2C%201.1%2C%201.0%2C%200.11%2C%200.10%2C%200.9%2C%200.8-brightgreen.svg
-    :target: https://kafka-python.readthedocs.io/en/master/compatibility.html
-.. image:: https://img.shields.io/pypi/pyversions/kafka-python.svg
-    :target: https://pypi.python.org/pypi/kafka-python
-.. image:: https://coveralls.io/repos/dpkp/kafka-python/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/dpkp/kafka-python?branch=master
+    :target: https://kafka-python-ng.readthedocs.io/en/master/compatibility.html
+.. image:: https://img.shields.io/pypi/pyversions/kafka-python-ng.svg
+    :target: https://pypi.python.org/pypi/kafka-python-ng
+.. image:: https://coveralls.io/repos/wbarnha/kafka-python-ng/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/wbarnha/kafka-python-ng?branch=master
 .. image:: https://img.shields.io/badge/license-Apache%202-blue.svg
-    :target: https://github.com/dpkp/kafka-python/blob/master/LICENSE
-.. image:: https://img.shields.io/pypi/dw/kafka-python.svg
-    :target: https://pypistats.org/packages/kafka-python
+    :target: https://github.com/wbarnha/kafka-python-ng/blob/master/LICENSE
+.. image:: https://img.shields.io/pypi/dw/kafka-python-ng.svg
+    :target: https://pypistats.org/packages/kafka-python-ng
 .. image:: https://img.shields.io/pypi/v/kafka-python.svg
-    :target: https://pypi.org/project/kafka-python
-.. image:: https://img.shields.io/pypi/implementation/kafka-python
-    :target: https://github.com/dpkp/kafka-python/blob/master/setup.py
+    :target: https://pypi.org/project/kafka-python-ng
+.. image:: https://img.shields.io/pypi/implementation/kafka-python-ng
+    :target: https://github.com/wbarnha/kafka-python-ng/blob/master/setup.py
 
 
 
 Python client for the Apache Kafka distributed stream processing system.
-kafka-python is designed to function much like the official java client, with a
+kafka-python-ng is designed to function much like the official java client, with a
 sprinkling of pythonic interfaces (e.g., consumer iterators).
 
-kafka-python is best used with newer brokers (0.9+), but is backwards-compatible with
+kafka-python-ng is best used with newer brokers (0.9+), but is backwards-compatible with
 older versions (to 0.8.0). Some features will only be enabled on newer brokers.
 For example, fully coordinated consumer groups -- i.e., dynamic partition
 assignment to multiple consumers in the same group -- requires use of 0.9+ kafka
@@ -32,15 +32,19 @@ check code (perhaps using zookeeper or consul). For older brokers, you can
 achieve something similar by manually assigning different partitions to each
 consumer instance with config management tools like chef, ansible, etc. This
 approach will work fine, though it does not support rebalancing on failures.
+
 See https://kafka-python.readthedocs.io/en/master/compatibility.html
+
 for more details.
 
 Please note that the master branch may contain unreleased features. For release
 documentation, please see readthedocs and/or python's inline help.
 
+
 .. code-block:: bash 
 
-    $ pip install kafka-python
+    $  pip install kafka-python-ng
+
 
 
 KafkaConsumer
@@ -50,7 +54,9 @@ KafkaConsumer is a high-level message consumer, intended to operate as similarly
 as possible to the official java client. Full support for coordinated
 consumer groups requires use of kafka brokers that support the Group APIs: kafka v0.9+.
 
+
 See https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html
+
 for API and configuration details.
 
 The consumer iterator returns ConsumerRecords, which are simple namedtuples
@@ -105,7 +111,9 @@ KafkaProducer
 
 KafkaProducer is a high-level, asynchronous message producer. The class is
 intended to operate as similarly as possible to the official java client.
+
 See https://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html
+
 for more details.
 
 .. code-block:: python
@@ -178,7 +186,7 @@ multiprocessing is recommended.
 Compression
 ***********
 
-kafka-python supports the following compression formats:
+kafka-python-ng supports the following compression formats:
 
 - gzip
 - LZ4
@@ -186,23 +194,26 @@ kafka-python supports the following compression formats:
 - Zstandard (zstd)
 
 gzip is supported natively, the others require installing additional libraries.
+
 See https://kafka-python.readthedocs.io/en/master/install.html for more information.
+
 
 
 Optimized CRC32 Validation
 **************************
 
-Kafka uses CRC32 checksums to validate messages. kafka-python includes a pure
+Kafka uses CRC32 checksums to validate messages. kafka-python-ng includes a pure
 python implementation for compatibility. To improve performance for high-throughput
 applications, kafka-python will use `crc32c` for optimized native code if installed.
 See https://kafka-python.readthedocs.io/en/master/install.html for installation instructions.
+
 See https://pypi.org/project/crc32c/ for details on the underlying crc32c lib.
 
 
 Protocol
 ********
 
-A secondary goal of kafka-python is to provide an easy-to-use protocol layer
+A secondary goal of kafka-python-ng is to provide an easy-to-use protocol layer
 for interacting with kafka brokers via the python repl. This is useful for
 testing, probing, and general experimentation. The protocol support is
 leveraged to enable a KafkaClient.check_version() method that

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -85,17 +85,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/kafka-python.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/kafka-python-ng.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/kafka-python.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/kafka-python-ng.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/kafka-python"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/kafka-python"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/kafka-python-ng"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/kafka-python-ng"
 	@echo "# devhelp"
 
 epub:

--- a/docs/apidoc/modules.rst
+++ b/docs/apidoc/modules.rst
@@ -1,4 +1,4 @@
-kafka-python API
+kafka-python-ng API
 ****************
 
 .. toctree::

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -484,7 +484,7 @@ Some of the major changes include:
 * SASL authentication is working (we think)
 * Removed several circular references to improve gc on close()
 
-Thanks to all contributors -- the state of the kafka-python community is strong!
+Thanks to all contributors -- the state of the kafka-python-ng community is strong!
 
 Detailed changelog are listed below:
 

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -2,20 +2,20 @@ Compatibility
 -------------
 
 .. image:: https://img.shields.io/badge/kafka-2.6%2C%202.5%2C%202.4%2C%202.3%2C%202.2%2C%202.1%2C%202.0%2C%201.1%2C%201.0%2C%200.11%2C%200.10%2C%200.9%2C%200.8-brightgreen.svg
-    :target: https://kafka-python.readthedocs.io/compatibility.html
-.. image:: https://img.shields.io/pypi/pyversions/kafka-python.svg
-    :target: https://pypi.python.org/pypi/kafka-python
+    :target: https://kafka-python-ng.readthedocs.io/compatibility.html
+.. image:: https://img.shields.io/pypi/pyversions/kafka-python-ng.svg
+    :target: https://pypi.python.org/pypi/kafka-python-ng
 
-kafka-python is compatible with (and tested against) broker versions 2.6
-through 0.8.0 . kafka-python is not compatible with the 0.8.2-beta release.
+kafka-python-ng is compatible with (and tested against) broker versions 2.6
+through 0.8.0 . kafka-python-ng is not compatible with the 0.8.2-beta release.
 
-Because the kafka server protocol is backwards compatible, kafka-python is
+Because the kafka server protocol is backwards compatible, kafka-python-ng is
 expected to work with newer broker releases as well.
 
-Although kafka-python is tested and expected to work on recent broker versions,
+Although kafka-python-ng is tested and expected to work on recent broker versions,
 not all features are supported. Specifically, authentication codecs, and
 transactional producer/consumer support are not fully implemented. PRs welcome!
 
-kafka-python is tested on python 2.7, 3.4, 3.7, 3.8 and pypy2.7.
+kafka-python-ng is tested on python 2.7, 3.4, 3.7, 3.8 and pypy2.7.
 
-Builds and tests via Travis-CI.  See https://travis-ci.org/dpkp/kafka-python
+Builds and tests via Travis-CI.  See https://travis-ci.org/wbarnha/kafka-python-ng

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# kafka-python documentation build configuration file, created by
+# kafka-python-ng documentation build configuration file, created by
 # sphinx-quickstart on Sun Jan  4 12:21:50 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -47,7 +47,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'kafka-python'
+project = u'kafka-python-ng'
 copyright = u'2016 -- Dana Powers, David Arthur, and Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -201,7 +201,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'kafka-python.tex', u'kafka-python Documentation',
+  ('index', 'kafka-python-ng.tex', u'kafka-python-ng Documentation',
    u'Dana Powers', 'manual'),
 ]
 
@@ -231,7 +231,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'kafka-python', u'kafka-python Documentation',
+    ('index', 'kafka-python-ng', u'kafka-python-ng Documentation',
      [u'Dana Powers'], 1)
 ]
 
@@ -245,7 +245,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'kafka-python', u'kafka-python Documentation',
+  ('index', 'kafka-python-ng', u'kafka-python-ng Documentation',
    u'Dana Powers', 'kafka-python', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,16 @@
-kafka-python
+kafka-python-ng
 ############
 
 .. image:: https://img.shields.io/badge/kafka-2.6%2C%202.5%2C%202.4%2C%202.3%2C%202.2%2C%202.1%2C%202.0%2C%201.1%2C%201.0%2C%200.11%2C%200.10%2C%200.9%2C%200.8-brightgreen.svg
     :target: https://kafka-python.readthedocs.io/en/master/compatibility.html
 .. image:: https://img.shields.io/pypi/pyversions/kafka-python.svg
-    :target: https://pypi.python.org/pypi/kafka-python
-.. image:: https://coveralls.io/repos/dpkp/kafka-python/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/dpkp/kafka-python?branch=master
-.. image:: https://travis-ci.org/dpkp/kafka-python.svg?branch=master
-    :target: https://travis-ci.org/dpkp/kafka-python
+    :target: https://pypi.python.org/pypi/kafka-python-ng
+.. image:: https://coveralls.io/repos/wbarnha/kafka-python-ng/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/wbarnha/kafka-python-ng?branch=master
+.. image:: https://travis-ci.org/wbarnha/kafka-python-ng.svg?branch=master
+    :target: https://travis-ci.org/wbarnha/kafka-python-ng
 .. image:: https://img.shields.io/badge/license-Apache%202-blue.svg
-    :target: https://github.com/dpkp/kafka-python/blob/master/LICENSE
+    :target: https://github.com/wbarnha/kafka-python-ng/blob/master/LICENSE
 
 Python client for the Apache Kafka distributed stream processing system.
 kafka-python is designed to function much like the official java client, with a
@@ -31,9 +31,11 @@ failures.  See `Compatibility <compatibility.html>`_ for more details.
 Please note that the master branch may contain unreleased features. For release
 documentation, please see readthedocs and/or python's inline help.
 
+
 .. code:: bash
 
-    pip install kafka-python
+    pip install kafka-python-ng
+
 
 
 KafkaConsumer

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,9 @@ failures.  See `Compatibility <compatibility.html>`_ for more details.
 Please note that the master branch may contain unreleased features. For release
 documentation, please see readthedocs and/or python's inline help.
 
->>> pip install kafka-python
+.. code:: bash
+
+    pip install kafka-python
 
 
 KafkaConsumer
@@ -47,28 +49,36 @@ See `KafkaConsumer <apidoc/KafkaConsumer.html>`_ for API and configuration detai
 The consumer iterator returns ConsumerRecords, which are simple namedtuples
 that expose basic message attributes: topic, partition, offset, key, and value:
 
->>> from kafka import KafkaConsumer
->>> consumer = KafkaConsumer('my_favorite_topic')
->>> for msg in consumer:
-...     print (msg)
+.. code:: python
 
->>> # join a consumer group for dynamic partition assignment and offset commits
->>> from kafka import KafkaConsumer
->>> consumer = KafkaConsumer('my_favorite_topic', group_id='my_favorite_group')
->>> for msg in consumer:
-...     print (msg)
+    from kafka import KafkaConsumer
+    consumer = KafkaConsumer('my_favorite_topic')
+    for msg in consumer:
+        print (msg)
 
->>> # manually assign the partition list for the consumer
->>> from kafka import TopicPartition
->>> consumer = KafkaConsumer(bootstrap_servers='localhost:1234')
->>> consumer.assign([TopicPartition('foobar', 2)])
->>> msg = next(consumer)
+.. code:: python
 
->>> # Deserialize msgpack-encoded values
->>> consumer = KafkaConsumer(value_deserializer=msgpack.loads)
->>> consumer.subscribe(['msgpackfoo'])
->>> for msg in consumer:
-...     assert isinstance(msg.value, dict)
+    # join a consumer group for dynamic partition assignment and offset commits
+    from kafka import KafkaConsumer
+    consumer = KafkaConsumer('my_favorite_topic', group_id='my_favorite_group')
+    for msg in consumer:
+        print (msg)
+
+.. code:: python
+
+    # manually assign the partition list for the consumer
+    from kafka import TopicPartition
+    consumer = KafkaConsumer(bootstrap_servers='localhost:1234')
+    consumer.assign([TopicPartition('foobar', 2)])
+    msg = next(consumer)
+
+.. code:: python
+
+    # Deserialize msgpack-encoded values
+    consumer = KafkaConsumer(value_deserializer=msgpack.loads)
+    consumer.subscribe(['msgpackfoo'])
+    for msg in consumer:
+        assert isinstance(msg.value, dict)
 
 
 KafkaProducer
@@ -78,36 +88,50 @@ KafkaProducer
 The class is intended to operate as similarly as possible to the official java
 client. See `KafkaProducer <apidoc/KafkaProducer.html>`_ for more details.
 
->>> from kafka import KafkaProducer
->>> producer = KafkaProducer(bootstrap_servers='localhost:1234')
->>> for _ in range(100):
-...     producer.send('foobar', b'some_message_bytes')
+.. code:: python
 
->>> # Block until a single message is sent (or timeout)
->>> future = producer.send('foobar', b'another_message')
->>> result = future.get(timeout=60)
+    from kafka import KafkaProducer
+    producer = KafkaProducer(bootstrap_servers='localhost:1234')
+    for _ in range(100):
+        producer.send('foobar', b'some_message_bytes')
 
->>> # Block until all pending messages are at least put on the network
->>> # NOTE: This does not guarantee delivery or success! It is really
->>> # only useful if you configure internal batching using linger_ms
->>> producer.flush()
+.. code:: python
 
->>> # Use a key for hashed-partitioning
->>> producer.send('foobar', key=b'foo', value=b'bar')
+    # Block until a single message is sent (or timeout)
+    future = producer.send('foobar', b'another_message')
+    result = future.get(timeout=60)
 
->>> # Serialize json messages
->>> import json
->>> producer = KafkaProducer(value_serializer=lambda v: json.dumps(v).encode('utf-8'))
->>> producer.send('fizzbuzz', {'foo': 'bar'})
+.. code:: python
 
->>> # Serialize string keys
->>> producer = KafkaProducer(key_serializer=str.encode)
->>> producer.send('flipflap', key='ping', value=b'1234')
+    # Block until all pending messages are at least put on the network
+    # NOTE: This does not guarantee delivery or success! It is really
+    # only useful if you configure internal batching using linger_ms
+    producer.flush()
 
->>> # Compress messages
->>> producer = KafkaProducer(compression_type='gzip')
->>> for i in range(1000):
-...     producer.send('foobar', b'msg %d' % i)
+.. code:: python
+
+    # Use a key for hashed-partitioning
+    producer.send('foobar', key=b'foo', value=b'bar')
+
+.. code:: python
+
+    # Serialize json messages
+    import json
+    producer = KafkaProducer(value_serializer=lambda v: json.dumps(v).encode('utf-8'))
+    producer.send('fizzbuzz', {'foo': 'bar'})
+
+.. code:: python
+
+    # Serialize string keys
+    producer = KafkaProducer(key_serializer=str.encode)
+    producer.send('flipflap', key='ping', value=b'1234')
+
+.. code:: python
+
+    # Compress messages
+    producer = KafkaProducer(compression_type='gzip')
+    for i in range(1000):
+        producer.send('foobar', b'msg %d' % i)
 
 
 Thread safety

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,9 +9,9 @@ Pip:
 
 .. code:: bash
 
-    pip install kafka-python
+    pip install kafka-python-ng
 
-Releases are also listed at https://github.com/dpkp/kafka-python/releases
+Releases are also listed at https://github.com/wbarnha/kafka-python-ng/releases
 
 
 Bleeding-Edge
@@ -19,21 +19,21 @@ Bleeding-Edge
 
 .. code:: bash
 
-    git clone https://github.com/dpkp/kafka-python
-    pip install ./kafka-python
+    git clone https://github.com/wbarnha/kafka-python-ng
+    pip install ./kafka-python-ng
 
 
 Optional crc32c install
 ***********************
-Highly recommended if you are using Kafka 11+ brokers. For those `kafka-python`
+Highly recommended if you are using Kafka 11+ brokers. For those `kafka-python-ng`
 uses a new message protocol version, that requires calculation of `crc32c`,
-which differs from the `zlib.crc32` hash implementation. By default `kafka-python`
+which differs from the `zlib.crc32` hash implementation. By default `kafka-python-ng`
 calculates it in pure python, which is quite slow. To speed it up we optionally
 support https://pypi.python.org/pypi/crc32c package if it's installed.
 
 .. code:: bash
 
-    pip install 'kafka-python[crc32c]'
+    pip install 'kafka-python-ng[crc32c]'
 
 
 Optional ZSTD install
@@ -41,7 +41,7 @@ Optional ZSTD install
 
 To enable ZSTD compression/decompression, install python-zstandard:
 
->>> pip install 'kafka-python[zstd]'
+>>> pip install 'kafka-python-ng[zstd]'
 
 
 Optional LZ4 install
@@ -49,7 +49,7 @@ Optional LZ4 install
 
 To enable LZ4 compression/decompression, install python-lz4:
 
->>> pip install 'kafka-python[lz4]'
+>>> pip install 'kafka-python-ng[lz4]'
 
 
 Optional Snappy install
@@ -90,4 +90,4 @@ Install the `python-snappy` module
 
 .. code:: bash
 
-    pip install 'kafka-python[snappy]'
+    pip install 'kafka-python-ng[snappy]'

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -2,9 +2,9 @@ License
 -------
 
 .. image:: https://img.shields.io/badge/license-Apache%202-blue.svg
-    :target: https://github.com/dpkp/kafka-python/blob/master/LICENSE
+    :target: https://github.com/wbarnha/kafka-python-ng/blob/master/LICENSE
 
-Apache License, v2.0. See `LICENSE <https://github.com/dpkp/kafka-python/blob/master/LICENSE>`_.
+Apache License, v2.0. See `LICENSE <https://github.com/wbarnha/kafka-python-ng/blob/master/LICENSE>`_.
 
 Copyright 2016, Dana Powers, David Arthur, and Contributors
-(See `AUTHORS <https://github.com/dpkp/kafka-python/blob/master/AUTHORS.md>`_).
+(See `AUTHORS <https://github.com/wbarnha/kafka-python-ng/blob/master/AUTHORS.md>`_).

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,7 +1,7 @@
 Support
 -------
 
-For support, see github issues at https://github.com/dpkp/kafka-python
+For support, see github issues at https://github.com/wbarnha/kafka-python-ng
 
 Limited IRC chat at #kafka-python on freenode (general chat is #apache-kafka).
 

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -1,17 +1,17 @@
 Tests
 =====
 
-.. image:: https://coveralls.io/repos/dpkp/kafka-python/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/dpkp/kafka-python?branch=master
-.. image:: https://travis-ci.org/dpkp/kafka-python.svg?branch=master
-    :target: https://travis-ci.org/dpkp/kafka-python
+.. image:: https://coveralls.io/repos/wbarnha/kafka-python-ng/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/wbarnha/kafka-python-ng?branch=master
+.. image:: https://travis-ci.org/wbarnha/kafka-python-ng.svg?branch=master
+    :target: https://travis-ci.org/wbarnha/kafka-python-ng
 
 Test environments are managed via tox. The test suite is run via pytest.
 
 Linting is run via pylint, but is generally skipped on pypy due to pylint
 compatibility / performance issues.
 
-For test coverage details, see https://coveralls.io/github/dpkp/kafka-python
+For test coverage details, see https://coveralls.io/github/wbarnha/kafka-python-ng
 
 The test suite includes unit tests that mock network interfaces, as well as
 integration tests that setup and teardown kafka broker (and zookeeper)

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -637,6 +637,9 @@ class KafkaClient(object):
             self._sensors.select_time.record((end_select - start_select) * 1000000000)
 
         for key, events in ready:
+            if key.fileobj.fileno() < 0:
+                self._selector.unregister(key.fileobj)
+
             if key.fileobj is self._wake_r:
                 self._clear_wake_fd()
                 continue

--- a/kafka/protocol/admin.py
+++ b/kafka/protocol/admin.py
@@ -719,7 +719,7 @@ class DescribeConfigsResponse_v1(Response):
                 ('config_names', String('utf-8')),
                 ('config_value', String('utf-8')),
                 ('read_only', Boolean),
-                ('is_default', Boolean),
+                ('config_source', Int8),
                 ('is_sensitive', Boolean),
                 ('config_synonyms', Array(
                     ('config_name', String('utf-8')),

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,9 @@
-__version__ = '2.0.3-dev'
+import sys
+
+if sys.version_info < (3, 8):
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
+
+
+__version__ = version("kafka-python-ng")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import setup, Command, find_packages
 
 # Pull version from source without importing
 # since we can't import something we haven't built yet :)
-exec(open('kafka/version.py').read())
 
 
 class Tox(Command):
@@ -32,9 +31,9 @@ with open(os.path.join(here, 'README.rst')) as f:
     README = f.read()
 
 setup(
-    name="kafka-python",
-    version=__version__,
-
+    name="kafka-python-ng",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
     tests_require=test_require,
     extras_require={
         "crc32c": ["crc32c"],
@@ -46,7 +45,9 @@ setup(
     packages=find_packages(exclude=['test']),
     author="Dana Powers",
     author_email="dana.powers@gmail.com",
-    url="https://github.com/dpkp/kafka-python",
+    maintainer="William Barnhart",
+    maintainer_email="williambbarnhart@gmail.com",
+    url="https://github.com/wbarnha/kafka-python-ng",
     license="Apache License 2.0",
     description="Pure Python client for Apache Kafka",
     long_description=README,

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 
 setup(
     name="kafka-python-ng",
+    python_requires=">=3.8",
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     tests_require=test_require,
@@ -60,13 +61,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/test/test_admin_integration.py
+++ b/test/test_admin_integration.py
@@ -1,3 +1,5 @@
+import platform
+
 import pytest
 
 from logging import info
@@ -151,6 +153,9 @@ def test_describe_consumer_group_does_not_exist(kafka_admin_client):
         group_description = kafka_admin_client.describe_consumer_groups(['test'])
 
 
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy", reason="Works on PyPy if run locally, but not in CI/CD pipeline."
+)
 @pytest.mark.skipif(env_kafka_version() < (0, 11), reason='Describe consumer group requires broker >=0.11')
 def test_describe_consumer_group_exists(kafka_admin_client, kafka_consumer_factory, topic):
     """Tests that the describe consumer group call returns valid consumer group information

--- a/test/test_consumer_group.py
+++ b/test/test_consumer_group.py
@@ -1,5 +1,6 @@
 import collections
 import logging
+import platform
 import threading
 import time
 
@@ -40,6 +41,9 @@ def test_consumer_topics(kafka_broker, topic):
     consumer.close()
 
 
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy", reason="Works on PyPy if run locally, but not in CI/CD pipeline."
+)
 @pytest.mark.skipif(env_kafka_version() < (0, 9), reason='Unsupported Kafka Version')
 def test_group(kafka_broker, topic):
     num_partitions = 4

--- a/test/test_partitioner.py
+++ b/test/test_partitioner.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import pytest
 
+
 from kafka.partitioner import DefaultPartitioner, murmur2
 
 

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -1,5 +1,6 @@
 import gc
 import platform
+import sys
 import time
 import threading
 
@@ -10,6 +11,7 @@ from kafka.producer.buffer import SimpleBufferPool
 from test.testutil import env_kafka_version, random_string
 
 
+@pytest.mark.skipif(env_kafka_version() <= (0, 8, 2) and sys.version_info > (3, 11), reason="Kafka 0.8.2 and earlier not supported by 3.12")
 def test_buffer_pool():
     pool = SimpleBufferPool(1000, 1000)
 
@@ -21,8 +23,8 @@ def test_buffer_pool():
     buf2 = pool.allocate(1000, 1000)
     assert buf2.read() == b''
 
-
 @pytest.mark.skipif(not env_kafka_version(), reason="No KAFKA_VERSION set")
+@pytest.mark.skipif(env_kafka_version() <= (0, 8, 2) and sys.version_info > (3, 11), reason="Kafka 0.8.2 and earlier not supported by 3.12")
 @pytest.mark.parametrize("compression", [None, 'gzip', 'snappy', 'lz4', 'zstd'])
 def test_end_to_end(kafka_broker, compression):
     if compression == 'lz4':
@@ -70,6 +72,7 @@ def test_end_to_end(kafka_broker, compression):
 
 @pytest.mark.skipif(platform.python_implementation() != 'CPython',
                     reason='Test relies on CPython-specific gc policies')
+@pytest.mark.skipif(env_kafka_version() <= (0, 8, 2) and sys.version_info > (3, 11), reason="Kafka 0.8.2 and earlier not supported by 3.12")
 def test_kafka_producer_gc_cleanup():
     gc.collect()
     threads = threading.active_count()
@@ -81,6 +84,7 @@ def test_kafka_producer_gc_cleanup():
 
 
 @pytest.mark.skipif(not env_kafka_version(), reason="No KAFKA_VERSION set")
+@pytest.mark.skipif(env_kafka_version() <= (0, 8, 2) and sys.version_info > (3, 11), reason="Kafka 0.8.2 and earlier not supported by 3.12")
 @pytest.mark.parametrize("compression", [None, 'gzip', 'snappy', 'lz4', 'zstd'])
 def test_kafka_producer_proper_record_metadata(kafka_broker, compression):
     if compression == 'zstd' and env_kafka_version() < (2, 1, 0):


### PR DESCRIPTION
In the previous rst documentation, code blocks were not used, which didn't make it easy to copy, and there was no corresponding code highlighting when previewing.

Also, in README.rst, hyperlinks are not required to be used in the form of `<url>`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2429)
<!-- Reviewable:end -->
