### PR TITLE
Fix packaging of 2.1.0 in Fedora: testing requires "pytest-timeout".

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ crc32c = ["crc32c"]
 lz4 = ["lz4"]
 snappy = ["python-snappy"]
 zstd = ["zstandard"]
-testing = ["pytest", "mock; python_version < '3.3'", "pytest-mock"]
+testing = ["pytest", "mock; python_version < '3.3'", "pytest-mock", "pytest-timeout"]
 
 [tool.setuptools]
 include-package-data = false


### PR DESCRIPTION
Without this, we get this in the Fedora package when trying to upgrade to 2.1.0:

```
+ /usr/bin/pytest --ignore=test/test_consumer_integration.py --ignore=test/record/test_util.py test
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --timeout=300
  inifile: /builddir/build/BUILD/python-kafka-2.1.0-build/kafka-python-2.1.0/pytest.ini
  rootdir: /builddir/build/BUILD/python-kafka-2.1.0-build/kafka-python-2.1.0
```

Fedora update pull request submitted here: https://src.fedoraproject.org/rpms/python-kafka/pull-request/5