### PR TITLE
Dont raise RuntimeError for dead process in SpawnedService.wait_for()

### DIFF
--- a/test/service.py
+++ b/test/service.py
@@ -113,7 +113,8 @@ class SpawnedService(threading.Thread):
         start = time.time()
         while True:
             if not self.is_alive():
-                raise RuntimeError("Child thread died already.")
+                log.error("Child thread died already.")
+                return False
 
             elapsed = time.time() - start
             if elapsed >= timeout:


### PR DESCRIPTION
We have retry / backoff code in test/fixtures.py, so there's no reason to raise an exception here. Exception causes flakey test runs where backoff/retry would likely have worked. See https://github.com/dpkp/kafka-python/actions/runs/13184905494/job/36804606580 