### PR TITLE
Support client.poll with future and timeout_ms

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -276,6 +276,10 @@ class Fetcher(six.Iterator):
             future = self._send_list_offsets_requests(timestamps)
             self._client.poll(future=future, timeout_ms=inner_timeout_ms())
 
+            # Timeout w/o future completion
+            if not future.is_done:
+                break
+
             if future.succeeded():
                 return future.value
             if not future.retriable():

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -695,7 +695,8 @@ class KafkaConsumer(six.Iterator):
             dict: Map of topic to list of records (may be empty).
         """
         begin = time.time()
-        self._coordinator.poll(timeout_ms=timeout_ms)
+        if not self._coordinator.poll(timeout_ms=timeout_ms):
+            return {}
 
         # Fetch positions if we have partitions we're subscribed to that we
         # don't know the offset for
@@ -1162,7 +1163,8 @@ class KafkaConsumer(six.Iterator):
 
         while time.time() < self._consumer_timeout:
 
-            self._coordinator.poll(timeout_ms=inner_poll_ms())
+            if not self._coordinator.poll(timeout_ms=inner_poll_ms()):
+                continue
 
             # Fetch offsets for any subscribed partitions that we arent tracking yet
             if not self._subscription.has_all_fetch_positions():

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -338,7 +338,6 @@ class BaseCoordinator(object):
             log.info("Successfully joined group %s with generation %s",
                      self.group_id, self._generation.generation_id)
             self.state = MemberState.STABLE
-            self.rejoin_needed = False
             if self._heartbeat_thread:
                 self._heartbeat_thread.enable()
 
@@ -424,6 +423,7 @@ class BaseCoordinator(object):
                                            future.value)
                     self.join_future = None
                     self.rejoining = False
+                    self.rejoin_needed = False
 
                 else:
                     self.join_future = None

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -267,7 +267,7 @@ class ConsumerCoordinator(BaseCoordinator):
         periodic offset commits if they are enabled.
         """
         if self.group_id is None:
-            return
+            return True
 
         inner_timeout_ms = timeout_ms_fn(timeout_ms, 'Timeout in coordinator.poll')
         try:
@@ -296,9 +296,10 @@ class ConsumerCoordinator(BaseCoordinator):
                 self.poll_heartbeat()
 
             self._maybe_auto_commit_offsets_async()
+            return True
 
         except Errors.KafkaTimeoutError:
-            return
+            return False
 
     def time_to_next_poll(self):
         """Return seconds (float) remaining until :meth:`.poll` should be called again"""

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -14,7 +14,7 @@ from kafka.vendor.six.moves import urllib, range
 from kafka.vendor.six.moves.urllib.parse import urlparse  # pylint: disable=E0611,F0401
 
 from kafka import errors, KafkaAdminClient, KafkaClient, KafkaConsumer, KafkaProducer
-from kafka.errors import InvalidReplicationFactorError
+from kafka.errors import InvalidReplicationFactorError, KafkaTimeoutError
 from kafka.protocol.admin import CreateTopicsRequest
 from kafka.protocol.metadata import MetadataRequest
 from test.testutil import env_kafka_version, random_string
@@ -555,6 +555,8 @@ class KafkaFixture(Fixture):
                 future.error_on_callbacks = True
                 future.add_errback(_failure)
                 self._client.poll(future=future, timeout_ms=timeout)
+                if not future.is_done:
+                    raise KafkaTimeoutError()
                 return future.value
             except Exception as exc:
                 time.sleep(1)

--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -228,6 +228,9 @@ def test_poll(mocker):
     ifr_request_timeout = mocker.patch.object(KafkaClient, '_next_ifr_request_timeout_ms')
     _poll = mocker.patch.object(KafkaClient, '_poll')
     cli = KafkaClient(api_version=(0, 9))
+    now = time.time()
+    t = mocker.patch('time.time')
+    t.return_value = now
 
     # metadata timeout wins
     ifr_request_timeout.return_value = float('inf')
@@ -346,17 +349,16 @@ def test_maybe_refresh_metadata_cant_send(mocker, client):
     t.return_value = now
 
     # first poll attempts connection
-    client.poll(timeout_ms=12345678)
-    client._poll.assert_called_with(12345.678)
+    client.poll()
+    client._poll.assert_called()
     client._init_connect.assert_called_once_with('foobar')
 
     # poll while connecting should not attempt a new connection
     client._connecting.add('foobar')
     client._can_connect.reset_mock()
-    client.poll(timeout_ms=12345678)
-    client._poll.assert_called_with(12345.678)
+    client.poll()
+    client._poll.assert_called()
     assert not client._can_connect.called
-
     assert not client._metadata_refresh_in_progress
 
 


### PR DESCRIPTION
Also check for coordinator.poll failure, and fix `needs_rejoin() on timeout and eventual success.