### PR TITLE
Remove unreachable raise in __cmp__ method

### DIFF
--- a/kafka/vendor/enum34.py
+++ b/kafka/vendor/enum34.py
@@ -719,7 +719,6 @@ if pyver < 2.6:
                 return 0
             return -1
         return NotImplemented
-        raise TypeError("unorderable types: %s() and %s()" % (self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__cmp__'] = __cmp__
     del __cmp__
 


### PR DESCRIPTION
Motivation:
The raise statement was unreachable code and never executed after the return statement, causing confusion and redundancy.

Modifications:
Removed the `raise NotImplementedError` call in the `__cmp__` method.

Result:
The `__cmp__` method is now clearer, avoiding any unused or unreachable code.