### PR TITLE
REF: switch to deque.copy() for Python 3 compatibility

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -1,5 +1,4 @@
 import collections
-import copy
 import itertools
 import logging
 import sys
@@ -611,8 +610,7 @@ class Fetcher(object):
         fetchable = self._subscriptions.fetchable_partitions()
         # do not fetch a partition if we have a pending fetch response to process
         # use copy.copy to avoid runtimeerror on mutation from different thread
-        # TODO: switch to deque.copy() with py3
-        discard = {fetch.topic_partition for fetch in copy.copy(self._completed_fetches)}
+        discard = {fetch.topic_partition for fetch in self._completed_fetches.copy()}
         current = self._next_partition_records
         if current:
             discard.add(current.topic_partition)


### PR DESCRIPTION
removed unused 'copy' import and replaced `copy.copy()` with `deque.copy()` in [kafka/consumer/fetcher.py](cci:7://file:///Users/ranjanyadav/Developer/github.com/yranjan06/kafka-python/kafka/consumer/fetcher.py:0:0-0:0).
This resolves the TODO comment regarding Python 3 compatibility and improves performance.

## Verification
Ran unit tests locally.

**Before:**
`test/test_fetcher.py ... 38 passed in 1.11s`

**After:**
`test/test_fetcher.py ... 38 passed in 0.84s`