### PR TITLE
Refactor Makefile

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -73,7 +73,7 @@ jobs:
           java-version: 21
       - name: Pull Kafka release
         run: make servers/${{ matrix.kafka }}/kafka-bin
-      - name: Test with tox
+      - name: Pytest
         run: make test
         env:
           KAFKA_VERSION: ${{ matrix.kafka }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,16 +70,10 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
-      - name: Check Java installation
-        run: source travis_java_install.sh
-      - name: Pull Kafka releases
-        run: ./build_integration.sh
-        env:
-          PLATFORM: ${{ matrix.platform }}
-          KAFKA_VERSION: ${{ matrix.kafka }}
+          java-version: 21
+      - name: Pull Kafka release
+        run: make servers/${{ matrix.kafka }}/kafka-bin
       - name: Test with tox
-        run: tox
+        run: make test
         env:
-          PLATFORM: ${{ matrix.platform }}
           KAFKA_VERSION: ${{ matrix.kafka }}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ SHELL = bash
 
 export KAFKA_VERSION ?= 2.4.0
 DIST_BASE_URL ?= https://archive.apache.org/dist/kafka/
-TEST_FLAGS ?=
 
 # Required to support testing old kafka versions on newer java releases
 # The performance opts defaults are set in each kafka brokers bin/kafka_run_class.sh file

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,18 @@ publish:
 .PHONY: all test test-local cov-local clean doc dist publish
 
 kafka_artifact_version=$(lastword $(subst -, ,$(1)))
+
+# Mappings for artifacts -> scala version; any unlisted will use default 2.12
 kafka_scala_0_8_0=2.8.0
-scala_version=$(if $(SCALA_VERSION),$(SCALA_VERSION),$(if $(kafka_scala_$(subst .,_,$(1))),$(kafka_scala_$(subst .,_,$(1))),"2.12"))
+kafka_scala_0_8_1=2.10
+kafka_scala_0_8_1_1=2.10
+kafka_scala_0_9_0_0=2.11
+kafka_scala_0_9_0_1=2.11
+kafka_scala_0_10_0_0=2.11
+kafka_scala_0_10_0_1=2.11
+kafka_scala_0_10_1_0=2.11
+scala_version=$(if $(SCALA_VERSION),$(SCALA_VERSION),$(if $(kafka_scala_$(subst .,_,$(1))),$(kafka_scala_$(subst .,_,$(1))),2.12))
+
 kafka_artifact_name=kafka_$(call scala_version,$(1))-$(1).$(if $(filter 0.8.0,$(1)),tar.gz,tgz)
 
 build-integration: servers/$(KAFKA_VERSION)/kafka-bin

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ setup:
 	pip install -r requirements-dev.txt
 	pip install -Ue .
 
-# Test and produce coverage using tox. This is the same as is run on Travis
+lint:
+	pylint --recursive=y --errors-only kafka test
+
 test: build-integration
-	tox -e $(TOX_ENV) -- $(TEST_FLAGS)
+	pytest --durations=10 kafka test
 
 # Test using pytest directly if you want to use local python. Useful for other
 # platforms that require manual installation for C libraries, ie. Windows.

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ kafka_artifact_version=$(lastword $(subst -, ,$(1)))
 kafka_scala_0_8_0=2.8.0
 kafka_scala_0_8_1=2.10
 kafka_scala_0_8_1_1=2.10
+kafka_scala_0_8_2_0=2.11
+kafka_scala_0_8_2_1=2.11
+kafka_scala_0_8_2_2=2.11
 kafka_scala_0_9_0_0=2.11
 kafka_scala_0_9_0_1=2.11
 kafka_scala_0_10_0_0=2.11
@@ -97,6 +100,7 @@ servers/%/kafka-bin: servers/dist/$$(call kafka_artifact_name,$$*) | servers/dis
 	if [ -d "$@" ]; then rm -rf $@.bak; mv $@ $@.bak; fi
 	mkdir $@
 	tar xzvf $< -C $@ --strip-components 1
+	if [[ "$*" < "1" ]]; then make servers/patch-libs/$*; fi
 
 servers/patch-libs/%: servers/dist/jakarta.xml.bind-api-2.3.3.jar | servers/$$*/kafka-bin
 	cp $< servers/$*/kafka-bin/libs/

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ servers/dist:
 
 servers/dist/kafka_%.tgz servers/dist/kafka_%.tar.gz:
 	@echo "Downloading $(@F)"
-	wget -P servers/dist/ -N $(DIST_BASE_URL)$(call kafka_artifact_version,$*)/$(@F)
+	wget -nv -P servers/dist/ -N $(DIST_BASE_URL)$(call kafka_artifact_version,$*)/$(@F)
 
 servers/dist/jakarta.xml.bind-api-2.3.3.jar:
-	wget -P servers/dist/ -N https://repo1.maven.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/2.3.3/jakarta.xml.bind-api-2.3.3.jar
+	wget -nv -P servers/dist/ -N https://repo1.maven.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/2.3.3/jakarta.xml.bind-api-2.3.3.jar
 
 # to allow us to derive the prerequisite artifact name from the target name
 .SECONDEXPANSION:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
-# Some simple testing tasks (sorry, UNIX only).
+# Some simple testing tasks
 
-TEST_FLAGS ?=
-export KAFKA_VERSION ?= 0.11.0.2
-KAFKA_ARTIFACT ?= kafka_$(SCALA_VERSION)-$(KAFKA_VERSION).tgz
+export KAFKA_VERSION ?= 2.4.0
 DIST_BASE_URL ?= https://archive.apache.org/dist/kafka/
-TOX_ENV ?= 312
+TEST_FLAGS ?=
 
 # Required to support testing old kafka versions on newer java releases
 # The performance opts defaults are set in each kafka brokers bin/kafka_run_class.sh file

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,6 @@ doc:
 	make -C docs html
 	@echo "open file://`pwd`/docs/_build/html/index.html"
 
-dist:
-	python setup.py bdist_wheel
-	python setup.py sdist
-
-publish:
-	twine upload dist/kafka-python-${KAFKA_PYTHON_VERSION}.tar.gz dist/kafka_python-${KAFKA_PYTHON_VERSION}-py2.py3-none-any.whl
-
 .PHONY: all test test-local cov-local clean doc dist publish
 
 kafka_artifact_version=$(lastword $(subst -, ,$(1)))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Some simple testing tasks
 
+SHELL = bash
+
 export KAFKA_VERSION ?= 2.4.0
 DIST_BASE_URL ?= https://archive.apache.org/dist/kafka/
 TEST_FLAGS ?=

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ Sphinx
 sphinx-rtd-theme
 tox
 xxhash
+zstandard

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,7 @@ commands =
 setenv =
     CRC32C_SW_MODE = auto
     PROJECT_ROOT = {toxinidir}
-passenv = KAFKA_VERSION
-
+passenv = KAFKA_*
 
 [testenv:pypy]
 # pylint is super slow on pypy...


### PR DESCRIPTION
Move artifact download + installation into Makefile (from build_integration.sh). Call pylint and pytest directly in separate targets. Export KAFKA vars for testing. Add support for running old kafka versions with newer jvm.