### PR TITLE
kafka.net.transport: close connection on socket write error

### DIFF
--- a/kafka/net/transport.py
+++ b/kafka/net/transport.py
@@ -253,13 +253,19 @@ class KafkaTCPTransport:
             self._close(error)
 
     def _close(self, error=None):
-        if self._sock:
-            self._net.unregister_event(self._sock, selectors.EVENT_READ | selectors.EVENT_WRITE)
-            self._sock.close()
-            self._sock = None
-        if self._protocol:
-            self._protocol.connection_lost(error)
-            self._protocol = None
+        # idempotent; no lock
+        sock = self._sock
+        self._sock = None
+        if sock is not None:
+            try:
+                self._net.unregister_event(sock, selectors.EVENT_READ | selectors.EVENT_WRITE)
+            except (KeyError, ValueError):
+                pass
+            sock.close()
+        proto = self._protocol
+        self._protocol = None
+        if proto is not None:
+            proto.connection_lost(error)
 
   # Twisted
     def abortConnection(self):

--- a/kafka/net/transport.py
+++ b/kafka/net/transport.py
@@ -196,14 +196,13 @@ class KafkaTCPTransport:
                     self._protocol._sensors.bytes_sent.record(total_bytes)
         finally:
             self._writing = False
-        if self._closed:
-            self._close()
+        if self._closed or err is not None:
+            self._close(error=err)
         elif not self._write:
             self._sock.shutdown(socket.SHUT_WR)
 
     def _sock_send(self):
         total_bytes = 0
-        err = None
         while self._write_buffer:
             next_chunk = self._write_buffer.popleft()
             # Wrap in memoryview so partial-send slicing is O(1) instead of
@@ -217,12 +216,11 @@ class KafkaTCPTransport:
                     next_chunk = next_chunk[sent_bytes:]
                 except (BlockingIOError, InterruptedError):
                     self._write_buffer.appendleft(next_chunk)
-                    return total_bytes, err
+                    return total_bytes, None
                 except BaseException as e:
                     log.exception("%s: Error sending request data: %s", self, e)
-                    err = Errors.KafkaConnectionError(e)
-                    return total_bytes, err
-        return total_bytes, err
+                    return total_bytes, Errors.KafkaConnectionError(e)
+        return total_bytes, None
 
     def write_eof(self):
         """Close the write end after flushing buffered data.
@@ -335,11 +333,11 @@ class KafkaTCPTransport:
     def host_port(self):
         try:
             host, port = self._sock.getpeername()[0:2]
-        except OSError:
+        except OSError, ValueError:
             return 'none'
         try:
             local_port = self._sock.getsockname()[1]
-        except OSError:
+        except OSError, ValueError:
             return f'{host}:{port}'
         return f'{host}:{port}<-{local_port}'
 

--- a/kafka/net/transport.py
+++ b/kafka/net/transport.py
@@ -339,11 +339,11 @@ class KafkaTCPTransport:
     def host_port(self):
         try:
             host, port = self._sock.getpeername()[0:2]
-        except OSError, ValueError:
+        except (OSError, ValueError):
             return 'none'
         try:
             local_port = self._sock.getsockname()[1]
-        except OSError, ValueError:
+        except (OSError, ValueError):
             return f'{host}:{port}'
         return f'{host}:{port}<-{local_port}'
 

--- a/test/net/test_transport.py
+++ b/test/net/test_transport.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import kafka.errors as Errors
 from kafka.future import Future
 from kafka.net.selector import NetworkSelector
 from kafka.net.transport import KafkaTCPTransport
@@ -137,6 +138,40 @@ class TestKafkaTCPTransport:
         t.abort()
         t.abort()
         proto.connection_lost.assert_called_once()
+
+    def test_sock_send_error_closes_transport(self, net, socketpair):
+        """If _sock_send returns an error, _write_to_sock must close the
+        transport and propagate the error via protocol.connection_lost.
+
+        Regression for an earlier bug where the err return value from
+        _sock_send was discarded and the loop kept retrying on a broken
+        socket forever.
+        """
+        _, wsock = socketpair
+        t = KafkaTCPTransport(net, wsock)
+        proto = MagicMock()
+        done = Future()
+        proto.connection_lost.side_effect = lambda err: done.success(err)
+        t.set_protocol(proto)
+
+        err = Errors.KafkaConnectionError('write failed')
+
+        # Stub _sock_send: drain one chunk (real _sock_send drops the chunk
+        # that errored — no appendleft on BaseException) and return the
+        # error so the while-loop's buffer check terminates.
+        def fake_sock_send():
+            if t._write_buffer:
+                t._write_buffer.popleft()
+            return 0, err
+        t._sock_send = fake_sock_send
+
+        t.write(b'data')
+        net.poll(timeout_ms=1000, future=done)
+
+        assert done.is_done
+        assert not t._writing
+        assert t._sock is None
+        proto.connection_lost.assert_called_once_with(err)
 
     def test_can_write_eof(self, net):
         sock = _make_mock_sock()


### PR DESCRIPTION
- kafka.net.transport: close connection on socket write error
- transport: idempotent _close()
