### PR TITLE
Avoid logging errors during test fixture cleanup

### DIFF
--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -183,7 +183,8 @@ class ZookeeperFixture(Fixture):
         return env
 
     def out(self, message):
-        log.info("*** Zookeeper [%s:%s]: %s", self.host, self.port or '(auto)', message)
+        if len(log.handlers) > 0:
+            log.info("*** Zookeeper [%s:%s]: %s", self.host, self.port or '(auto)', message)
 
     def open(self):
         if self.tmp_dir is None:
@@ -381,7 +382,8 @@ class KafkaFixture(Fixture):
         return env
 
     def out(self, message):
-        log.info("*** Kafka [%s:%s]: %s", self.host, self.port or '(auto)', message)
+        if len(log.handlers) > 0:
+            log.info("*** Kafka [%s:%s]: %s", self.host, self.port or '(auto)', message)
 
     def _create_zk_chroot(self):
         self.out("Creating Zookeeper chroot node...")


### PR DESCRIPTION
Pytest fixture cleanup causes a lot of log spam due to closed file descriptors. Small change to avoid logging if handlers are gone.