### PR TITLE
Resolve datetime deprecation warnings

### DIFF
--- a/test/sasl/test_msk.py
+++ b/test/sasl/test_msk.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timezone
+import datetime
 import json
+import sys
 
 from kafka.sasl.msk import AwsMskIamClient
 
@@ -10,7 +11,10 @@ except ImportError:
 
 
 def client_factory(token=None):
-    now = datetime.fromtimestamp(1629321911, timezone.utc)
+    if sys.version_info >= (3, 3):
+        now = datetime.datetime.fromtimestamp(1629321911, datetime.timezone.utc)
+    else:
+        now = datetime.datetime.utcfromtimestamp(1629321911)
     with mock.patch('kafka.sasl.msk.datetime') as mock_dt:
         mock_dt.datetime.utcnow = mock.Mock(return_value=now)
         return AwsMskIamClient(

--- a/test/sasl/test_msk.py
+++ b/test/sasl/test_msk.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 import json
 
 from kafka.sasl.msk import AwsMskIamClient
@@ -10,7 +10,7 @@ except ImportError:
 
 
 def client_factory(token=None):
-    now = datetime.datetime.utcfromtimestamp(1629321911)
+    now = datetime.fromtimestamp(1629321911, timezone.utc)
     with mock.patch('kafka.sasl.msk.datetime') as mock_dt:
         mock_dt.datetime.utcnow = mock.Mock(return_value=now)
         return AwsMskIamClient(


### PR DESCRIPTION
# PR Summary
This PR fixes the `datetime` deprecation warnings that can be viewed in the [CI logs](https://github.com/dpkp/kafka-python/actions/runs/14481536471/job/40619297397#step:10:81):
```
test/sasl/test_msk.py::test_aws_msk_iam_client_temporary_credentials
  /home/runner/work/kafka-python/kafka-python/test/sasl/test_msk.py:13: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    now = datetime.datetime.utcfromtimestamp(1629321911)
```