### PR TITLE
Improve connection state logging

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -365,7 +365,7 @@ class KafkaClient(object):
                     self._connecting.remove(node_id)
                 try:
                     self._selector.unregister(sock)
-                except KeyError:
+                except (KeyError, ValueError):
                     pass
 
                 if self._sensors:


### PR DESCRIPTION
Intended to align connection state with log messages, so update state first + log state change second.
This moves state change to CONNECTING prior to sock initialization, which means that `close()` can now be called without a sock, and that means that the sock passed to `state_change_callback` can be None, though only when disconnected.