### PR TITLE
fix flush_in_progress not visible to sender

### DIFF
--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -430,7 +430,7 @@ class RecordAccumulator(object):
                 expired = bool(waited_time >= time_to_wait)
 
                 sendable = (full or expired or self._closed or
-                            self._flush_in_progress())
+                            self.flush_in_progress())
 
                 if sendable and not backing_off:
                     ready_nodes.add(leader)
@@ -563,7 +563,7 @@ class RecordAccumulator(object):
         """Deallocate the record batch."""
         self._incomplete.remove(batch)
 
-    def _flush_in_progress(self):
+    def flush_in_progress(self):
         """Are there any threads currently waiting on a flush?"""
         return self._flushes_in_progress.get() > 0
 

--- a/kafka/producer/transaction_manager.py
+++ b/kafka/producer/transaction_manager.py
@@ -553,11 +553,11 @@ class TxnRequestHandler(object):
         return self.transaction_manager.producer_id_and_epoch.epoch
 
     def fatal_error(self, exc):
-        self.transaction_manager._transition_to_fatal_error(exc)
+        self.transaction_manager.transition_to_fatal_error(exc)
         self._result.done(error=exc)
 
     def abortable_error(self, exc):
-        self.transaction_manager._transition_to_abortable_error(exc)
+        self.transaction_manager.transition_to_abortable_error(exc)
         self._result.done(error=exc)
 
     def fail(self, exc):


### PR DESCRIPTION
Call site

https://github.com/dpkp/kafka-python/blob/2abf2cd6458dcb069940c04da2711aa41683f4f4/kafka/producer/sender.py#L285

This is called in Sender._maybe_send_transactional_request(), but over there it's called without `_` prefix. Since this method is accessed by other classes I assume we should remove the prefix, instead of making the caller call `_flush_in_progress` instead