### PR TITLE
Consumer: use background thread for all network io; drop HeartbeatThread

### DIFF
--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -200,14 +200,12 @@ class ClusterMetadata:
         """
         for topic in topics:
             ensure_valid_topic_name(topic)
-        if set(topics).difference(self._topics):
-            # TODO: handle future when old metadata request is currently in-flight
-            # TODO: handle future when set_topics called multiple times before new request
-            future = self.request_update()
-        else:
-            future = Future().success(self)
+        if not set(topics).difference(self._topics):
+            return Future().success(self)
+        # TODO: handle future when old metadata request is currently in-flight
+        # TODO: handle future when set_topics called multiple times before new request
         self._topics = set(topics)
-        return future
+        return self.request_update()
 
     def add_topic(self, topic):
         """Add a topic to the list of topics tracked via metadata.
@@ -224,8 +222,8 @@ class ClusterMetadata:
         """
         ensure_valid_topic_name(topic)
         if topic in self._topics:
-            # TODO: handle future when old metadata request is currently in-flight
             return Future().success(self)
+        # TODO: handle future when old metadata request is currently in-flight
         self._topics.add(topic)
         return self.request_update()
 

--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -196,12 +196,8 @@ class Fetcher:
         for fut in waited_on:
             fut.add_both(_wake)
 
-        # Hold _client._lock so we serialize with HeartbeatThread, which
-        # also drives _net.poll under this lock. Drops once Phase D
-        # retires HeartbeatThread.
         try:
-            with self._client._lock:
-                self._net.run(self._manager.wait_for, wakeup, timeout_ms)
+            self._net.run(self._manager.wait_for, wakeup, timeout_ms)
         except Errors.KafkaTimeoutError:
             pass
 
@@ -301,8 +297,7 @@ class Fetcher:
         Raises:
             KafkaTimeoutError if timeout_ms provided
         """
-        with self._client._lock:
-            offsets = self._net.run(self._fetch_offsets_by_times_async, timestamps, timeout_ms)
+        offsets = self._net.run(self._fetch_offsets_by_times_async, timestamps, timeout_ms)
         for tp in timestamps:
             if tp not in offsets:
                 offsets[tp] = None
@@ -427,8 +422,7 @@ class Fetcher:
             KafkaTimeoutError if timeout_ms provided.
         """
         timestamps = dict([(tp, timestamp) for tp in partitions])
-        with self._client._lock:
-            offsets = self._net.run(self._fetch_offsets_by_times_async, timestamps, timeout_ms)
+        offsets = self._net.run(self._fetch_offsets_by_times_async, timestamps, timeout_ms)
         for tp in timestamps:
             offsets[tp] = offsets[tp].offset
         return offsets

--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -174,15 +174,12 @@ class Fetcher:
         if records:
             return records
 
-        # No records yet. Wait for any signal that more work might be
-        # ready: an in-flight fetch completing OR a pending offset-reset
-        # task completing (positions become available, enabling future
-        # fetches). The wait drives the manager's event loop — the
-        # consumer has no background IO thread, so call_soon-scheduled
-        # tasks (resets, sent fetches) only run inside manager.run.
-        # add_both fires synchronously on already-done futures, closing
-        # the race where a response arrives between scheduling and the
-        # wait setup.
+        # No records yet. Block until either an in-flight fetch
+        # completes (records may have arrived) or a pending offset-reset
+        # task completes (positions become available, enabling a fetch
+        # on the next caller iteration). add_both fires synchronously on
+        # already-done futures, closing the race where a future resolves
+        # between scheduling and the wait setup.
         waited_on = list(self._fetch_futures)
         if self._reset_task is not None and not self._reset_task.is_done:
             waited_on.append(self._reset_task)

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -386,6 +386,11 @@ class KafkaConsumer:
         self._cluster = self._manager.cluster
         self._net = self._manager._net
 
+        # Drive the IO loop on a background thread so coroutines (heartbeat,
+        # metadata refresh) make progress without depending on user-thread
+        # poll() timing.
+        self._net.start()
+
         # If api_version was not passed explicitly, bootstrap to auto-discover
         # it. bootstrap is passed as a deferred coroutine so that once the IO
         # thread is introduced in a later phase it runs on the IO thread.
@@ -730,9 +735,6 @@ class KafkaConsumer:
         poll_timeout_ms = timer.timeout_ms
         if self.config['group_id'] is not None:
             poll_timeout_ms = min(poll_timeout_ms, self._coordinator.time_to_next_poll() * 1000)
-
-        # turn the IO crank here until we have permanent io thread
-        self._client.poll(timeout_ms=0)
 
         return self._fetcher.fetch_records(
             max_records, update_offsets=update_offsets, timeout_ms=poll_timeout_ms)

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -290,8 +290,7 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
 
         Returns: True is coordinator found before timeout_ms, else False
         """
-        with self._client._lock:
-            return self._net.run(self.ensure_coordinator_ready_async, timeout_ms)
+        return self._net.run(self.ensure_coordinator_ready_async, timeout_ms)
 
     async def ensure_coordinator_ready_async(self, timeout_ms=None):
         """Async variant of :meth:`ensure_coordinator_ready`.
@@ -341,7 +340,7 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
         self._find_coordinator_future = None
 
     def lookup_coordinator(self):
-        with self._client._lock, self._lock:
+        with self._lock:
             if self._find_coordinator_future is not None:
                 return self._find_coordinator_future
 
@@ -411,8 +410,7 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
 
         Returns: True if group initialized before timeout_ms, else False
         """
-        with self._client._lock:
-            return self._net.run(self.ensure_active_group_async, timeout_ms)
+        return self._net.run(self.ensure_active_group_async, timeout_ms)
 
     async def ensure_active_group_async(self, timeout_ms=None):
         """Async variant of :meth:`ensure_active_group`."""
@@ -928,8 +926,7 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
 
     def maybe_leave_group(self, reason=None, timeout_ms=None):
         """Leave the current group and reset local generation/member_id."""
-        with self._client._lock:
-            return self._net.run(self.maybe_leave_group_async, reason, timeout_ms)
+        return self._net.run(self.maybe_leave_group_async, reason, timeout_ms)
 
     async def maybe_leave_group_async(self, reason=None, timeout_ms=None):
         if not self._use_group_apis:

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -813,6 +813,8 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
         self.rejoin_needed = True
 
     def _maybe_start_heartbeat_loop(self):
+        if self._heartbeat_closed:
+            return
         if self._heartbeat_loop_future is None or self._heartbeat_loop_future.is_done:
             heartbeat_log.debug('Starting heartbeat loop')
             self._heartbeat_loop_future = self._manager.call_soon(self._heartbeat_loop)

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -4,7 +4,6 @@ import logging
 import threading
 import time
 import warnings
-import weakref
 
 from kafka.coordinator.heartbeat import Heartbeat
 from kafka import errors as Errors
@@ -143,11 +142,10 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
         self._cluster = self._manager.cluster
         self._net = self._manager._net
         self.heartbeat = Heartbeat(**self.config)
-        self._heartbeat_wakeup = WakeupNotifier(self._manager._net)
+        self._heartbeat_wakeup = WakeupNotifier(self._net)
         self._heartbeat_loop_future = None
         self._heartbeat_enabled = False
         self._heartbeat_closed = False
-        self._heartbeat_thread = None
         self._lock = threading.RLock()
         self.rejoin_needed = True
         self.rejoining = False  # renamed / complement of java needsJoinPrepare
@@ -366,26 +364,26 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
 
     def poll_heartbeat(self):
         """
-        Check the status of the heartbeat thread (if it is active) and indicate
-        the liveness of the client. This must be called periodically after
-        joining with :meth:`.ensure_active_group` to ensure that the member stays
-        in the group. If an interval of time longer than the provided rebalance
-        timeout (max_poll_interval_ms) expires without calling this method, then
-        the client will proactively leave the group.
+        Check the status of the heartbeat coroutine and indicate the liveness
+        of the client. This must be called periodically after joining with
+        :meth:`.ensure_active_group` to ensure that the member stays in the
+        group. If an interval of time longer than the provided rebalance
+        timeout (max_poll_interval_ms) expires without calling this method,
+        then the client will proactively leave the group.
 
-        Raises: RuntimeError for unexpected errors raised from the heartbeat thread
+        Raises: the underlying exception if the heartbeat coroutine has
+        terminated with an error. The next call to ensure_active_group will
+        respawn the loop.
         """
         with self._lock:
-            if self._heartbeat_thread is not None:
-                if self._heartbeat_thread.failed:
-                    # set the heartbeat thread to None and raise an exception.
-                    # If the user catches it, the next call to ensure_active_group()
-                    # will spawn a new heartbeat thread.
-                    cause = self._heartbeat_thread.failed
-                    self._heartbeat_thread = None
-                    raise cause  # pylint: disable-msg=raising-bad-type
-
-                self.heartbeat.poll()
+            fut = self._heartbeat_loop_future
+            if fut is not None and fut.is_done and fut.failed():
+                # Forget the dead future so the next ensure_active_group()
+                # respawns the heartbeat loop.
+                cause = fut.exception
+                self._heartbeat_loop_future = None
+                raise cause  # pylint: disable-msg=raising-bad-type
+            self.heartbeat.poll()
 
     def time_to_next_heartbeat(self):
         """Returns seconds (float) remaining before next heartbeat should be sent
@@ -424,7 +422,6 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
         if not await self.ensure_coordinator_ready_async(timeout_ms=timer.timeout_ms):
             return False
         self._maybe_start_heartbeat_loop()
-        self._maybe_start_heartbeat_thread()
         return await self.join_group_async(timeout_ms=timer.timeout_ms)
 
     async def join_group_async(self, timeout_ms=None):
@@ -817,14 +814,6 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
     def request_rejoin(self):
         self.rejoin_needed = True
 
-    def _maybe_start_heartbeat_thread(self):
-        if self._heartbeat_thread is None:
-            heartbeat_log.info('Starting new heartbeat thread')
-            self._heartbeat_thread = HeartbeatThread(self)
-            self._heartbeat_thread.daemon = True
-            self._heartbeat_thread.start()
-            heartbeat_log.debug("Started heartbeat thread %s", self._heartbeat_thread.ident)
-
     def _maybe_start_heartbeat_loop(self):
         if self._heartbeat_loop_future is None or self._heartbeat_loop_future.is_done:
             heartbeat_log.debug('Starting heartbeat loop')
@@ -844,11 +833,6 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
     def _close_heartbeat(self):
         self._heartbeat_closed = True
         self._heartbeat_wakeup.notify()
-
-    def _close_heartbeat_thread(self, timeout_ms=None):
-        if self._heartbeat_thread is not None:
-            self._heartbeat_thread.close(timeout_ms=timeout_ms)
-            self._heartbeat_thread = None
 
     async def _heartbeat_loop(self):
         heartbeat_log.debug('Heartbeat loop started.')
@@ -937,7 +921,6 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
         and reset local generation / member_id"""
         if self._use_group_apis:
             self._close_heartbeat()
-            self._close_heartbeat_thread(timeout_ms=timeout_ms)
             self.maybe_leave_group(timeout_ms=timeout_ms)
 
     def is_dynamic_member(self):
@@ -1110,52 +1093,3 @@ class GroupCoordinatorMetrics:
             'The number of seconds since the last controller heartbeat was sent',
             tags), AnonMeasurable(
                 lambda _, now: (now / 1000) - self.heartbeat.last_send))
-
-
-class HeartbeatThread(threading.Thread):
-    def __init__(self, coordinator):
-        super().__init__()
-        self.name = coordinator.group_id + '-heartbeat'
-        self.coordinator = weakref.proxy(coordinator)
-        self.closed = False
-        self.failed = None
-
-    def close(self, timeout_ms=None):
-        if self.closed:
-            return
-
-        heartbeat_log.info('Stopping heartbeat thread')
-        self.closed = True
-
-        # Generally this should not happen - close() is triggered
-        # by the coordinator. But in some cases GC may close the coordinator
-        # from within the heartbeat thread.
-        if threading.current_thread() == self:
-            return
-
-        if self.is_alive():
-            if timeout_ms is None:
-                timeout_ms = self.coordinator.config['heartbeat_interval_ms']
-            self.join(timeout_ms / 1000)
-        if self.is_alive():
-            heartbeat_log.warning("Heartbeat thread did not fully terminate during close")
-
-    def run(self):
-        try:
-            heartbeat_log.debug('Heartbeat thread started')
-            # Run 4x heartbeat_interval
-            freq = (self.coordinator.config['heartbeat_interval_ms'] / 1000) / 4
-            while not self.closed:
-                with self.coordinator._client._lock, self.coordinator._lock:
-                    self.coordinator._client.poll(timeout_ms=100)
-                time.sleep(freq)
-
-        except ReferenceError:
-            heartbeat_log.debug('Heartbeat thread closed due to coordinator gc')
-
-        except BaseException as exc:
-            heartbeat_log.exception("Heartbeat thread failed due to unexpected error: %s", exc)
-            self.failed = exc
-
-        finally:
-            heartbeat_log.debug('Heartbeat thread closed')

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -459,8 +459,7 @@ class ConsumerCoordinator(BaseCoordinator):
 
     def refresh_committed_offsets_if_needed(self, timeout_ms=None):
         """Fetch committed offsets for assigned partitions."""
-        with self._client._lock:
-            return self._net.run(self.refresh_committed_offsets_if_needed_async, timeout_ms)
+        return self._net.run(self.refresh_committed_offsets_if_needed_async, timeout_ms)
 
     async def refresh_committed_offsets_if_needed_async(self, timeout_ms=None):
         missing_fetch_positions = set(self._subscription.missing_fetch_positions())
@@ -487,8 +486,7 @@ class ConsumerCoordinator(BaseCoordinator):
         """
         if not partitions:
             return {}
-        with self._client._lock:
-            return self._net.run(self.fetch_committed_offsets_async, partitions, timeout_ms)
+        return self._net.run(self.fetch_committed_offsets_async, partitions, timeout_ms)
 
     async def fetch_committed_offsets_async(self, partitions, timeout_ms=None):
         """Async variant of :meth:`fetch_committed_offsets`."""
@@ -620,8 +618,7 @@ class ConsumerCoordinator(BaseCoordinator):
         assert all(map(lambda v: isinstance(v, OffsetAndMetadata),
                        offsets.values()))
         self._invoke_completed_offset_commit_callbacks()
-        with self._client._lock:
-            return self._net.run(self._commit_offsets_sync_async, offsets, timeout_ms)
+        return self._net.run(self._commit_offsets_sync_async, offsets, timeout_ms)
 
     async def _commit_offsets_sync_async(self, offsets, timeout_ms=None):
         if not offsets:

--- a/test/integration/test_admin_integration.py
+++ b/test/integration/test_admin_integration.py
@@ -354,6 +354,7 @@ def test_delete_records(kafka_admin_client, kafka_consumer_factory, send_message
     consumer1.assign(partitions)
     for _ in range(600):
         next(consumer1)
+    consumer1.close()
 
     result = kafka_admin_client.delete_records({t0p0: -1, t0p1: 50, t1p0: 40, t1p2: 30}, timeout_ms=1000)
     assert result[t0p0] == {"low_watermark": 100, "error_code": 0, "partition_index": t0p0.partition}
@@ -366,6 +367,7 @@ def test_delete_records(kafka_admin_client, kafka_consumer_factory, send_message
     all_messages = consumer2.poll(max_records=600, timeout_ms=2000)
     assert sum(len(x) for x in all_messages.values()) == 600 - 100 - 50 - 40 - 30
     assert not consumer2.poll(max_records=1, timeout_ms=1000) # ensure there are no delayed messages
+    consumer2.close()
 
     assert not all_messages.get(t0p0, [])
     assert [r.offset for r in all_messages[t0p1]] == list(range(50, 100))


### PR DESCRIPTION
- coordinator: drop HeartbeatThread
- Consumer: Drop client._lock
- Consumer: Start net.io_thread / drop client.poll()
- Update Fetcher comment
- Dont start new heartbeat loop if closed
