### PR TITLE
Add a check to ensure broker connection is ready during poll if auto commit is disabled

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -726,6 +726,10 @@ class KafkaConsumer(six.Iterator):
             log.debug('poll: timeout during coordinator.poll(); returning early')
             return {}
 
+        node_id = self._coordinator.coordinator()
+        if node_id is None or not self._client.ready(node_id, metadata_priority=False):
+            return {}
+
         has_all_fetch_positions = self._update_fetch_positions(timeout_ms=timer.timeout_ms)
 
         # If data is available already, e.g. from a previous network client


### PR DESCRIPTION
Potentially fixes https://github.com/dpkp/kafka-python/issues/2667

If `enable_auto_commit=False` the CPU usage of a kafka consumer increases to 100% if the broker connection is lost. If `enable_auto_commit=True`, the connection loss is detected by the periodic auto commit, which acts as a sort of health check in this case.

I added a similar check to the `poll` method. I am not sure if this the best location, thats why I also did not add any test yet. 
We might also only check the readiness in case `enabled_auto_commit=False`. 

Looking forward to your feedback.