### PR TITLE
Fixes KafkaConsumer examples in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,13 +56,15 @@ The consumer iterator returns ConsumerRecords, which are simple namedtuples
 that expose basic message attributes: topic, partition, offset, key, and value:
 
 >>> from kafka import KafkaConsumer
->>> consumer = KafkaConsumer('my_favorite_topic')
+>>> consumer = KafkaConsumer(bootstrap_servers='localhost:1234')
+>>> consumer.subscribe(['my_favourite_topic'])
 >>> for msg in consumer:
 ...     print (msg)
 
 >>> # join a consumer group for dynamic partition assignment and offset commits
 >>> from kafka import KafkaConsumer
->>> consumer = KafkaConsumer('my_favorite_topic', group_id='my_favorite_group')
+>>> consumer = KafkaConsumer(bootstrap_servers='localhost:1234', group_id='my_favorite_group')
+>>> consumer.subscribe(['my_favourite_topic'])
 >>> for msg in consumer:
 ...     print (msg)
 


### PR DESCRIPTION
in the README.rst files KafkaConsumer take as argument the topic which is not correct, i corrected the two first examples from:

>>> from kafka import KafkaConsumer
>>> consumer = KafkaConsumer('my_favorite_topic')
>>> for msg in consumer:
...     print (msg)

>>> # join a consumer group for dynamic partition assignment and offset commits
>>> from kafka import KafkaConsumer
>>> consumer = KafkaConsumer('my_favorite_topic', group_id='my_favorite_group')
>>> for msg in consumer:
...     print (msg)

to:

>>> from kafka import KafkaConsumer
>>> consumer = KafkaConsumer(bootstrap_servers='localhost:1234')
>>> consumer.subscribe(['my_favourite_topic'])
>>> for msg in consumer:
...     print (msg)

>>> # join a consumer group for dynamic partition assignment and offset commits
>>> from kafka import KafkaConsumer
>>> consumer = KafkaConsumer(bootstrap_servers='localhost:1234', group_id='my_favorite_group')
>>> consumer.subscribe(['my_favourite_topic'])
>>> for msg in consumer:
...     print (msg)

Thanks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpkp/kafka-python/2444)
<!-- Reviewable:end -->
