### PR TITLE
Ensure timeout is checked after each fetch position update

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -781,7 +781,7 @@ class KafkaConsumer(six.Iterator):
             # batch update fetch positions for any partitions without a valid position
             if self._update_fetch_positions(timeout_ms=timer.timeout_ms):
                 position = self._subscription.assignment[partition].position
-            elif timer.expired:
+            if timer.expired:
                 return None
         else:
             return position.offset


### PR DESCRIPTION
For `Consumer.position()` I had a case when `self._update_fetch_positions` always resulted in `True` and `position` was always `None`. This hangs the loop for ~305 seconds, and it appears to me that the line
```
elif timer.expired:
```
is never reached.

The root cause is probably how `timeout_ms` value is propagated and checked in the following methods, however I believe my change is still valid as the timeout check should work disregarding of `self._update_fetch_positions` value.