### PR TITLE
Consumer improvements

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -194,13 +194,7 @@ class Fetcher(six.Iterator):
         inner_timeout_ms = timeout_ms_fn(timeout_ms, 'Timeout updating fetch positions')
         # reset the fetch position to the committed position
         for tp in partitions:
-            if not self._subscriptions.is_assigned(tp):
-                log.warning("partition %s is not assigned - skipping offset"
-                            " update", tp)
-                continue
-            elif self._subscriptions.is_fetchable(tp):
-                log.warning("partition %s is still fetchable -- skipping offset"
-                            " update", tp)
+            if not self._subscriptions.is_assigned(tp) or self._subscriptions.has_valid_position(tp):
                 continue
 
             if self._subscriptions.is_offset_reset_needed(tp):

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -760,7 +760,8 @@ class KafkaConsumer(six.Iterator):
         assert self._subscription.is_assigned(partition), 'Partition is not assigned'
         position = self._subscription.assignment[partition].position
         if position is None:
-            self._update_fetch_positions([partition], timeout_ms=timeout_ms)
+            # batch update fetch positions for any partitions without a valid position
+            self._update_fetch_positions(self._subscription.assigned_partitions(), timeout_ms=timeout_ms)
             position = self._subscription.assignment[partition].position
         return position.offset if position else None
 

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -1144,9 +1144,9 @@ class KafkaConsumer(six.Iterator):
             # their own offsets).
             self._fetcher.reset_offsets_if_needed(partitions, timeout_ms=inner_timeout_ms())
 
-            if not self._subscription.has_all_fetch_positions():
-                # if we still don't have offsets for all partitions, then we should either seek
-                # to the last committed position or reset using the auto reset policy
+            if not self._subscription.has_all_fetch_positions(partitions):
+                # if we still don't have offsets for the given partitions, then we should either
+                # seek to the last committed position or reset using the auto reset policy
                 if (self.config['api_version'] >= (0, 8, 1) and
                     self.config['group_id'] is not None):
                     # first refresh commits for all assigned partitions

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -351,9 +351,11 @@ class SubscriptionState(object):
     def is_offset_reset_needed(self, partition):
         return self.assignment[partition].awaiting_reset
 
-    def has_all_fetch_positions(self):
-        for state in self.assignment.values():
-            if not state.has_valid_position:
+    def has_all_fetch_positions(self, partitions=None):
+        if partitions is None:
+            partitions = self.assigned_partitions()
+        for tp in partitions:
+            if not self.has_valid_position(tp):
                 return False
         return True
 
@@ -363,6 +365,9 @@ class SubscriptionState(object):
             if not state.has_valid_position:
                 missing.add(partition)
         return missing
+
+    def has_valid_position(self, partition):
+        return partition in self.assignment and self.assignment[partition].has_valid_position
 
     def is_assigned(self, partition):
         return partition in self.assignment
@@ -386,6 +391,9 @@ class SubscriptionState(object):
             except AttributeError:
                 state = self.assignment.pop(partition)
                 self.assignment[partition] = state
+
+    def position(self, partition):
+        return self.assignment[partition].position
 
 
 class TopicPartitionState(object):

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -402,7 +402,7 @@ class TopicPartitionState(object):
         self.has_valid_position = False # whether we have valid position
         self.paused = False # whether this partition has been paused by the user
         self.awaiting_reset = False # whether we are awaiting reset
-        self.reset_strategy = None # the reset strategy if awaitingReset is set
+        self.reset_strategy = None # the reset strategy if awaiting_reset is set
         self._position = None # OffsetAndMetadata exposed to the user
         self.highwater = None
         self.drop_pending_record_batch = False

--- a/test/test_fetcher.py
+++ b/test/test_fetcher.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 import itertools
 import time
 
-from kafka.client_async import KafkaClient
 from kafka.consumer.fetcher import (
     CompletedFetch, ConsumerRecord, Fetcher
 )


### PR DESCRIPTION
* KAFKA-5078 - Defer fetch record exception if iterator has already moved across a valid record
* KAFKA-5075 - Defer consumer fetcher exception if fetch position has already increased
* KAFKA-4937 - Batch offset fetches in the Consumer
* KAFKA-4547 - Avoid resetting paused partitions to committed offsets