### PR TITLE
Make the "mock" dependency optional (only used in Python 2.7).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ crc32c = ["crc32c"]
 lz4 = ["lz4"]
 snappy = ["python-snappy"]
 zstd = ["zstandard"]
-testing = ["pytest", "mock", "pytest-mock"]
+testing = ["pytest", "mock; python_version < '3.3'", "pytest-mock"]
 
 [tool.setuptools]
 include-package-data = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ crc32c
 docker-py
 flake8
 lz4
-mock
+mock; python_version < '3.3'
 py
 pylint
 pytest

--- a/test/record/test_default_records.py
+++ b/test/record/test_default_records.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import pytest
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 import kafka.codec
 from kafka.record.default_records import (
     DefaultRecordBatch, DefaultRecordBatchBuilder

--- a/test/record/test_legacy_records.py
+++ b/test/record/test_legacy_records.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 import pytest
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 from kafka.record.legacy_records import (
     LegacyRecordBatch, LegacyRecordBatchBuilder
 )

--- a/test/test_conn.py
+++ b/test/test_conn.py
@@ -4,7 +4,10 @@ from __future__ import absolute_import
 from errno import EALREADY, EINPROGRESS, EISCONN, ECONNRESET
 import socket
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from kafka.conn import BrokerConnection, ConnectionStates, collect_hosts

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -1,7 +1,10 @@
 import logging
 import time
 
-from mock import patch, ANY
+try:
+    from unittest.mock import patch, ANY
+except ImportError:
+    from mock import patch, ANY
 import pytest
 from kafka.vendor.six.moves import range
 


### PR DESCRIPTION
"mock" is included inside the standard "unittest" package in Python >= 3.3.

(This is an alternatve version of what was proposed (and declined) earlier in #2516. The idea is to allow distributions to package kafka-python without having to patch it explicitly to remove the "mock" dependency).