### PR TITLE
Raise ValueError for empty consumer subscription

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -961,7 +961,7 @@ class KafkaConsumer:
         Raises:
             IllegalStateError: If called after previously calling
                 :meth:`~kafka.KafkaConsumer.assign`.
-            AssertionError: If neither topics or pattern is provided.
+            ValueError: If neither topics or pattern is provided.
             TypeError: If listener is not a ConsumerRebalanceListener.
         """
         # SubscriptionState handles error checking

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -119,7 +119,8 @@ class SubscriptionState:
                 guaranteed, however, that the partitions revoked/assigned
                 through this interface are from topics subscribed in this call.
         """
-        assert topics or pattern, 'Must provide topics or pattern'
+        if not (topics or pattern):
+            raise ValueError('Must provide topics or pattern')
         if (topics and pattern):
             raise Errors.IllegalStateError(self._SUBSCRIPTION_EXCEPTION_MESSAGE)
 

--- a/test/consumer/test_subscription_state.py
+++ b/test/consumer/test_subscription_state.py
@@ -12,6 +12,12 @@ def test_type_error():
     s.subscribe(topics=['foo'])
 
 
+def test_subscribe_requires_topics_or_pattern():
+    s = SubscriptionState()
+    with pytest.raises(ValueError, match='Must provide topics or pattern'):
+        s.subscribe()
+
+
 def test_change_subscription():
     s = SubscriptionState()
     s.subscribe(topics=['foo'])


### PR DESCRIPTION
Refs #891

`KafkaConsumer.subscribe()` documents that callers must provide either `topics` or `pattern`. The underlying `SubscriptionState.subscribe()` enforced the missing-argument case with an `assert`, so normal Python raised `AssertionError` and optimized Python (`-O`) skipped the check and accepted an empty subscription.

This changes that missing-argument branch to raise `ValueError` and updates the public docstring. The existing `IllegalStateError` behavior when both `topics` and `pattern` are provided is unchanged.

Tests:
- `pytest test/consumer/test_subscription_state.py -q`
- `pytest test/consumer/test_consumer.py test/consumer/test_subscription_state.py -q`
- `pytest test/consumer -q`
- `python -O` smoke checks for `SubscriptionState.subscribe()` and `KafkaConsumer.subscribe()`
- `python -m compileall -q kafka/consumer/subscription_state.py kafka/consumer/group.py test/consumer/test_subscription_state.py`
- `pylint --errors-only kafka/consumer/subscription_state.py kafka/consumer/group.py test/consumer/test_subscription_state.py`
- `git diff --check`