### PR TITLE
Throw exception on invalid bucket type

### DIFF
--- a/kafka/metrics/stats/percentiles.py
+++ b/kafka/metrics/stats/percentiles.py
@@ -30,7 +30,7 @@ class Percentiles(AbstractSampledStat, AbstractCompoundStat):
                                  ' to be 0.0.')
             self.bin_scheme = Histogram.LinearBinScheme(self._buckets, max_val)
         else:
-            ValueError('Unknown bucket type: %s' % (bucketing,))
+            raise ValueError('Unknown bucket type: %s' % (bucketing,))
 
     def stats(self):
         measurables = []


### PR DESCRIPTION
## PR Summary
This small PR throws exception on invalid bucket type in `percentiles.py`.