### PR TITLE
Lazy unpack records in Consumer Fetcher

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -417,7 +417,6 @@ class Fetcher(six.Iterator):
                 try:
                     batch_offset = batch.base_offset + batch.last_offset_delta
                     leader_epoch = batch.leader_epoch
-                    self._subscriptions.assignment[tp].last_offset_from_record_batch = batch_offset
                     # Control batches have a single record indicating whether a transaction
                     # was aborted or committed.
                     # When isolation_level is READ_COMMITTED (currently unsupported)
@@ -642,16 +641,6 @@ class Fetcher(six.Iterator):
 
         for partition in self._fetchable_partitions():
             node_id = self._client.cluster.leader_for_partition(partition)
-
-            # advance position for any deleted compacted messages if required
-            if self._subscriptions.assignment[partition].last_offset_from_record_batch:
-                next_offset_from_batch_header = self._subscriptions.assignment[partition].last_offset_from_record_batch + 1
-                if next_offset_from_batch_header > self._subscriptions.assignment[partition].position.offset:
-                    log.debug(
-                        "Advance position for partition %s from %s to %s (last record batch location plus one)"
-                        " to correct for deleted compacted messages and/or transactional control records",
-                        partition, self._subscriptions.assignment[partition].position.offset, next_offset_from_batch_header)
-                    self._subscriptions.assignment[partition].position = OffsetAndMetadata(next_offset_from_batch_header, '', -1)
 
             position = self._subscriptions.assignment[partition].position
 

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -382,9 +382,6 @@ class TopicPartitionState(object):
         self._position = None # OffsetAndMetadata exposed to the user
         self.highwater = None
         self.drop_pending_record_batch = False
-        # The last message offset hint available from a record batch with
-        # magic=2 which includes deleted compacted messages
-        self.last_offset_from_record_batch = None
 
     def _set_position(self, offset):
         assert self.has_valid_position, 'Valid position required'
@@ -400,7 +397,6 @@ class TopicPartitionState(object):
         self.awaiting_reset = True
         self.reset_strategy = strategy
         self._position = None
-        self.last_offset_from_record_batch = None
         self.has_valid_position = False
 
     def seek(self, offset):
@@ -409,7 +405,6 @@ class TopicPartitionState(object):
         self.reset_strategy = None
         self.has_valid_position = True
         self.drop_pending_record_batch = True
-        self.last_offset_from_record_batch = None
 
     def pause(self):
         self.paused = True

--- a/kafka/record/abc.py
+++ b/kafka/record/abc.py
@@ -100,6 +100,11 @@ class ABCRecordBatch(object):
             if needed.
         """
 
+    @abc.abstractproperty
+    def magic(self):
+        """ Return magic value (0, 1, 2) for batch.
+        """
+
 
 @add_metaclass(abc.ABCMeta)
 class ABCRecords(object):

--- a/kafka/record/abc.py
+++ b/kafka/record/abc.py
@@ -10,6 +10,11 @@ class ABCRecord(object):
     __slots__ = ()
 
     @abc.abstractproperty
+    def size_in_bytes(self):
+        """ Number of total bytes in record
+        """
+
+    @abc.abstractproperty
     def offset(self):
         """ Absolute offset of record
         """

--- a/kafka/record/abc.py
+++ b/kafka/record/abc.py
@@ -45,6 +45,11 @@ class ABCRecord(object):
             be the checksum for v0 and v1 and None for v2 and above.
         """
 
+    @abc.abstractmethod
+    def validate_crc(self):
+        """ Return True if v0/v1 record matches checksum. noop/True for v2 records
+        """
+
     @abc.abstractproperty
     def headers(self):
         """ If supported by version list of key-value tuples, or empty list if

--- a/kafka/record/default_records.py
+++ b/kafka/record/default_records.py
@@ -366,6 +366,9 @@ class DefaultRecord(ABCRecord):
     def checksum(self):
         return None
 
+    def validate_crc(self):
+        return True
+
     def __repr__(self):
         return (
             "DefaultRecord(offset={!r}, timestamp={!r}, timestamp_type={!r},"

--- a/kafka/record/default_records.py
+++ b/kafka/record/default_records.py
@@ -556,8 +556,8 @@ class DefaultRecordBatchBuilder(DefaultRecordBase, ABCRecordBatchBuilder):
             0,  # CRC will be set below, as we need a filled buffer for it
             self._get_attributes(use_compression_type),
             self._last_offset,
-            self._first_timestamp,
-            self._max_timestamp,
+            self._first_timestamp or 0,
+            self._max_timestamp or 0,
             self._producer_id,
             self._producer_epoch,
             self._base_sequence,

--- a/kafka/record/legacy_records.py
+++ b/kafka/record/legacy_records.py
@@ -339,6 +339,10 @@ class LegacyRecord(ABCRecord):
     def checksum(self):
         return self._crc
 
+    @property
+    def size_in_bytes(self):
+        return LegacyRecordBatchBuilder.estimate_size_in_bytes(self._magic, None, self._key, self._value)
+
     def __repr__(self):
         return (
             "LegacyRecord(magic={!r} offset={!r}, timestamp={!r}, timestamp_type={!r},"

--- a/kafka/record/memory_records.py
+++ b/kafka/record/memory_records.py
@@ -115,7 +115,7 @@ class MemoryRecordsBuilder(object):
     __slots__ = ("_builder", "_batch_size", "_buffer", "_next_offset", "_closed",
                  "_bytes_written")
 
-    def __init__(self, magic, compression_type, batch_size):
+    def __init__(self, magic, compression_type, batch_size, offset=0):
         assert magic in [0, 1, 2], "Not supported magic"
         assert compression_type in [0, 1, 2, 3, 4], "Not valid compression type"
         if magic >= 2:
@@ -130,9 +130,13 @@ class MemoryRecordsBuilder(object):
         self._batch_size = batch_size
         self._buffer = None
 
-        self._next_offset = 0
+        self._next_offset = offset
         self._closed = False
         self._bytes_written = 0
+
+    def skip(self, offsets_to_skip):
+        # Exposed for testing compacted records
+        self._next_offset += offsets_to_skip
 
     def append(self, timestamp, key, value, headers=[]):
         """ Append a message to the buffer.

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -463,24 +463,6 @@ def test__unpack_records(fetcher):
     assert records[2].offset == 2
 
 
-def test__message_generator(fetcher, topic, mocker):
-    fetcher.config['check_crcs'] = False
-    tp = TopicPartition(topic, 0)
-    msgs = []
-    for i in range(10):
-        msgs.append((None, b"foo", None))
-    completed_fetch = CompletedFetch(
-        tp, 0, 0, [0, 100, _build_record_batch(msgs)],
-        mocker.MagicMock()
-    )
-    fetcher._completed_fetches.append(completed_fetch)
-    for i in range(10):
-        msg = next(fetcher)
-        assert isinstance(msg, ConsumerRecord)
-        assert msg.offset == i
-        assert msg.value == b'foo'
-
-
 def test__parse_fetched_data(fetcher, topic, mocker):
     fetcher.config['check_crcs'] = False
     tp = TopicPartition(topic, 0)


### PR DESCRIPTION
(Lots of commits here, planning to split some into separate PRs).

After more closely reviewing fetch_offset code, namely changes from #1724, it looks like there may be edge cases where offset tracking "loses" messages. #2011 highlights this for paused partitions, but I believe the same issue could happen when using the `consumer.poll()` interface and experiencing a rebalance or other event that causes current fetch response data to become "unfetchable". In that case the fetch response will be discarded without returning records, but the subscription position will still be updated to the end of the fetch response! This would cause the discarded records to be "lost" to the consumer without raising an exception or logging any useful message (the prior log message was at level 0, which is lower than debug). I *think* this issue does not impact the iterator interface `for msg in consumer:` because we handle lazy offset updates in the iterator.

Fix #2011, #2072, #2173, #2310