### PR TITLE
Add optional timeout_ms kwarg to remaining consumer/coordinator methods

### DIFF
--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -163,7 +163,7 @@ class BaseCoordinator(object):
         pass
 
     @abc.abstractmethod
-    def _on_join_prepare(self, generation, member_id):
+    def _on_join_prepare(self, generation, member_id, timeout_ms=None):
         """Invoked prior to each group join or rejoin.
 
         This is typically used to perform any cleanup from the previous
@@ -415,7 +415,8 @@ class BaseCoordinator(object):
             # while another rebalance is still in progress.
             if not self.rejoining:
                 self._on_join_prepare(self._generation.generation_id,
-                                      self._generation.member_id)
+                                      self._generation.member_id,
+                                      timeout_ms=inner_timeout_ms())
                 self.rejoining = True
 
             # fence off the heartbeat thread explicitly so that it cannot

--- a/kafka/util.py
+++ b/kafka/util.py
@@ -21,7 +21,7 @@ if six.PY3:
             crc -= TO_SIGNED
         return crc
 else:
-    from binascii import crc32
+    from binascii import crc32 # noqa: F401
 
 
 def timeout_ms_fn(timeout_ms, error_message):
@@ -32,7 +32,10 @@ def timeout_ms_fn(timeout_ms, error_message):
             return fallback
         elapsed = (time.time() - begin) * 1000
         if elapsed >= timeout_ms:
-            raise KafkaTimeoutError(error_message)
+            if error_message is not None:
+                raise KafkaTimeoutError(error_message)
+            else:
+                return 0
         ret = max(0, timeout_ms - elapsed)
         if fallback is not None:
             return min(ret, fallback)

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -130,10 +130,10 @@ def test_update_fetch_positions(fetcher, topic, mocker):
     fetcher._subscriptions.need_offset_reset(partition)
     fetcher._subscriptions.assignment[partition].awaiting_reset = False
     fetcher.update_fetch_positions([partition])
-    fetcher._reset_offset.assert_called_with(partition)
+    fetcher._reset_offset.assert_called_with(partition, timeout_ms=None)
     assert fetcher._subscriptions.assignment[partition].awaiting_reset is True
     fetcher.update_fetch_positions([partition])
-    fetcher._reset_offset.assert_called_with(partition)
+    fetcher._reset_offset.assert_called_with(partition, timeout_ms=None)
 
     # partition needs reset, has committed offset
     fetcher._reset_offset.reset_mock()


### PR DESCRIPTION
Should help avoid unexpected blocking in consumers.

Fix #1346 