### PR TITLE
Remove the "mock" dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ crc32c = ["crc32c"]
 lz4 = ["lz4"]
 snappy = ["python-snappy"]
 zstd = ["zstandard"]
-testing = ["pytest", "mock", "pytest-mock"]
+testing = ["pytest", "pytest-mock"]
 
 [tool.setuptools]
 include-package-data = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ crc32c
 docker-py
 flake8
 lz4
-mock
 py
 pylint
 pytest

--- a/test/record/test_default_records.py
+++ b/test/record/test_default_records.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import pytest
-from mock import patch
+from unittest.mock import patch
 import kafka.codec
 from kafka.record.default_records import (
     DefaultRecordBatch, DefaultRecordBatchBuilder

--- a/test/record/test_legacy_records.py
+++ b/test/record/test_legacy_records.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 import pytest
-from mock import patch
+from unittest.mock import patch
 from kafka.record.legacy_records import (
     LegacyRecordBatch, LegacyRecordBatchBuilder
 )

--- a/test/test_conn.py
+++ b/test/test_conn.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from errno import EALREADY, EINPROGRESS, EISCONN, ECONNRESET
 import socket
 
-import mock
+from unittest import mock
 import pytest
 
 from kafka.conn import BrokerConnection, ConnectionStates, collect_hosts

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from mock import patch, ANY
+from unittest.mock import patch, ANY
 import pytest
 from kafka.vendor.six.moves import range
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ deps =
     pylint
     pytest-pylint
     pytest-mock
-    mock
     python-snappy
     zstandard
     lz4


### PR DESCRIPTION
"mock" is included inside the standard "unittest" package in Python >= 3.3.