### PR TITLE
Call ApiVersionsRequest during connection, prior to Sasl Handshake

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -1014,7 +1014,7 @@ class KafkaClient(object):
                     continue
                 try_node = node_id or self.least_loaded_node()
                 if try_node is None:
-                    sleep_time = min(time_remaining,  least_loaded_node_refresh_ms / 1000.0)
+                    sleep_time = min(time_remaining,  self.least_loaded_node_refresh_ms() / 1000.0)
                     if sleep_time > 0:
                         log.warning('No node available during check_version; sleeping %.2f secs', sleep_time)
                         time.sleep(sleep_time)

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -1027,7 +1027,7 @@ class KafkaClient(object):
                         continue
                 conn = self._conns[try_node]
 
-                while not conn.disconnected() and conn._api_version is None and time.time() < end:
+                while conn.connecting() and time.time() < end:
                     timeout_ms = min((end - time.time()) * 1000, 200)
                     self.poll(timeout_ms=timeout_ms)
 

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -338,6 +338,8 @@ class KafkaClient(object):
 
                 if self.cluster.is_bootstrap(node_id):
                     self._bootstrap_fails = 0
+                    if self._api_versions is None:
+                        self._api_versions = conn._api_versions
 
                 else:
                     for node_id in list(self._conns.keys()):
@@ -976,7 +978,7 @@ class KafkaClient(object):
     def get_api_versions(self):
         """Return the ApiVersions map, if available.
 
-        Note: Only available after first connection to any broker version 0.10.0 or later.
+        Note: Only available after bootstrap; requires broker version 0.10.0 or later.
 
         Returns: a map of dict mapping {api_key : (min_version, max_version)},
         or None if ApiVersion is not supported by the kafka cluster.
@@ -1030,8 +1032,6 @@ class KafkaClient(object):
                     self.poll(timeout_ms=timeout_ms)
 
                 if conn._api_version is not None:
-                    if not self._api_versions:
-                        self._api_versions = conn._api_versions
                     return conn._api_version
 
             # Timeout

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -315,7 +315,13 @@ class KafkaClient(object):
                 if self.cluster.is_bootstrap(node_id):
                     self._last_bootstrap = time.time()
 
-            elif conn.state in (ConnectionStates.API_VERSIONS, ConnectionStates.AUTHENTICATING):
+            elif conn.state is ConnectionStates.API_VERSIONS_SEND:
+                try:
+                    self._selector.register(sock, selectors.EVENT_WRITE, conn)
+                except KeyError:
+                    self._selector.modify(sock, selectors.EVENT_WRITE, conn)
+
+            elif conn.state in (ConnectionStates.API_VERSIONS_RECV, ConnectionStates.AUTHENTICATING):
                 try:
                     self._selector.register(sock, selectors.EVENT_READ, conn)
                 except KeyError:

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -976,15 +976,14 @@ class KafkaClient(object):
     def get_api_versions(self):
         """Return the ApiVersions map, if available.
 
-        Note: A call to check_version must previously have succeeded and returned
-        version 0.10.0 or later
+        Note: Only available after first connection to any broker version 0.10.0 or later.
 
         Returns: a map of dict mapping {api_key : (min_version, max_version)},
         or None if ApiVersion is not supported by the kafka cluster.
         """
         return self._api_versions
 
-    def check_version(self, node_id=None, timeout=None, strict=False):
+    def check_version(self, node_id=None, timeout=None, **kwargs):
         """Attempt to guess the version of a Kafka broker.
 
         Keyword Arguments:

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -1071,7 +1071,7 @@ class KafkaClient(object):
         broker_api_versions = self._api_versions
         api_key = operation[0].API_KEY
         if broker_api_versions is None or api_key not in broker_api_versions:
-            raise IncompatibleBrokerVersion(
+            raise Errors.IncompatibleBrokerVersion(
                 "Kafka broker does not support the '{}' Kafka protocol."
                 .format(operation[0].__name__))
         broker_min_version, broker_max_version = broker_api_versions[api_key]
@@ -1079,7 +1079,7 @@ class KafkaClient(object):
         if version < broker_min_version:
             # max library version is less than min broker version. Currently,
             # no Kafka versions specify a min msg version. Maybe in the future?
-            raise IncompatibleBrokerVersion(
+            raise Errors.IncompatibleBrokerVersion(
                 "No version of the '{}' Kafka protocol is supported by both the client and broker."
                 .format(operation[0].__name__))
         return version

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -27,7 +27,8 @@ from kafka.oauth.abstract import AbstractTokenProvider
 from kafka.protocol.admin import DescribeAclsRequest, DescribeClientQuotasRequest, ListGroupsRequest, SaslHandShakeRequest
 from kafka.protocol.api_versions import ApiVersionsRequest
 from kafka.protocol.broker_api_versions import BROKER_API_VERSIONS
-from kafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
+from kafka.protocol.commit import OffsetFetchRequest
+from kafka.protocol.find_coordinator import FindCoordinatorRequest
 from kafka.protocol.list_offsets import ListOffsetsRequest
 from kafka.protocol.produce import ProduceRequest
 from kafka.protocol.metadata import MetadataRequest
@@ -233,7 +234,7 @@ class BrokerConnection(object):
     SASL_MECHANISMS = ('PLAIN', 'GSSAPI', 'OAUTHBEARER', "SCRAM-SHA-256", "SCRAM-SHA-512")
     VERSION_CHECKS = (
         ((0, 9), ListGroupsRequest[0]()),
-        ((0, 8, 2), GroupCoordinatorRequest[0]('kafka-python-default-group')),
+        ((0, 8, 2), FindCoordinatorRequest[0]('kafka-python-default-group')),
         ((0, 8, 1), OffsetFetchRequest[0]('kafka-python-default-group', [])),
         ((0, 8, 0), MetadataRequest[0]([])),
     )

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -171,7 +171,7 @@ class BrokerConnection(object):
             Default: None
         api_version_auto_timeout_ms (int): number of milliseconds to throw a
             timeout exception from the constructor when checking the broker
-            api version. Only applies if api_version is None
+            api version. Only applies if api_version is None. Default: 2000.
         selector (selectors.BaseSelector): Provide a specific selector
             implementation to use for I/O multiplexing.
             Default: selectors.DefaultSelector
@@ -217,6 +217,7 @@ class BrokerConnection(object):
         'ssl_password': None,
         'ssl_ciphers': None,
         'api_version': None,
+        'api_version_auto_timeout_ms': 2000,
         'selector': selectors.DefaultSelector,
         'state_change_callback': lambda node_id, sock, conn: True,
         'metrics': None,
@@ -549,14 +550,14 @@ class BrokerConnection(object):
                 # ((0, 10), ApiVersionsRequest[0]()),
                 request = ApiVersionsRequest[0]()
                 future = Future()
-                response = self._send(request, blocking=True)
+                response = self._send(request, blocking=True, request_timeout_ms=(self.config['api_version_auto_timeout_ms'] * 0.8))
                 response.add_callback(self._handle_api_versions_response, future)
                 response.add_errback(self._handle_api_versions_failure, future)
                 self._api_versions_future = future
             elif self._check_version_idx < len(self.VERSION_CHECKS):
                 version, request = self.VERSION_CHECKS[self._check_version_idx]
                 future = Future()
-                response = self._send(request, blocking=True)
+                response = self._send(request, blocking=True, request_timeout_ms=(self.config['api_version_auto_timeout_ms'] * 0.8))
                 response.add_callback(self._handle_check_version_response, future, version)
                 response.add_errback(self._handle_check_version_failure, future)
                 self._api_versions_future = future

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -597,6 +597,7 @@ class BrokerConnection(object):
             for api_key, min_version, max_version in response.api_versions
         ])
         self._api_version = self._infer_broker_version_from_api_versions(self._api_versions)
+        log.info('Broker version identified as %s', '.'.join(map(str, self._api_version)))
         future.success(self._api_version)
         self.connect()
 
@@ -607,8 +608,8 @@ class BrokerConnection(object):
 
     def _handle_check_version_response(self, future, version, _response):
         log.info('Broker version identified as %s', '.'.join(map(str, version)))
-        #log.info('Set configuration api_version=%s to skip auto'
-        #         ' check_version requests on startup', version)
+        log.info('Set configuration api_version=%s to skip auto'
+                 ' check_version requests on startup', version)
         self._api_versions = BROKER_API_VERSIONS[version]
         self._api_version = version
         future.success(version)

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -537,7 +537,10 @@ class BrokerConnection(object):
 
     def _try_api_versions_check(self):
         if self._api_versions_future is None:
-            if self._check_version_idx is None:
+            if self.config['api_version'] is not None:
+                self._api_version = self.config['api_version']
+                return True
+            elif self._check_version_idx is None:
                 # TODO: Implement newer versions
                 # ((3, 9), ApiVersionsRequest[4]()),
                 # ((2, 4), ApiVersionsRequest[3]()),

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -1364,12 +1364,18 @@ class BrokerConnection(object):
         # so if all else fails, choose that
         return (0, 10, 0)
 
-    def check_version(self, timeout=2, strict=False, topics=[]):
+    def check_version(self, timeout=2, **kwargs):
         """Attempt to guess the broker version.
+
+        Keyword Arguments:
+            timeout (numeric, optional): Maximum number of seconds to block attempting
+                to connect and check version. Default 2
 
         Note: This is a blocking call.
 
         Returns: version tuple, i.e. (3, 9), (2, 4), etc ...
+
+        Raises: NodeNotReadyError on timeout
         """
         timeout_at = time.time() + timeout
         if not self.connect_blocking(timeout_at - time.time()):

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -543,6 +543,7 @@ class BrokerConnection(object):
         if self._api_versions_future is None:
             if self.config['api_version'] is not None:
                 self._api_version = self.config['api_version']
+                self._api_versions = BROKER_API_VERSIONS[self._api_version]
                 return True
             elif self._check_version_idx is None:
                 request = ApiVersionsRequest[self._api_versions_idx]()

--- a/kafka/protocol/api_versions.py
+++ b/kafka/protocol/api_versions.py
@@ -76,8 +76,8 @@ class ApiVersionsRequest_v1(Request):
 class ApiVersionsRequest_v2(Request):
     API_KEY = 18
     API_VERSION = 2
-    RESPONSE_TYPE = ApiVersionsResponse_v1
-    SCHEMA = ApiVersionsRequest_v0.SCHEMA
+    RESPONSE_TYPE = ApiVersionsResponse_v2
+    SCHEMA = ApiVersionsRequest_v1.SCHEMA
 
 
 ApiVersionsRequest = [

--- a/test/test_conn.py
+++ b/test/test_conn.py
@@ -15,6 +15,13 @@ from kafka.protocol.produce import ProduceRequest
 
 import kafka.errors as Errors
 
+from kafka.vendor import six
+
+if six.PY2:
+    ConnectionError = socket.error
+    TimeoutError = socket.error
+    BlockingIOError = Exception
+
 
 @pytest.fixture
 def dns_lookup(mocker):


### PR DESCRIPTION
Moves ApiVersionsRequest into pre-connection state handling, prior to SaslHandshake. Use v2 for initial request and check for UnsupportedVersionError.

Skips ApiVersionsRequest if `api_version` has been configured by user.