### PR TITLE
Only mark coordinator dead if connection_delay > 0

### DIFF
--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -228,7 +228,7 @@ class BaseCoordinator(object):
         """
         if self.coordinator_id is None:
             return None
-        elif self._client.is_disconnected(self.coordinator_id):
+        elif self._client.is_disconnected(self.coordinator_id) and self._client.connection_delay(self.coordinator_id) > 0:
             self.coordinator_dead('Node Disconnected')
             return None
         else:


### PR DESCRIPTION
Disconnected doesn't always mean we can't make immediate progress. Aligns with java client.