### PR TITLE
Fix thread not waking up when there is still data to be sent

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -1075,6 +1075,13 @@ class BrokerConnection(object):
                     total_bytes = self._send_bytes(self._send_buffer)
                     self._send_buffer = self._send_buffer[total_bytes:]
 
+                # If all data was sent, we need to get the new data from the protocol now, otherwise
+                # this function would return True, indicating that there are no more pending
+                # requests. This could cause the calling thread to wait indefinitely as it won't
+                # know that there is still buffered data to send.
+                if not self._send_buffer:
+                    self._send_buffer = self._protocol.send_bytes()
+
             if self._sensors:
                 self._sensors.bytes_sent.record(total_bytes)
             # Return True iff send buffer is empty


### PR DESCRIPTION
When producing messages quickly without waiting for the future of previous requests, there could  be some situations when the last batch was not sent.

That seemed to be more frequent with larger messages (~100KiB), but apparently it could happen to any message when `linger_ms` is 0. Not sure if it could happen when it is non-zero though.

The reason is that `BrokerConnection.send_pending_requests_v2` would fill the internal buffer with the bytes from a request and try to send it.

https://github.com/dpkp/kafka-python/blob/512d0a0b8d71cf7f34f1b23f8a42d52c28af3266/kafka/conn.py#L1071

If it couldn't send it completely for some reason, it would try to send again in the next call to `send_pending_requests_v2`.

But if between those 2 calls, `BrokerConnection.send` was called, new data would be appended to self._protocol: KafkaProtocol:

https://github.com/dpkp/kafka-python/blob/512d0a0b8d71cf7f34f1b23f8a42d52c28af3266/kafka/conn.py#L1015

but the second call to `send_pending_requests_v2` wouldn't check if any new data was available and would return False:

https://github.com/dpkp/kafka-python/blob/512d0a0b8d71cf7f34f1b23f8a42d52c28af3266/kafka/conn.py#L1070

This would tell `KafkaClient._poll` that all pending data was sent, which would make the client not listen to socked write readiness anymore:

https://github.com/dpkp/kafka-python/blob/512d0a0b8d71cf7f34f1b23f8a42d52c28af3266/kafka/client_async.py#L744-L748