### PR TITLE
KIP-98: Add idempotent producer support

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -478,6 +478,7 @@ class KafkaProducer(object):
         self._sender = Sender(client, self._metadata,
                               self._accumulator,
                               metrics=self._metrics,
+                              transaction_state=self._transaction_state,
                               guarantee_message_order=guarantee_message_order,
                               **self.config)
         self._sender.daemon = True

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -469,7 +469,10 @@ class KafkaProducer(object):
                                                      " producer. Otherwise we cannot guarantee idempotence")
 
         message_version = self._max_usable_produce_magic()
-        self._accumulator = RecordAccumulator(message_version=message_version, **self.config)
+        self._accumulator = RecordAccumulator(
+                transaction_state=self._transaction_state,
+                message_version=message_version,
+                **self.config)
         self._metadata = client.cluster
         guarantee_message_order = bool(self.config['max_in_flight_requests_per_connection'] == 1)
         self._sender = Sender(client, self._metadata,

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -19,6 +19,7 @@ from kafka.partitioner.default import DefaultPartitioner
 from kafka.producer.future import FutureRecordMetadata, FutureProduceResult
 from kafka.producer.record_accumulator import AtomicInteger, RecordAccumulator
 from kafka.producer.sender import Sender
+from kafka.producer.transaction_state import TransactionState
 from kafka.record.default_records import DefaultRecordBatchBuilder
 from kafka.record.legacy_records import LegacyRecordBatchBuilder
 from kafka.serializer import Serializer
@@ -93,6 +94,19 @@ class KafkaProducer(object):
         value_serializer (callable): used to convert user-supplied message
             values to bytes. If not None, called as f(value), should return
             bytes. Default: None.
+        enable_idempotence (bool): When set to True, the producer will ensure
+            that exactly one copy of each message is written in the stream.
+            If False, producer retries due to broker failures, etc., may write
+            duplicates of the retried message in the stream. Default: False.
+
+            Note that enabling idempotence requires
+            `max_in_flight_requests_per_connection` to be set to 1 and `retries`
+            cannot be zero. Additionally, `acks` must be set to 'all'. If these
+            values are left at their defaults, the producer will override the
+            defaults to be suitable. If the values are set to something
+            incompatible with the idempotent producer, a KafkaConfigurationError
+            will be raised.
+
         acks (0, 1, 'all'): The number of acknowledgments the producer requires
             the leader to have received before considering a request complete.
             This controls the durability of records that are sent. The
@@ -303,6 +317,7 @@ class KafkaProducer(object):
         'client_id': None,
         'key_serializer': None,
         'value_serializer': None,
+        'enable_idempotence': False,
         'acks': 1,
         'bootstrap_topics_filter': set(),
         'compression_type': None,
@@ -365,6 +380,7 @@ class KafkaProducer(object):
     def __init__(self, **configs):
         log.debug("Starting the Kafka producer")  # trace
         self.config = copy.copy(self.DEFAULT_CONFIG)
+        user_provided_configs = set(configs.keys())
         for key in self.config:
             if key in configs:
                 self.config[key] = configs.pop(key)
@@ -427,6 +443,30 @@ class KafkaProducer(object):
             checker, compression_attrs = self._COMPRESSORS[ct]
             assert checker(), "Libraries for {} compression codec not found".format(ct)
             self.config['compression_attrs'] = compression_attrs
+
+        self._transaction_state = None
+        if self.config['enable_idempotence']:
+            self._transaction_state = TransactionState()
+            if 'retries' not in user_provided_configs:
+                log.info("Overriding the default 'retries' config to 3 since the idempotent producer is enabled.")
+                self.config['retries'] = 3
+            elif self.config['retries'] == 0:
+                raise Errors.KafkaConfigurationError("Must set 'retries' to non-zero when using the idempotent producer.")
+
+            if 'max_in_flight_requests_per_connection' not in user_provided_configs:
+                log.info("Overriding the default 'max_in_flight_requests_per_connection' to 1 since idempontence is enabled.")
+                self.config['max_in_flight_requests_per_connection'] = 1
+            elif self.config['max_in_flight_requests_per_connection'] != 1:
+                raise Errors.KafkaConfigurationError("Must set 'max_in_flight_requests_per_connection' to 1 in order"
+                                                     " to use the idempotent producer."
+                                                     " Otherwise we cannot guarantee idempotence.")
+
+            if 'acks' not in user_provided_configs:
+                log.info("Overriding the default 'acks' config to 'all' since idempotence is enabled")
+                self.config['acks'] = -1
+            elif self.config['acks'] != -1:
+                raise Errors.KafkaConfigurationError("Must set 'acks' config to 'all' in order to use the idempotent"
+                                                     " producer. Otherwise we cannot guarantee idempotence")
 
         message_version = self._max_usable_produce_magic()
         self._accumulator = RecordAccumulator(message_version=message_version, **self.config)

--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -496,7 +496,7 @@ class RecordAccumulator(object):
                                         sequence_number = self._transaction_state.sequence_number(batch.topic_partition)
                                         log.debug("Dest: %s: %s producer_id=%s epoch=%s sequence=%s",
                                                   node_id, batch.topic_partition, producer_id_and_epoch.producer_id, producer_id_and_epoch.epoch,
-                                                  batch.topic_partition, sequence_number)
+                                                  sequence_number)
                                         batch.records.set_producer_state(producer_id_and_epoch.producer_id, producer_id_and_epoch.epoch, sequence_number)
                                     batch.records.close()
                                     size += batch.records.size_in_bytes()

--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -52,6 +52,10 @@ class ProducerBatch(object):
     def record_count(self):
         return self.records.next_offset()
 
+    @property
+    def producer_id(self):
+        return self.records.producer_id if self.records else None
+
     def try_append(self, timestamp_ms, key, value, headers):
         metadata = self.records.append(timestamp_ms, key, value, headers)
         if metadata is None:

--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -473,16 +473,16 @@ class RecordAccumulator(object):
                                     # single request
                                     break
                                 else:
-                                    pid_and_epoch = None
+                                    producer_id_and_epoch = None
                                     if self._transaction_state:
-                                        pid_and_epoch = self._transaction_state.pid_and_epoch
-                                        if not pid_and_epoch.is_valid:
+                                        producer_id_and_epoch = self._transaction_state.producer_id_and_epoch
+                                        if not producer_id_and_epoch.is_valid:
                                             # we cannot send the batch until we have refreshed the PID
                                             log.debug("Waiting to send ready batches because transaction producer id is not valid")
                                             break
 
                                     batch = dq.popleft()
-                                    if pid_and_epoch and not batch.in_retry():
+                                    if producer_id_and_epoch and not batch.in_retry():
                                         # If the batch is in retry, then we should not change the pid and
                                         # sequence number, since this may introduce duplicates. In particular,
                                         # the previous attempt may actually have been accepted, and if we change
@@ -490,9 +490,9 @@ class RecordAccumulator(object):
                                         # a duplicate.
                                         sequence_number = self._transaction_state.sequence_number(batch.topic_partition)
                                         log.debug("Dest: %s : producer_idd: %s epoch: %s Assigning sequence for %s: %s",
-                                                  node_id, pid_and_epoch.producer_id, pid_and_epoch.epoch,
+                                                  node_id, producer_id_and_epoch.producer_id, producer_id_and_epoch.epoch,
                                                   batch.topic_partition, sequence_number)
-                                        batch.records.set_producer_state(pid_and_epoch.producer_id, pid_and_epoch.epoch, sequence_number)
+                                        batch.records.set_producer_state(producer_id_and_epoch.producer_id, producer_id_and_epoch.epoch, sequence_number)
                                     batch.records.close()
                                     size += batch.records.size_in_bytes()
                                     ready.append(batch)

--- a/kafka/producer/sender.py
+++ b/kafka/producer/sender.py
@@ -136,7 +136,7 @@ class Sender(threading.Thread):
         expired_batches = self._accumulator.abort_expired_batches(
             self.config['request_timeout_ms'], self._metadata)
 
-        # Reset the PID if an expired batch has previously been sent to the broker.
+        # Reset the producer_id if an expired batch has previously been sent to the broker.
         # See the documentation of `TransactionState.reset_producer_id` to understand why
         # we need to reset the producer id here.
         if self._transaction_state and any([batch.in_retry() for batch in expired_batches]):
@@ -201,9 +201,7 @@ class Sender(threading.Thread):
             self.wakeup()
 
     def _maybe_wait_for_producer_id(self):
-        log.debug("_maybe_wait_for_producer_id")
         if not self._transaction_state:
-            log.debug("_maybe_wait_for_producer_id: no transaction_state...")
             return
 
         while not self._transaction_state.has_pid():
@@ -236,7 +234,6 @@ class Sender(threading.Thread):
             except Errors.RequestTimedOutError:
                 log.debug("InitProducerId request to node %s timed out", node_id)
             time.sleep(self.config['retry_backoff_ms'] / 1000)
-        log.debug("_maybe_wait_for_producer_id: ok: %s", self._transaction_state.producer_id_and_epoch)
 
     def _failed_produce(self, batches, node_id, error):
         log.error("Error sending produce request to node %d: %s", node_id, error) # trace

--- a/kafka/producer/transaction_state.py
+++ b/kafka/producer/transaction_state.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import, division
+
+import collections
+import threading
+import time
+
+from kafka.errors import IllegalStateError
+
+
+NO_PRODUCER_ID = -1
+NO_PRODUCER_EPOCH = -1
+
+
+class PidAndEpoch(object):
+    __slots__ = ('producer_id', 'epoch')
+
+    def __init__(self, producer_id, epoch):
+        self.producer_id = producer_id
+        self.epoch = epoch
+
+    @property
+    def is_valid(self):
+        return NO_PRODUCER_ID < self.producer_id
+
+    def __str__(self):
+        return "PidAndEpoch(producer_id={}, epoch={})".format(self.producer_id, self.epoch)
+
+class TransactionState(object):
+    __slots__ = ('pid_and_epoch', '_sequence_numbers', '_lock')
+
+    def __init__(self):
+        self.pid_and_epoch = PidAndEpoch(NO_PRODUCER_ID, NO_PRODUCER_EPOCH)
+        self._sequence_numbers = collections.defaultdict(lambda: 0)
+        self._lock = threading.Condition()
+
+    def has_pid(self):
+        return self.pid_and_epoch.is_valid
+
+
+    def await_pid_and_epoch(self, max_wait_time_ms):
+        """
+        A blocking call to get the pid and epoch for the producer. If the PID and epoch has not been set, this method
+        will block for at most maxWaitTimeMs. It is expected that this method be called from application thread
+        contexts (ie. through Producer.send). The PID it self will be retrieved in the background thread.
+
+        Arguments:
+            max_wait_time_ms (numeric): The maximum time to block.
+
+        Returns:
+            PidAndEpoch object. Callers must check the 'is_valid' property of the returned object to ensure that a
+                valid pid and epoch is actually returned.
+        """
+        with self._lock:
+            start = time.time()
+            elapsed = 0
+            while not self.has_pid() and elapsed < max_wait_time_ms:
+                self._lock.wait(max_wait_time_ms / 1000)
+                elapsed = time.time() - start
+            return self.pid_and_epoch
+
+    def set_pid_and_epoch(self, producer_id, epoch):
+        """
+        Set the pid and epoch atomically. This method will signal any callers blocked on the `pidAndEpoch` method
+        once the pid is set. This method will be called on the background thread when the broker responds with the pid.
+        """
+        with self._lock:
+            self.pid_and_epoch = PidAndEpoch(producer_id, epoch)
+            if self.pid_and_epoch.is_valid:
+                self._lock.notify_all()
+
+    def reset_producer_id(self):
+        """
+        This method is used when the producer needs to reset it's internal state because of an irrecoverable exception
+        from the broker.
+       
+        We need to reset the producer id and associated state when we have sent a batch to the broker, but we either get
+        a non-retriable exception or we run out of retries, or the batch expired in the producer queue after it was already
+        sent to the broker.
+       
+        In all of these cases, we don't know whether batch was actually committed on the broker, and hence whether the
+        sequence number was actually updated. If we don't reset the producer state, we risk the chance that all future
+        messages will return an OutOfOrderSequenceException.
+        """
+        with self._lock:
+            self.pid_and_epoch = PidAndEpoch(NO_PRODUCER_ID, NO_PRODUCER_EPOCH)
+            self._sequence_numbers.clear()
+
+    def sequence_number(self, tp):
+        with self._lock:
+            return self._sequence_numbers[tp]
+
+    def increment_sequence_number(self, tp, increment):
+        with self._lock:
+            if tp not in self._sequence_numbers:
+                raise IllegalStateError("Attempt to increment sequence number for a partition with no current sequence.")
+            self._sequence_numbers[tp] += increment

--- a/kafka/protocol/init_producer_id.py
+++ b/kafka/protocol/init_producer_id.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+from kafka.protocol.api import Request, Response
+from kafka.protocol.types import Int16, Int32, Int64, Schema, String
+
+
+class InitProducerIdResponse_v0(Response):
+    API_KEY = 22
+    API_VERSION = 0
+    SCHEMA = Schema(
+        ('throttle_time_ms', Int32),
+        ('error_code', Int16),
+        ('producer_id', Int64),
+        ('producer_epoch', Int16),
+    )
+
+
+class InitProducerIdResponse_v1(Response):
+    API_KEY = 22
+    API_VERSION = 1
+    SCHEMA = InitProducerIdResponse_v0.SCHEMA
+
+
+class InitProducerIdRequest_v0(Request):
+    API_KEY = 22
+    API_VERSION = 0
+    RESPONSE_TYPE = InitProducerIdResponse_v0
+    SCHEMA = Schema(
+        ('transactional_id', String('utf-8')),
+        ('transaction_timeout_ms', Int32),
+    )
+
+
+class InitProducerIdRequest_v1(Request):
+    API_KEY = 22
+    API_VERSION = 1
+    RESPONSE_TYPE = InitProducerIdResponse_v1
+    SCHEMA = InitProducerIdRequest_v0.SCHEMA
+
+
+InitProducerIdRequest = [
+    InitProducerIdRequest_v0, InitProducerIdRequest_v1,
+]
+InitProducerIdResponse = [
+    InitProducerIdResponse_v0, InitProducerIdResponse_v1,
+]

--- a/kafka/record/default_records.py
+++ b/kafka/record/default_records.py
@@ -448,6 +448,15 @@ class DefaultRecordBatchBuilder(DefaultRecordBase, ABCRecordBatchBuilder):
 
         self._buffer = bytearray(self.HEADER_STRUCT.size)
 
+    def set_producer_state(self, producer_id, producer_epoch, base_sequence):
+        self._producer_id = producer_id
+        self._producer_epoch = producer_epoch
+        self._base_sequence = base_sequence
+
+    @property
+    def producer_id(self):
+        return self._producer_id
+
     def _get_attributes(self, include_compression_type=True):
         attrs = 0
         if include_compression_type:

--- a/kafka/record/memory_records.py
+++ b/kafka/record/memory_records.py
@@ -22,7 +22,7 @@ from __future__ import division
 
 import struct
 
-from kafka.errors import CorruptRecordException
+from kafka.errors import CorruptRecordException, IllegalStateError, UnsupportedVersionError
 from kafka.record.abc import ABCRecords
 from kafka.record.legacy_records import LegacyRecordBatch, LegacyRecordBatchBuilder
 from kafka.record.default_records import DefaultRecordBatch, DefaultRecordBatchBuilder
@@ -113,7 +113,7 @@ class MemoryRecords(ABCRecords):
 class MemoryRecordsBuilder(object):
 
     __slots__ = ("_builder", "_batch_size", "_buffer", "_next_offset", "_closed",
-                 "_bytes_written")
+                 "_magic", "_bytes_written", "_producer_id")
 
     def __init__(self, magic, compression_type, batch_size, offset=0):
         assert magic in [0, 1, 2], "Not supported magic"
@@ -123,15 +123,18 @@ class MemoryRecordsBuilder(object):
                 magic=magic, compression_type=compression_type,
                 is_transactional=False, producer_id=-1, producer_epoch=-1,
                 base_sequence=-1, batch_size=batch_size)
+            self._producer_id = -1
         else:
             self._builder = LegacyRecordBatchBuilder(
                 magic=magic, compression_type=compression_type,
                 batch_size=batch_size)
+            self._producer_id = None
         self._batch_size = batch_size
         self._buffer = None
 
         self._next_offset = offset
         self._closed = False
+        self._magic = magic
         self._bytes_written = 0
 
     def skip(self, offsets_to_skip):
@@ -155,6 +158,24 @@ class MemoryRecordsBuilder(object):
         self._next_offset += 1
         return metadata
 
+    def set_producer_state(self, producer_id, producer_epoch, base_sequence):
+        if self._magic < 2:
+            raise UnsupportedVersionError('Producer State requires Message format v2+')
+        elif self._closed:
+            # Sequence numbers are assigned when the batch is closed while the accumulator is being drained.
+            # If the resulting ProduceRequest to the partition leader failed for a retriable error, the batch will
+            # be re queued. In this case, we should not attempt to set the state again, since changing the pid and sequence
+            # once a batch has been sent to the broker risks introducing duplicates.
+            raise IllegalStateError("Trying to set producer state of an already closed batch. This indicates a bug on the client.")
+        self._builder.set_producer_state(producer_id, producer_epoch, base_sequence)
+        self._producer_id = producer_id
+
+    @property
+    def producer_id(self):
+        if self._magic < 2:
+            raise UnsupportedVersionError('Producer State requires Message format v2+')
+        return self._producer_id
+
     def close(self):
         # This method may be called multiple times on the same batch
         # i.e., on retries
@@ -164,6 +185,8 @@ class MemoryRecordsBuilder(object):
         if not self._closed:
             self._bytes_written = self._builder.size()
             self._buffer = bytes(self._builder.build())
+            if self._magic == 2:
+                self._producer_id = self._builder.producer_id
             self._builder = None
         self._closed = True
 

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -100,7 +100,7 @@ def test_kafka_producer_proper_record_metadata(kafka_broker, compression):
                           retries=5,
                           max_block_ms=30000,
                           compression_type=compression) as producer:
-        magic = producer._max_usable_produce_magic()
+        magic = producer.max_usable_produce_magic(producer.config['api_version'])
 
         # record headers are supported in 0.11.0
         if env_kafka_version() < (0, 11, 0):

--- a/test/test_record_accumulator.py
+++ b/test/test_record_accumulator.py
@@ -1,0 +1,61 @@
+# pylint: skip-file
+from __future__ import absolute_import
+
+import pytest
+import io
+
+from kafka.producer.future import FutureRecordMetadata, RecordMetadata
+from kafka.producer.record_accumulator import RecordAccumulator, ProducerBatch
+from kafka.record.memory_records import MemoryRecordsBuilder
+from kafka.structs import TopicPartition
+
+
+def test_producer_batch_producer_id():
+    tp = TopicPartition('foo', 0)
+    records = MemoryRecordsBuilder(
+        magic=2, compression_type=0, batch_size=100000)
+    batch = ProducerBatch(tp, records, io.BytesIO())
+    assert batch.producer_id == -1
+    batch.records.set_producer_state(123, 456, 789)
+    assert batch.producer_id == 123
+    records.close()
+    assert batch.producer_id == 123
+
+@pytest.mark.parametrize("magic", [0, 1, 2])
+def test_producer_batch_try_append(magic):
+    tp = TopicPartition('foo', 0)
+    records = MemoryRecordsBuilder(
+        magic=magic, compression_type=0, batch_size=100000)
+    batch = ProducerBatch(tp, records, io.BytesIO())
+    assert batch.record_count == 0
+    future = batch.try_append(0, b'key', b'value', [])
+    assert isinstance(future, FutureRecordMetadata)
+    assert not future.is_done
+    batch.done(base_offset=123, timestamp_ms=456, log_start_offset=0)
+    assert future.is_done
+    # record-level checksum only provided in v0/v1 formats; payload includes magic-byte
+    if magic == 0:
+        checksum = 592888119
+    elif magic == 1:
+        checksum = 213653215
+    else:
+        checksum = None
+
+    expected_metadata = RecordMetadata(
+        topic=tp[0], partition=tp[1], topic_partition=tp,
+        offset=123, timestamp=456, log_start_offset=0,
+        checksum=checksum,
+        serialized_key_size=3, serialized_value_size=5, serialized_header_size=-1)
+    assert future.value == expected_metadata
+
+def test_producer_batch_retry():
+    tp = TopicPartition('foo', 0)
+    records = MemoryRecordsBuilder(
+        magic=2, compression_type=0, batch_size=100000)
+    batch = ProducerBatch(tp, records, io.BytesIO())
+    assert not batch.in_retry()
+    batch.set_retry()
+    assert batch.in_retry()
+
+def test_producer_batch_maybe_expire():
+    pass

--- a/test/test_record_accumulator.py
+++ b/test/test_record_accumulator.py
@@ -15,7 +15,7 @@ def test_producer_batch_producer_id():
     tp = TopicPartition('foo', 0)
     records = MemoryRecordsBuilder(
         magic=2, compression_type=0, batch_size=100000)
-    batch = ProducerBatch(tp, records, io.BytesIO())
+    batch = ProducerBatch(tp, records)
     assert batch.producer_id == -1
     batch.records.set_producer_state(123, 456, 789)
     assert batch.producer_id == 123
@@ -27,7 +27,7 @@ def test_producer_batch_try_append(magic):
     tp = TopicPartition('foo', 0)
     records = MemoryRecordsBuilder(
         magic=magic, compression_type=0, batch_size=100000)
-    batch = ProducerBatch(tp, records, io.BytesIO())
+    batch = ProducerBatch(tp, records)
     assert batch.record_count == 0
     future = batch.try_append(0, b'key', b'value', [])
     assert isinstance(future, FutureRecordMetadata)
@@ -53,7 +53,7 @@ def test_producer_batch_retry():
     tp = TopicPartition('foo', 0)
     records = MemoryRecordsBuilder(
         magic=2, compression_type=0, batch_size=100000)
-    batch = ProducerBatch(tp, records, io.BytesIO())
+    batch = ProducerBatch(tp, records)
     assert not batch.in_retry()
     batch.set_retry()
     assert batch.in_retry()
@@ -62,7 +62,7 @@ def test_producer_batch_maybe_expire():
     tp = TopicPartition('foo', 0)
     records = MemoryRecordsBuilder(
         magic=2, compression_type=0, batch_size=100000)
-    batch = ProducerBatch(tp, records, io.BytesIO(), now=1)
+    batch = ProducerBatch(tp, records, now=1)
     future = batch.try_append(0, b'key', b'value', [], now=2)
     request_timeout_ms = 5000
     retry_backoff_ms = 200

--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -6,6 +6,7 @@ import io
 
 from kafka.client_async import KafkaClient
 from kafka.protocol.broker_api_versions import BROKER_API_VERSIONS
+from kafka.producer.kafka import KafkaProducer
 from kafka.protocol.produce import ProduceRequest
 from kafka.producer.record_accumulator import RecordAccumulator, ProducerBatch
 from kafka.producer.sender import Sender
@@ -24,6 +25,7 @@ def sender(client, accumulator, metrics, mocker):
 
 
 @pytest.mark.parametrize(("api_version", "produce_version"), [
+    ((2, 1), 7),
     ((0, 10, 0), 2),
     ((0, 9), 1),
     ((0, 8, 0), 0)
@@ -31,6 +33,7 @@ def sender(client, accumulator, metrics, mocker):
 def test_produce_request(sender, mocker, api_version, produce_version):
     sender._client._api_versions = BROKER_API_VERSIONS[api_version]
     tp = TopicPartition('foo', 0)
+    magic = KafkaProducer.max_usable_produce_magic(api_version)
     records = MemoryRecordsBuilder(
         magic=1, compression_type=0, batch_size=100000)
     batch = ProducerBatch(tp, records)


### PR DESCRIPTION
#1396

"Idempotence" here means that the KafkaProducer avoids causing duplicate messages on the broker via retries by using a combination of producer_id and sequence numbers.