### PR TITLE
kafka.net.manager: close before stopping IO thread; fail pending bootstrap

### DIFF
--- a/kafka/net/compat.py
+++ b/kafka/net/compat.py
@@ -134,10 +134,9 @@ class KafkaNetClient:
             return self._manager.poll(timeout_ms=timeout_ms, future=future)
 
     def close(self, node_id=None):
-        if node_id is None:
-            self._manager.stop()
         self._manager.close(node_id=node_id)
         if node_id is None:
+            self._manager.stop()
             self._net.close()
 
     def least_loaded_node(self, bootstrap_fallback=False):

--- a/kafka/net/manager.py
+++ b/kafka/net/manager.py
@@ -13,6 +13,7 @@ from .metrics import KafkaManagerMetrics
 from .transport import KafkaSSLTransport, KafkaTCPTransport
 from kafka.cluster import ClusterMetadata
 import kafka.errors as Errors
+from kafka.net.wakeup_notifier import WakeupNotifier
 from kafka.protocol.broker_version_data import BrokerVersionData
 from kafka.future import Future
 from kafka.version import __version__
@@ -76,6 +77,7 @@ class KafkaConnectionManager:
         self.close_idle_connections()
         self.broker_version_data = None
         self._bootstrap_future = None
+        self._bootstrap_wakeup = WakeupNotifier(self._net)
         self._io_thread = None
         self._pending_waiters = {}  # event -> state dict, for pending run() waiters
         self._pending_waiters_lock = threading.Lock()
@@ -86,6 +88,7 @@ class KafkaConnectionManager:
             self._sensors = None
         if self.config['api_version'] is not None:
             self.broker_version_data = BrokerVersionData(self.config['api_version'])
+        self.closed = False
 
     @property
     def broker_version(self):
@@ -97,7 +100,7 @@ class KafkaConnectionManager:
         return sorted(filter(lambda conn: conn.connected, self._conns.values()), key=lambda conn: conn.transport.last_activity)
 
     async def _do_bootstrap(self, deadline):
-        while deadline is None or time.monotonic() < deadline:
+        while not self.closed and (deadline is None or time.monotonic() < deadline):
             bootstrap_broker = random.choice(self.cluster.bootstrap_brokers())
             log.debug('Attempting bootstrap with %s', bootstrap_broker)
             try:
@@ -110,7 +113,7 @@ class KafkaConnectionManager:
                 if deadline is not None:
                     delay = min(delay, max(0, deadline - time.monotonic()))
                 log.debug('Bootstrap %s NodeNotReadyError: backoff %s', bootstrap_broker, delay)
-                await self._net.sleep(delay)
+                await self._bootstrap_wakeup(delay)
                 continue
 
             try:
@@ -334,7 +337,9 @@ class KafkaConnectionManager:
             conn = self._conns.get(node_id)
             if conn is not None:
                 conn.close()
-        else:
+        elif not self.closed:
+            self.closed = True
+            self._bootstrap_wakeup.notify()
             for conn in list(self._conns.values()):
                 conn.close()
             self.cluster.close()

--- a/kafka/net/manager.py
+++ b/kafka/net/manager.py
@@ -436,7 +436,7 @@ class KafkaConnectionManager:
         async def wrapper():
             try:
                 future.success(await self._invoke(coro, args))
-            except Exception as exc:
+            except BaseException as exc:
                 future.failure(exc)
         self._net.call_soon_threadsafe(wrapper)
         return future

--- a/test/net/test_compat.py
+++ b/test/net/test_compat.py
@@ -182,8 +182,7 @@ class TestKafkaNetClientVersion:
         # Pre-set bootstrap future so check_version doesn't try to connect
         manager._bootstrap_future = Future()
         manager._bootstrap_future.success(True)
-        with patch.object(manager, 'bootstrap', return_value=manager._bootstrap_future):
-            result = client.check_version()
+        result = client.check_version()
         assert isinstance(result, tuple)
 
 


### PR DESCRIPTION
- **manager.close before manager.stop**
- **kafka.net.manager: add closed attr and _bootstrap_wakeup; notify bootstrap on close**
