### PR TITLE
KIP-345 Consumer group static membership

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -13,7 +13,7 @@ from kafka.vendor import six
 from kafka.admin.acl_resource import ACLOperation, ACLPermissionType, ACLFilter, ACL, ResourcePattern, ResourceType, \
     ACLResourcePatternType
 from kafka.client_async import KafkaClient, selectors
-from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata, ConsumerProtocolMemberAssignment, ConsumerProtocol
+from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata_v0, ConsumerProtocolMemberAssignment_v0, ConsumerProtocol_v0
 import kafka.errors as Errors
 from kafka.errors import (
     IncompatibleBrokerVersion, KafkaConfigurationError, UnknownTopicOrPartitionError,
@@ -1242,7 +1242,7 @@ class KafkaAdminClient(object):
                     for (described_group_information, group_information_name, group_information_field) in zip(described_group, described_groups_field_schema.names, described_groups_field_schema.fields):
                         if group_information_name == 'protocol_type':
                             protocol_type = described_group_information
-                            protocol_type_is_consumer = (protocol_type == ConsumerProtocol.PROTOCOL_TYPE or not protocol_type)
+                            protocol_type_is_consumer = (protocol_type == ConsumerProtocol_v0.PROTOCOL_TYPE or not protocol_type)
                         if isinstance(group_information_field, Array):
                             member_information_list = []
                             member_schema = group_information_field.array_of
@@ -1251,9 +1251,9 @@ class KafkaAdminClient(object):
                                 for (member, member_field, member_name)  in zip(members, member_schema.fields, member_schema.names):
                                     if protocol_type_is_consumer:
                                         if member_name == 'member_metadata' and member:
-                                            member_information.append(ConsumerProtocolMemberMetadata.decode(member))
+                                            member_information.append(ConsumerProtocolMemberMetadata_v0.decode(member))
                                         elif member_name == 'member_assignment' and member:
-                                            member_information.append(ConsumerProtocolMemberAssignment.decode(member))
+                                            member_information.append(ConsumerProtocolMemberAssignment_v0.decode(member))
                                         else:
                                             member_information.append(member)
                                 member_info_tuple = MemberInformation._make(member_information)

--- a/kafka/coordinator/assignors/abstract.py
+++ b/kafka/coordinator/assignors/abstract.py
@@ -23,8 +23,9 @@ class AbstractPartitionAssignor(object):
 
         Arguments:
             cluster (ClusterMetadata): metadata for use in assignment
-            members (dict of {member_id: MemberMetadata}): decoded metadata for
-                each member in the group.
+            members (dict of {member_id: Subscription}): decoded metadata
+                for each member in the group, including group_instance_id
+                when available.
 
         Returns:
             dict: {member_id: MemberAssignment}

--- a/kafka/coordinator/assignors/range.py
+++ b/kafka/coordinator/assignors/range.py
@@ -32,10 +32,10 @@ class RangePartitionAssignor(AbstractPartitionAssignor):
     version = 0
 
     @classmethod
-    def assign(cls, cluster, member_metadata):
+    def assign(cls, cluster, group_subscriptions):
         consumers_per_topic = collections.defaultdict(list)
-        for member, metadata in six.iteritems(member_metadata):
-            for topic in metadata.subscription:
+        for member, subscription in six.iteritems(group_subscriptions):
+            for topic in subscription.subscription:
                 consumers_per_topic[topic].append(member)
 
         # construct {member_id: {topic: [partition, ...]}}
@@ -61,7 +61,7 @@ class RangePartitionAssignor(AbstractPartitionAssignor):
                 assignment[member][topic] = partitions[start:start+length]
 
         protocol_assignment = {}
-        for member_id in member_metadata:
+        for member_id in group_subscriptions:
             protocol_assignment[member_id] = ConsumerProtocolMemberAssignment_v0(
                 cls.version,
                 sorted(assignment[member_id].items()),

--- a/kafka/coordinator/assignors/range.py
+++ b/kafka/coordinator/assignors/range.py
@@ -35,7 +35,7 @@ class RangePartitionAssignor(AbstractPartitionAssignor):
     def assign(cls, cluster, group_subscriptions):
         consumers_per_topic = collections.defaultdict(list)
         for member, subscription in six.iteritems(group_subscriptions):
-            for topic in subscription.subscription:
+            for topic in subscription.topics:
                 consumers_per_topic[topic].append(member)
 
         # construct {member_id: {topic: [partition, ...]}}

--- a/kafka/coordinator/assignors/range.py
+++ b/kafka/coordinator/assignors/range.py
@@ -6,7 +6,7 @@ import logging
 from kafka.vendor import six
 
 from kafka.coordinator.assignors.abstract import AbstractPartitionAssignor
-from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata, ConsumerProtocolMemberAssignment
+from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata_v0, ConsumerProtocolMemberAssignment_v0
 
 log = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ class RangePartitionAssignor(AbstractPartitionAssignor):
 
         protocol_assignment = {}
         for member_id in member_metadata:
-            protocol_assignment[member_id] = ConsumerProtocolMemberAssignment(
+            protocol_assignment[member_id] = ConsumerProtocolMemberAssignment_v0(
                 cls.version,
                 sorted(assignment[member_id].items()),
                 b'')
@@ -70,7 +70,7 @@ class RangePartitionAssignor(AbstractPartitionAssignor):
 
     @classmethod
     def metadata(cls, topics):
-        return ConsumerProtocolMemberMetadata(cls.version, list(topics), b'')
+        return ConsumerProtocolMemberMetadata_v0(cls.version, list(topics), b'')
 
     @classmethod
     def on_assignment(cls, assignment):

--- a/kafka/coordinator/assignors/roundrobin.py
+++ b/kafka/coordinator/assignors/roundrobin.py
@@ -7,7 +7,7 @@ import logging
 from kafka.vendor import six
 
 from kafka.coordinator.assignors.abstract import AbstractPartitionAssignor
-from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata, ConsumerProtocolMemberAssignment
+from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata_v0, ConsumerProtocolMemberAssignment_v0
 from kafka.structs import TopicPartition
 
 log = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ class RoundRobinPartitionAssignor(AbstractPartitionAssignor):
 
         protocol_assignment = {}
         for member_id in member_metadata:
-            protocol_assignment[member_id] = ConsumerProtocolMemberAssignment(
+            protocol_assignment[member_id] = ConsumerProtocolMemberAssignment_v0(
                 cls.version,
                 sorted(assignment[member_id].items()),
                 b'')
@@ -89,7 +89,7 @@ class RoundRobinPartitionAssignor(AbstractPartitionAssignor):
 
     @classmethod
     def metadata(cls, topics):
-        return ConsumerProtocolMemberMetadata(cls.version, list(topics), b'')
+        return ConsumerProtocolMemberMetadata_v0(cls.version, list(topics), b'')
 
     @classmethod
     def on_assignment(cls, assignment):

--- a/kafka/coordinator/assignors/roundrobin.py
+++ b/kafka/coordinator/assignors/roundrobin.py
@@ -52,7 +52,7 @@ class RoundRobinPartitionAssignor(AbstractPartitionAssignor):
     def assign(cls, cluster, group_subscriptions):
         all_topics = set()
         for subscription in six.itervalues(group_subscriptions):
-            all_topics.update(subscription.subscription)
+            all_topics.update(subscription.topics)
 
         all_topic_partitions = []
         for topic in all_topics:
@@ -75,7 +75,7 @@ class RoundRobinPartitionAssignor(AbstractPartitionAssignor):
             # member subscribed topics, we should be safe assuming that
             # each topic in all_topic_partitions is in at least one member
             # subscription; otherwise this could yield an infinite loop
-            while partition.topic not in group_subscriptions[member_id].subscription:
+            while partition.topic not in group_subscriptions[member_id].topics:
                 member_id = next(member_iter)
             assignment[member_id][partition.topic].append(partition.partition)
 

--- a/kafka/coordinator/assignors/sticky/sticky_assignor.py
+++ b/kafka/coordinator/assignors/sticky/sticky_assignor.py
@@ -66,6 +66,7 @@ class StickyAssignorUserDataV1(Struct):
 
 class StickyAssignmentExecutor:
     def __init__(self, cluster, members):
+        # a mapping of member_id => StickyAssignorMemberMetadataV1
         self.members = members
         # a mapping between consumers and their assigned partitions that is updated during assignment procedure
         self.current_assignment = defaultdict(list)
@@ -630,9 +631,9 @@ class StickyPartitionAssignor(AbstractPartitionAssignor):
 
         try:
             decoded_user_data = StickyAssignorUserDataV1.decode(user_data)
-        except Exception as e:
+        except Exception:
             # ignore the consumer's previous assignment if it cannot be parsed
-            log.error("Could not parse member data", e)     # pylint: disable=logging-too-many-args
+            log.exception("Could not parse member data")
             return StickyAssignorMemberMetadataV1(
                 partitions=[], generation=cls.DEFAULT_GENERATION_ID, subscription=metadata.topics
             )

--- a/kafka/coordinator/assignors/sticky/sticky_assignor.py
+++ b/kafka/coordinator/assignors/sticky/sticky_assignor.py
@@ -625,7 +625,7 @@ class StickyPartitionAssignor(AbstractPartitionAssignor):
         user_data = metadata.user_data
         if not user_data:
             return StickyAssignorMemberMetadataV1(
-                partitions=[], generation=cls.DEFAULT_GENERATION_ID, subscription=metadata.subscription
+                partitions=[], generation=cls.DEFAULT_GENERATION_ID, subscription=metadata.topics
             )
 
         try:
@@ -634,7 +634,7 @@ class StickyPartitionAssignor(AbstractPartitionAssignor):
             # ignore the consumer's previous assignment if it cannot be parsed
             log.error("Could not parse member data", e)     # pylint: disable=logging-too-many-args
             return StickyAssignorMemberMetadataV1(
-                partitions=[], generation=cls.DEFAULT_GENERATION_ID, subscription=metadata.subscription
+                partitions=[], generation=cls.DEFAULT_GENERATION_ID, subscription=metadata.topics
             )
 
         member_partitions = []
@@ -642,7 +642,7 @@ class StickyPartitionAssignor(AbstractPartitionAssignor):
             member_partitions.extend([TopicPartition(topic, partition) for partition in partitions])
         return StickyAssignorMemberMetadataV1(
             # pylint: disable=no-member
-            partitions=member_partitions, generation=decoded_user_data.generation, subscription=metadata.subscription
+            partitions=member_partitions, generation=decoded_user_data.generation, subscription=metadata.topics
         )
 
     @classmethod

--- a/kafka/coordinator/assignors/sticky/sticky_assignor.py
+++ b/kafka/coordinator/assignors/sticky/sticky_assignor.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from kafka.coordinator.assignors.abstract import AbstractPartitionAssignor
 from kafka.coordinator.assignors.sticky.partition_movements import PartitionMovements
 from kafka.coordinator.assignors.sticky.sorted_set import SortedSet
-from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata, ConsumerProtocolMemberAssignment
+from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata_v0, ConsumerProtocolMemberAssignment_v0
 from kafka.coordinator.protocol import Schema
 from kafka.protocol.struct import Struct
 from kafka.protocol.types import String, Array, Int32
@@ -603,7 +603,7 @@ class StickyPartitionAssignor(AbstractPartitionAssignor):
 
         assignment = {}
         for member_id in members:
-            assignment[member_id] = ConsumerProtocolMemberAssignment(
+            assignment[member_id] = ConsumerProtocolMemberAssignment_v0(
                 cls.version, sorted(executor.get_final_assignment(member_id)), b''
             )
         return assignment
@@ -661,7 +661,7 @@ class StickyPartitionAssignor(AbstractPartitionAssignor):
                 partitions_by_topic[topic_partition.topic].append(topic_partition.partition)
             data = StickyAssignorUserDataV1(list(partitions_by_topic.items()), generation)
             user_data = data.encode()
-        return ConsumerProtocolMemberMetadata(cls.version, list(topics), user_data)
+        return ConsumerProtocolMemberMetadata_v0(cls.version, list(topics), user_data)
 
     @classmethod
     def on_assignment(cls, assignment):

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -489,7 +489,7 @@ class ConsumerCoordinator(BaseCoordinator):
 
     def _invoke_completed_offset_commit_callbacks(self):
         if self._async_commit_fenced:
-            raise Errors.FencedInstanceIdError("Get fenced exception for group_instance_id %s", self.group_instance_id)
+            raise Errors.FencedInstanceIdError("Got fenced exception for group_instance_id %s", self.group_instance_id)
         while self.completed_offset_commits:
             callback, offsets, res_or_exc = self.completed_offset_commits.popleft()
             callback(offsets, res_or_exc)

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -342,7 +342,7 @@ class ConsumerCoordinator(BaseCoordinator):
                 member.group_instance_id
             )
             member_subscriptions[member.member_id] = subscription
-            all_subscribed_topics.update(subscription.subscription)
+            all_subscribed_topics.update(subscription.topics)
 
         # the leader will begin watching for changes to any of the topics
         # the group is interested in, which ensures that all metadata changes

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -337,16 +337,11 @@ class ConsumerCoordinator(BaseCoordinator):
         member_subscriptions = {}
         all_subscribed_topics = set()
         for member in members:
-            if len(member) == 3:
-                member_id, group_instance_id, metadata_bytes = member
-            else:
-                member_id, metadata_bytes = member
-                group_instance_id = None
             subscription = Subscription(
-                ConsumerProtocol[0].METADATA.decode(metadata_bytes),
-                group_instance_id
+                ConsumerProtocol[0].METADATA.decode(member.metadata_bytes),
+                member.group_instance_id
             )
-            member_subscriptions[member_id] = subscription
+            member_subscriptions[member.member_id] = subscription
             all_subscribed_topics.update(subscription.subscription)
 
         # the leader will begin watching for changes to any of the topics

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -489,7 +489,7 @@ class ConsumerCoordinator(BaseCoordinator):
 
     def _invoke_completed_offset_commit_callbacks(self):
         if self._async_commit_fenced:
-            raise Errors.FencedInstanceIdError("Got fenced exception for group_instance_id %s", self.group_instance_id)
+            raise Errors.FencedInstanceIdError("Got fenced exception for group_instance_id %s" % (self.group_instance_id,))
         while self.completed_offset_commits:
             callback, offsets, res_or_exc = self.completed_offset_commits.popleft()
             callback(offsets, res_or_exc)

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -150,7 +150,7 @@ class ConsumerCoordinator(BaseCoordinator):
         super(ConsumerCoordinator, self).__del__()
 
     def protocol_type(self):
-        return ConsumerProtocol.PROTOCOL_TYPE
+        return ConsumerProtocol[0].PROTOCOL_TYPE
 
     def group_protocols(self):
         """Returns list of preferred (protocols, metadata)"""
@@ -238,7 +238,7 @@ class ConsumerCoordinator(BaseCoordinator):
         assignor = self._lookup_assignor(protocol)
         assert assignor, 'Coordinator selected invalid assignment protocol: %s' % (protocol,)
 
-        assignment = ConsumerProtocol.ASSIGNMENT.decode(member_assignment_bytes)
+        assignment = ConsumerProtocol[0].ASSIGNMENT.decode(member_assignment_bytes)
 
         try:
             self._subscription.assign_from_subscribed(assignment.partitions())
@@ -341,7 +341,7 @@ class ConsumerCoordinator(BaseCoordinator):
             else:
                 member_id, metadata_bytes = member
                 group_instance_id = None
-            metadata = ConsumerProtocol.METADATA.decode(metadata_bytes)
+            metadata = ConsumerProtocol[0].METADATA.decode(metadata_bytes),
             member_metadata[member_id] = metadata
             all_subscribed_topics.update(metadata.subscription) # pylint: disable-msg=no-member
 

--- a/kafka/coordinator/protocol.py
+++ b/kafka/coordinator/protocol.py
@@ -8,7 +8,7 @@ from kafka.structs import TopicPartition
 class ConsumerProtocolMemberMetadata_v0(Struct):
     SCHEMA = Schema(
         ('version', Int16),
-        ('subscription', Array(String('utf-8'))),
+        ('topics', Array(String('utf-8'))),
         ('user_data', Bytes))
 
 

--- a/kafka/coordinator/protocol.py
+++ b/kafka/coordinator/protocol.py
@@ -5,14 +5,14 @@ from kafka.protocol.types import Array, Bytes, Int16, Int32, Schema, String
 from kafka.structs import TopicPartition
 
 
-class ConsumerProtocolMemberMetadata(Struct):
+class ConsumerProtocolMemberMetadata_v0(Struct):
     SCHEMA = Schema(
         ('version', Int16),
         ('subscription', Array(String('utf-8'))),
         ('user_data', Bytes))
 
 
-class ConsumerProtocolMemberAssignment(Struct):
+class ConsumerProtocolMemberAssignment_v0(Struct):
     SCHEMA = Schema(
         ('version', Int16),
         ('assignment', Array(
@@ -26,8 +26,10 @@ class ConsumerProtocolMemberAssignment(Struct):
                 for partition in partitions]
 
 
-class ConsumerProtocol(object):
+class ConsumerProtocol_v0(object):
     PROTOCOL_TYPE = 'consumer'
-    ASSIGNMENT_STRATEGIES = ('range', 'roundrobin')
-    METADATA = ConsumerProtocolMemberMetadata
-    ASSIGNMENT = ConsumerProtocolMemberAssignment
+    METADATA = ConsumerProtocolMemberMetadata_v0
+    ASSIGNMENT = ConsumerProtocolMemberAssignment_v0
+
+
+ConsumerProtocol = [ConsumerProtocol_v0]

--- a/kafka/coordinator/subscription.py
+++ b/kafka/coordinator/subscription.py
@@ -16,8 +16,11 @@ class Subscription(object):
         return self._metadata.user_data
 
     @property
-    def subscription(self):
-        return self._metadata.subscription
+    def topics(self):
+        return self._metadata.topics
+
+    # Alias for old interface / name
+    subscription = topics
 
     @property
     def group_instance_id(self):

--- a/kafka/coordinator/subscription.py
+++ b/kafka/coordinator/subscription.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+
+class Subscription(object):
+    __slots__ = ('_metadata', '_group_instance_id')
+    def __init__(self, metadata, group_instance_id):
+        self._metadata = metadata
+        self._group_instance_id = group_instance_id
+
+    @property
+    def version(self):
+        return self._metadata.version
+
+    @property
+    def user_data(self):
+        return self._metadata.user_data
+
+    @property
+    def subscription(self):
+        return self._metadata.subscription
+
+    @property
+    def group_instance_id(self):
+        return self._group_instance_id
+
+    def encode(self):
+        return self._metadata.encode()
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, Subscription) and
+            self._metadata == other._metadata and
+            self._group_instance_id == other._group_instance_id
+        )

--- a/kafka/protocol/commit.py
+++ b/kafka/protocol/commit.py
@@ -171,7 +171,7 @@ class OffsetCommitRequest_v6(Request):
 class OffsetCommitRequest_v7(Request):
     API_KEY = 8
     API_VERSION = 7
-    RESPONSE_TYPE = OffsetCommitResponse_v6
+    RESPONSE_TYPE = OffsetCommitResponse_v7
     SCHEMA = Schema(
         ('group_id', String('utf-8')),
         ('generation_id', Int32),

--- a/kafka/protocol/commit.py
+++ b/kafka/protocol/commit.py
@@ -59,6 +59,12 @@ class OffsetCommitResponse_v6(Response):
     SCHEMA = OffsetCommitResponse_v5.SCHEMA
 
 
+class OffsetCommitResponse_v7(Response):
+    API_KEY = 8
+    API_VERSION = 7
+    SCHEMA = OffsetCommitResponse_v6.SCHEMA
+
+
 class OffsetCommitRequest_v0(Request):
     API_KEY = 8
     API_VERSION = 0  # Zookeeper-backed storage
@@ -162,17 +168,34 @@ class OffsetCommitRequest_v6(Request):
     )
 
 
+class OffsetCommitRequest_v7(Request):
+    API_KEY = 8
+    API_VERSION = 7
+    RESPONSE_TYPE = OffsetCommitResponse_v6
+    SCHEMA = Schema(
+        ('group_id', String('utf-8')),
+        ('generation_id', Int32),
+        ('member_id', String('utf-8')),
+        ('group_instance_id', String('utf-8')), # added for static membership / kip-345
+        ('topics', Array(
+            ('topic', String('utf-8')),
+            ('partitions', Array(
+                ('partition', Int32),
+                ('offset', Int64),
+                ('leader_epoch', Int32),
+                ('metadata', String('utf-8'))))))
+    )
+
+
 OffsetCommitRequest = [
-    OffsetCommitRequest_v0, OffsetCommitRequest_v1,
-    OffsetCommitRequest_v2, OffsetCommitRequest_v3,
-    OffsetCommitRequest_v4, OffsetCommitRequest_v5,
-    OffsetCommitRequest_v6,
+    OffsetCommitRequest_v0, OffsetCommitRequest_v1, OffsetCommitRequest_v2,
+    OffsetCommitRequest_v3, OffsetCommitRequest_v4, OffsetCommitRequest_v5,
+    OffsetCommitRequest_v6, OffsetCommitRequest_v7,
 ]
 OffsetCommitResponse = [
-    OffsetCommitResponse_v0, OffsetCommitResponse_v1,
-    OffsetCommitResponse_v2, OffsetCommitResponse_v3,
-    OffsetCommitResponse_v4, OffsetCommitResponse_v5,
-    OffsetCommitResponse_v6,
+    OffsetCommitResponse_v0, OffsetCommitResponse_v1, OffsetCommitResponse_v2,
+    OffsetCommitResponse_v3, OffsetCommitResponse_v4, OffsetCommitResponse_v5,
+    OffsetCommitResponse_v6, OffsetCommitResponse_v7,
 ]
 
 

--- a/kafka/protocol/group.py
+++ b/kafka/protocol/group.py
@@ -58,6 +58,23 @@ class JoinGroupResponse_v4(Response):
     SCHEMA = JoinGroupResponse_v3.SCHEMA
 
 
+class JoinGroupResponse_v5(Response):
+    API_KEY = 11
+    API_VERSION = 5
+    SCHEMA = Schema(
+        ('throttle_time_ms', Int32),
+        ('error_code', Int16),
+        ('generation_id', Int32),
+        ('group_protocol', String('utf-8')),
+        ('leader_id', String('utf-8')),
+        ('member_id', String('utf-8')),
+        ('members', Array(
+            ('member_id', String('utf-8')),
+            ('group_instance_id', String('utf-8')),
+            ('member_metadata', Bytes)))
+    )
+
+
 class JoinGroupRequest_v0(Request):
     API_KEY = 11
     API_VERSION = 0
@@ -110,13 +127,31 @@ class JoinGroupRequest_v4(Request):
     SCHEMA = JoinGroupRequest_v3.SCHEMA
 
 
+class JoinGroupRequest_v5(Request):
+    API_KEY = 11
+    API_VERSION = 5
+    RESPONSE_TYPE = JoinGroupResponse_v5
+    SCHEMA = Schema(
+        ('group', String('utf-8')),
+        ('session_timeout', Int32),
+        ('rebalance_timeout', Int32),
+        ('member_id', String('utf-8')),
+        ('group_instance_id', String('utf-8')),
+        ('protocol_type', String('utf-8')),
+        ('group_protocols', Array(
+            ('protocol_name', String('utf-8')),
+            ('protocol_metadata', Bytes)))
+    )
+
+
 JoinGroupRequest = [
     JoinGroupRequest_v0, JoinGroupRequest_v1, JoinGroupRequest_v2,
-    JoinGroupRequest_v3, JoinGroupRequest_v4,
+    JoinGroupRequest_v3, JoinGroupRequest_v4, JoinGroupRequest_v5,
+
 ]
 JoinGroupResponse = [
     JoinGroupResponse_v0, JoinGroupResponse_v1, JoinGroupResponse_v2,
-    JoinGroupResponse_v3, JoinGroupResponse_v4,
+    JoinGroupResponse_v3, JoinGroupResponse_v4, JoinGroupResponse_v5,
 ]
 
 
@@ -153,6 +188,12 @@ class SyncGroupResponse_v2(Response):
     SCHEMA = SyncGroupResponse_v1.SCHEMA
 
 
+class SyncGroupResponse_v3(Response):
+    API_KEY = 14
+    API_VERSION = 3
+    SCHEMA = SyncGroupResponse_v2.SCHEMA
+
+
 class SyncGroupRequest_v0(Request):
     API_KEY = 14
     API_VERSION = 0
@@ -181,8 +222,29 @@ class SyncGroupRequest_v2(Request):
     SCHEMA = SyncGroupRequest_v1.SCHEMA
 
 
-SyncGroupRequest = [SyncGroupRequest_v0, SyncGroupRequest_v1, SyncGroupRequest_v2]
-SyncGroupResponse = [SyncGroupResponse_v0, SyncGroupResponse_v1, SyncGroupResponse_v2]
+class SyncGroupRequest_v3(Request):
+    API_KEY = 14
+    API_VERSION = 3
+    RESPONSE_TYPE = SyncGroupResponse_v3
+    SCHEMA = Schema(
+        ('group', String('utf-8')),
+        ('generation_id', Int32),
+        ('member_id', String('utf-8')),
+        ('group_instance_id', String('utf-8')),
+        ('group_assignment', Array(
+            ('member_id', String('utf-8')),
+            ('member_metadata', Bytes)))
+    )
+
+
+SyncGroupRequest = [
+    SyncGroupRequest_v0, SyncGroupRequest_v1, SyncGroupRequest_v2,
+    SyncGroupRequest_v3,
+]
+SyncGroupResponse = [
+    SyncGroupResponse_v0, SyncGroupResponse_v1, SyncGroupResponse_v2,
+    SyncGroupResponse_v3,
+]
 
 
 class MemberAssignment(Struct):
@@ -218,6 +280,12 @@ class HeartbeatResponse_v2(Response):
     SCHEMA = HeartbeatResponse_v1.SCHEMA
 
 
+class HeartbeatResponse_v3(Response):
+    API_KEY = 12
+    API_VERSION = 3
+    SCHEMA = HeartbeatResponse_v2.SCHEMA
+
+
 class HeartbeatRequest_v0(Request):
     API_KEY = 12
     API_VERSION = 0
@@ -243,8 +311,26 @@ class HeartbeatRequest_v2(Request):
     SCHEMA = HeartbeatRequest_v1.SCHEMA
 
 
-HeartbeatRequest = [HeartbeatRequest_v0, HeartbeatRequest_v1, HeartbeatRequest_v2]
-HeartbeatResponse = [HeartbeatResponse_v0, HeartbeatResponse_v1, HeartbeatResponse_v2]
+class HeartbeatRequest_v3(Request):
+    API_KEY = 12
+    API_VERSION = 3
+    RESPONSE_TYPE = HeartbeatResponse_v3
+    SCHEMA = Schema(
+        ('group', String('utf-8')),
+        ('generation_id', Int32),
+        ('member_id', String('utf-8')),
+        ('group_instance_id', String('utf-8'))
+    )
+
+
+HeartbeatRequest = [
+    HeartbeatRequest_v0, HeartbeatRequest_v1, HeartbeatRequest_v2,
+    HeartbeatRequest_v3,
+]
+HeartbeatResponse = [
+    HeartbeatResponse_v0, HeartbeatResponse_v1, HeartbeatResponse_v2,
+    HeartbeatResponse_v3,
+]
 
 
 class LeaveGroupResponse_v0(Response):
@@ -268,6 +354,19 @@ class LeaveGroupResponse_v2(Response):
     API_KEY = 13
     API_VERSION = 2
     SCHEMA = LeaveGroupResponse_v1.SCHEMA
+
+
+class LeaveGroupResponse_v3(Response):
+    API_KEY = 13
+    API_VERSION = 3
+    SCHEMA = Schema(
+        ('throttle_time_ms', Int32),
+        ('error_code', Int16),
+        ('members', Array(
+            ('member_id', String('utf-8')),
+            ('group_instance_id', String('utf-8')),
+            ('error_code', Int16)))
+    )
 
 
 class LeaveGroupRequest_v0(Request):
@@ -294,5 +393,23 @@ class LeaveGroupRequest_v2(Request):
     SCHEMA = LeaveGroupRequest_v1.SCHEMA
 
 
-LeaveGroupRequest = [LeaveGroupRequest_v0, LeaveGroupRequest_v1, LeaveGroupRequest_v2]
-LeaveGroupResponse = [LeaveGroupResponse_v0, LeaveGroupResponse_v1, LeaveGroupResponse_v2]
+class LeaveGroupRequest_v3(Request):
+    API_KEY = 13
+    API_VERSION = 3
+    RESPONSE_TYPE = LeaveGroupResponse_v3
+    SCHEMA = Schema(
+        ('group', String('utf-8')),
+        ('members', Array(
+            ('member_id', String('utf-8')),
+            ('group_instance_id', String('utf-8'))))
+    )
+
+
+LeaveGroupRequest = [
+    LeaveGroupRequest_v0, LeaveGroupRequest_v1, LeaveGroupRequest_v2,
+    LeaveGroupRequest_v3,
+]
+LeaveGroupResponse = [
+    LeaveGroupResponse_v0, LeaveGroupResponse_v1, LeaveGroupResponse_v2,
+    LeaveGroupResponse_v3,
+]

--- a/kafka/protocol/group.py
+++ b/kafka/protocol/group.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import collections
+
 from kafka.protocol.api import Request, Response
 from kafka.protocol.struct import Struct
 from kafka.protocol.types import Array, Bytes, Int16, Int32, Schema, String
@@ -7,6 +9,9 @@ from kafka.protocol.types import Array, Bytes, Int16, Int32, Schema, String
 
 DEFAULT_GENERATION_ID = -1
 UNKNOWN_MEMBER_ID = ''
+
+GroupMember = collections.namedtuple("GroupMember", ["member_id", "group_instance_id", "metadata_bytes"])
+GroupMember.__new__.__defaults__ = (None,) * len(GroupMember._fields)
 
 
 class JoinGroupResponse_v0(Response):

--- a/test/integration/test_admin_integration.py
+++ b/test/integration/test_admin_integration.py
@@ -231,7 +231,7 @@ def test_describe_consumer_group_exists(kafka_admin_client, kafka_consumer_facto
             else:
                 assert(len(consumer_group.members) == 1)
             for member in consumer_group.members:
-                    assert(member.member_metadata.subscription[0] == topic)
+                    assert(member.member_metadata.topics[0] == topic)
                     assert(member.member_assignment.assignment[0][0] == topic)
             consumer_groups.add(consumer_group.group)
         assert(sorted(list(consumer_groups)) == group_id_list)

--- a/test/test_assignors.py
+++ b/test/test_assignors.py
@@ -11,6 +11,7 @@ from kafka.coordinator.assignors.range import RangePartitionAssignor
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from kafka.coordinator.assignors.sticky.sticky_assignor import StickyPartitionAssignor
 from kafka.coordinator.protocol import ConsumerProtocolMemberAssignment_v0
+from kafka.coordinator.subscription import Subscription
 from kafka.vendor import six
 
 
@@ -34,13 +35,13 @@ def create_cluster(mocker, topics, topics_partitions=None, topic_partitions_lamb
 def test_assignor_roundrobin(mocker):
     assignor = RoundRobinPartitionAssignor
 
-    member_metadata = {
-        'C0': assignor.metadata({'t0', 't1'}),
-        'C1': assignor.metadata({'t0', 't1'}),
+    group_subscriptions = {
+        'C0': Subscription(assignor.metadata({'t0', 't1'}), None),
+        'C1': Subscription(assignor.metadata({'t0', 't1'}), None),
     }
 
     cluster = create_cluster(mocker, {'t0', 't1'}, topics_partitions={0, 1, 2})
-    ret = assignor.assign(cluster, member_metadata)
+    ret = assignor.assign(cluster, group_subscriptions)
     expected = {
         'C0': ConsumerProtocolMemberAssignment_v0(
             assignor.version, [('t0', [0, 2]), ('t1', [1])], b''),
@@ -56,13 +57,13 @@ def test_assignor_roundrobin(mocker):
 def test_assignor_range(mocker):
     assignor = RangePartitionAssignor
 
-    member_metadata = {
-        'C0': assignor.metadata({'t0', 't1'}),
-        'C1': assignor.metadata({'t0', 't1'}),
+    group_subscriptions = {
+        'C0': Subscription(assignor.metadata({'t0', 't1'}), None),
+        'C1': Subscription(assignor.metadata({'t0', 't1'}), None),
     }
 
     cluster = create_cluster(mocker, {'t0', 't1'}, topics_partitions={0, 1, 2})
-    ret = assignor.assign(cluster, member_metadata)
+    ret = assignor.assign(cluster, group_subscriptions)
     expected = {
         'C0': ConsumerProtocolMemberAssignment_v0(
             assignor.version, [('t0', [0, 1]), ('t1', [0, 1])], b''),

--- a/test/test_assignors.py
+++ b/test/test_assignors.py
@@ -10,7 +10,7 @@ from kafka.structs import TopicPartition
 from kafka.coordinator.assignors.range import RangePartitionAssignor
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from kafka.coordinator.assignors.sticky.sticky_assignor import StickyPartitionAssignor
-from kafka.coordinator.protocol import ConsumerProtocolMemberAssignment
+from kafka.coordinator.protocol import ConsumerProtocolMemberAssignment_v0
 from kafka.vendor import six
 
 
@@ -42,9 +42,9 @@ def test_assignor_roundrobin(mocker):
     cluster = create_cluster(mocker, {'t0', 't1'}, topics_partitions={0, 1, 2})
     ret = assignor.assign(cluster, member_metadata)
     expected = {
-        'C0': ConsumerProtocolMemberAssignment(
+        'C0': ConsumerProtocolMemberAssignment_v0(
             assignor.version, [('t0', [0, 2]), ('t1', [1])], b''),
-        'C1': ConsumerProtocolMemberAssignment(
+        'C1': ConsumerProtocolMemberAssignment_v0(
             assignor.version, [('t0', [1]), ('t1', [0, 2])], b'')
     }
     assert ret == expected
@@ -64,9 +64,9 @@ def test_assignor_range(mocker):
     cluster = create_cluster(mocker, {'t0', 't1'}, topics_partitions={0, 1, 2})
     ret = assignor.assign(cluster, member_metadata)
     expected = {
-        'C0': ConsumerProtocolMemberAssignment(
+        'C0': ConsumerProtocolMemberAssignment_v0(
             assignor.version, [('t0', [0, 1]), ('t1', [0, 1])], b''),
-        'C1': ConsumerProtocolMemberAssignment(
+        'C1': ConsumerProtocolMemberAssignment_v0(
             assignor.version, [('t0', [2]), ('t1', [2])], b'')
     }
     assert ret == expected
@@ -102,9 +102,9 @@ def test_sticky_assignor1(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C0': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t0', [0]), ('t1', [1]), ('t3', [0])], b''),
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t0', [1]), ('t2', [0]), ('t3', [1])], b''),
-        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0]), ('t2', [1])], b''),
+        'C0': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t0', [0]), ('t1', [1]), ('t3', [0])], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t0', [1]), ('t2', [0]), ('t3', [1])], b''),
+        'C2': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [0]), ('t2', [1])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -115,10 +115,10 @@ def test_sticky_assignor1(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C0': ConsumerProtocolMemberAssignment(
+        'C0': ConsumerProtocolMemberAssignment_v0(
             StickyPartitionAssignor.version, [('t0', [0]), ('t1', [1]), ('t2', [0]), ('t3', [0])], b''
         ),
-        'C2': ConsumerProtocolMemberAssignment(
+        'C2': ConsumerProtocolMemberAssignment_v0(
             StickyPartitionAssignor.version, [('t0', [1]), ('t1', [0]), ('t2', [1]), ('t3', [1])], b''
         ),
     }
@@ -158,9 +158,9 @@ def test_sticky_assignor2(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C0': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t0', [0])], b''),
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 1])], b''),
-        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [0, 1, 2])], b''),
+        'C0': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t0', [0])], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [0, 1])], b''),
+        'C2': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t2', [0, 1, 2])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -171,8 +171,8 @@ def test_sticky_assignor2(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t0', [0]), ('t1', [0, 1])], b''),
-        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [0, 1, 2])], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t0', [0]), ('t1', [0, 1])], b''),
+        'C2': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t2', [0, 1, 2])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -187,7 +187,7 @@ def test_sticky_one_consumer_no_topic(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [], b''),
+        'C': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -202,7 +202,7 @@ def test_sticky_one_consumer_nonexisting_topic(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [], b''),
+        'C': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -217,7 +217,7 @@ def test_sticky_one_consumer_one_topic(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
+        'C': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -232,7 +232,7 @@ def test_sticky_should_only_assign_partitions_from_subscribed_topics(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
+        'C': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -247,7 +247,7 @@ def test_sticky_one_consumer_multiple_topics(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 1, 2]), ('t2', [0, 1, 2])], b''),
+        'C': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [0, 1, 2]), ('t2', [0, 1, 2])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -263,8 +263,8 @@ def test_sticky_two_consumers_one_topic_one_partition(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0])], b''),
-        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t', [0])], b''),
+        'C2': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -280,8 +280,8 @@ def test_sticky_two_consumers_one_topic_two_partitions(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0])], b''),
-        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [1])], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t', [0])], b''),
+        'C2': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t', [1])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -299,9 +299,9 @@ def test_sticky_multiple_consumers_mixed_topic_subscriptions(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 2])], b''),
-        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [0, 1])], b''),
-        'C3': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [1])], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [0, 2])], b''),
+        'C2': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t2', [0, 1])], b''),
+        'C3': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [1])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -316,7 +316,7 @@ def test_sticky_add_remove_consumer_one_topic(mocker):
 
     assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
     }
     assert_assignment(assignment, expected_assignment)
 
@@ -356,8 +356,8 @@ def test_sticky_add_remove_topic_two_consumers(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 2])], b''),
-        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [1])], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [0, 2])], b''),
+        'C2': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [1])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -371,8 +371,8 @@ def test_sticky_add_remove_topic_two_consumers(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 2]), ('t2', [1])], b''),
-        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [1]), ('t2', [0, 2])], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [0, 2]), ('t2', [1])], b''),
+        'C2': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [1]), ('t2', [0, 2])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -386,8 +386,8 @@ def test_sticky_add_remove_topic_two_consumers(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [1])], b''),
-        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [0, 2])], b''),
+        'C1': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t2', [1])], b''),
+        'C2': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t2', [0, 2])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -601,7 +601,7 @@ def test_assignment_updated_for_deleted_topic(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0]), ('t3', list(range(100)))], b''),
+        'C': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t1', [0]), ('t3', list(range(100)))], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -616,7 +616,7 @@ def test_no_exceptions_when_only_subscribed_topic_is_deleted(mocker):
 
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
+        'C': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 
@@ -630,7 +630,7 @@ def test_no_exceptions_when_only_subscribed_topic_is_deleted(mocker):
     cluster = create_cluster(mocker, topics={}, topics_partitions={})
     sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     expected_assignment = {
-        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [], b''),
+        'C': ConsumerProtocolMemberAssignment_v0(StickyPartitionAssignor.version, [], b''),
     }
     assert_assignment(sticky_assignment, expected_assignment)
 

--- a/test/test_coordinator.py
+++ b/test/test_coordinator.py
@@ -21,6 +21,7 @@ from kafka.protocol.broker_api_versions import BROKER_API_VERSIONS
 from kafka.protocol.commit import (
     OffsetCommitRequest, OffsetCommitResponse,
     OffsetFetchRequest, OffsetFetchResponse)
+from kafka.protocol.group import GroupMember
 from kafka.protocol.metadata import MetadataResponse
 from kafka.structs import OffsetAndMetadata, TopicPartition
 from kafka.util import WeakMethod
@@ -209,7 +210,7 @@ def test_perform_assignment(mocker, coordinator):
 
     ret = coordinator._perform_assignment(
         'member-foo', 'roundrobin',
-        [(member, subscription.encode())
+        [GroupMember(member, None, subscription.encode())
          for member, subscription in group_subscriptions.items()])
 
     assert RoundRobinPartitionAssignor.assign.call_count == 1

--- a/test/test_coordinator.py
+++ b/test/test_coordinator.py
@@ -13,7 +13,7 @@ from kafka.coordinator.assignors.sticky.sticky_assignor import StickyPartitionAs
 from kafka.coordinator.base import Generation, MemberState, HeartbeatThread
 from kafka.coordinator.consumer import ConsumerCoordinator
 from kafka.coordinator.protocol import (
-    ConsumerProtocolMemberMetadata, ConsumerProtocolMemberAssignment)
+    ConsumerProtocolMemberMetadata_v0, ConsumerProtocolMemberAssignment_v0)
 import kafka.errors as Errors
 from kafka.future import Future
 from kafka.protocol.broker_api_versions import BROKER_API_VERSIONS
@@ -73,15 +73,15 @@ def test_group_protocols(coordinator):
 
     coordinator._subscription.subscribe(topics=['foobar'])
     assert coordinator.group_protocols() == [
-        ('range', ConsumerProtocolMemberMetadata(
+        ('range', ConsumerProtocolMemberMetadata_v0(
             RangePartitionAssignor.version,
             ['foobar'],
             b'')),
-        ('roundrobin', ConsumerProtocolMemberMetadata(
+        ('roundrobin', ConsumerProtocolMemberMetadata_v0(
             RoundRobinPartitionAssignor.version,
             ['foobar'],
             b'')),
-        ('sticky', ConsumerProtocolMemberMetadata(
+        ('sticky', ConsumerProtocolMemberMetadata_v0(
             StickyPartitionAssignor.version,
             ['foobar'],
             b'')),
@@ -134,7 +134,7 @@ def test_join_complete(mocker, coordinator):
     coordinator.config['assignors'] = (assignor,)
     mocker.spy(assignor, 'on_assignment')
     assert assignor.on_assignment.call_count == 0
-    assignment = ConsumerProtocolMemberAssignment(0, [('foobar', [0, 1])], b'')
+    assignment = ConsumerProtocolMemberAssignment_v0(0, [('foobar', [0, 1])], b'')
     coordinator._on_join_complete(0, 'member-foo', 'roundrobin', assignment.encode())
     assert assignor.on_assignment.call_count == 1
     assignor.on_assignment.assert_called_with(assignment)
@@ -148,7 +148,7 @@ def test_join_complete_with_sticky_assignor(mocker, coordinator):
     mocker.spy(assignor, 'on_generation_assignment')
     assert assignor.on_assignment.call_count == 0
     assert assignor.on_generation_assignment.call_count == 0
-    assignment = ConsumerProtocolMemberAssignment(0, [('foobar', [0, 1])], b'')
+    assignment = ConsumerProtocolMemberAssignment_v0(0, [('foobar', [0, 1])], b'')
     coordinator._on_join_complete(0, 'member-foo', 'sticky', assignment.encode())
     assert assignor.on_assignment.call_count == 1
     assert assignor.on_generation_assignment.call_count == 1
@@ -166,7 +166,7 @@ def test_subscription_listener(mocker, coordinator):
     assert listener.on_partitions_revoked.call_count == 1
     listener.on_partitions_revoked.assert_called_with(set([]))
 
-    assignment = ConsumerProtocolMemberAssignment(0, [('foobar', [0, 1])], b'')
+    assignment = ConsumerProtocolMemberAssignment_v0(0, [('foobar', [0, 1])], b'')
     coordinator._on_join_complete(
         0, 'member-foo', 'roundrobin', assignment.encode())
     assert listener.on_partitions_assigned.call_count == 1
@@ -184,7 +184,7 @@ def test_subscription_listener_failure(mocker, coordinator):
     coordinator._on_join_prepare(0, 'member-foo')
     assert listener.on_partitions_revoked.call_count == 1
 
-    assignment = ConsumerProtocolMemberAssignment(0, [('foobar', [0, 1])], b'')
+    assignment = ConsumerProtocolMemberAssignment_v0(0, [('foobar', [0, 1])], b'')
     coordinator._on_join_complete(
         0, 'member-foo', 'roundrobin', assignment.encode())
     assert listener.on_partitions_assigned.call_count == 1
@@ -193,13 +193,13 @@ def test_subscription_listener_failure(mocker, coordinator):
 def test_perform_assignment(mocker, coordinator):
     coordinator._subscription.subscribe(topics=['foo1'])
     member_metadata = {
-        'member-foo': ConsumerProtocolMemberMetadata(0, ['foo1'], b''),
-        'member-bar': ConsumerProtocolMemberMetadata(0, ['foo1'], b'')
+        'member-foo': ConsumerProtocolMemberMetadata_v0(0, ['foo1'], b''),
+        'member-bar': ConsumerProtocolMemberMetadata_v0(0, ['foo1'], b'')
     }
     assignments = {
-        'member-foo': ConsumerProtocolMemberAssignment(
+        'member-foo': ConsumerProtocolMemberAssignment_v0(
             0, [('foo1', [0])], b''),
-        'member-bar': ConsumerProtocolMemberAssignment(
+        'member-bar': ConsumerProtocolMemberAssignment_v0(
             0, [('foo1', [1])], b'')
     }
 


### PR DESCRIPTION
Implements static consumer group membership from KIP-345. Pass `group_instance_id` to KafkaConsumer() to specify static group membership. Raises `FencedInstanceIdError` on duplicate consumers if id is reused (in practice the older consumer is typically the one that raises the error). Partition assignors have been updated to consider static members, aligning with the java client implementations.

Note that there are some internal / non-public interface changes that may break code if it has tight dependencies.