### PR TITLE
Consumer: Improve retriable offset fetch error handling

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -555,10 +555,12 @@ class Fetcher:
         """Drive resets to completion or until the timer expires.
 
         Each iteration fans out per-node ListOffsets requests concurrently
-        and awaits all of them; backoff partitions are filtered out of
-        partitions_needing_reset() so the loop exits when there's no more
-        in-window work. If all partitions have unknown leaders, awaits a
-        metadata refresh and retries within the remaining budget.
+        and awaits all of them. After a retriable failure (NotLeader, etc.)
+        a partition's next_allowed_retry_time is set ``retry_backoff_ms`` in
+        the future; the loop sleeps until that time and retries rather than
+        relying on an external caller to redrive. If all partitions have
+        unknown leaders, awaits a metadata refresh and retries within the
+        remaining budget.
 
         Arguments:
             timeout_ms (int, optional): Hard upper bound on the loop's
@@ -575,9 +577,19 @@ class Fetcher:
             timeout_ms = self.config['request_timeout_ms']
         timer = Timer(timeout_ms)
         while not timer.expired:
+            if self._cached_list_offsets_exception is not None:
+                return
             partitions = self._subscriptions.partitions_needing_reset()
             if not partitions:
-                return
+                next_retry = self._subscriptions.next_offset_reset_retry_time()
+                if next_retry is None:
+                    return
+                delay = max(0.0, next_retry - time.monotonic())
+                if timer.timeout_ms is not None:
+                    delay = min(delay, timer.timeout_ms / 1000)
+                if delay > 0:
+                    await self._manager._net.sleep(delay)
+                continue
 
             offset_resets = {}
             for tp in partitions:

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -400,6 +400,13 @@ class SubscriptionState:
         return partitions
 
     @synchronized
+    def next_offset_reset_retry_time(self):
+        times = [state.next_allowed_retry_time
+                 for state in self.assignment.values()
+                 if state.awaiting_reset and state.next_allowed_retry_time is not None]
+        return min(times) if times else None
+
+    @synchronized
     def is_assigned(self, partition):
         return partition in self.assignment
 

--- a/test/consumer/test_fetcher.py
+++ b/test/consumer/test_fetcher.py
@@ -268,6 +268,48 @@ def test__reset_offsets_async(fetcher, manager, mocker):
     assert fetcher._subscriptions.assignment[tp1].position.offset == 1002
 
 
+def test__reset_offsets_async_retries_after_retriable_failure(
+        fetcher, manager, mocker):
+    """A retriable per-partition error (NotLeader, etc.) sets the partition
+    into retry_backoff_ms backoff. _reset_offsets_async must sleep for that
+    backoff and retry, rather than exit and rely on an outer caller to
+    redrive.
+    """
+    tp = TopicPartition("topic", 0)
+    fetcher._subscriptions.subscribe(topics=["topic"])
+    fetcher._subscriptions.assign_from_subscribed([tp])
+    fetcher._subscriptions.request_offset_reset(tp)
+    mocker.patch.object(fetcher._client.cluster, "leader_for_partition",
+                        return_value=0)
+    mocker.patch.object(fetcher._client, 'ready', return_value=True)
+
+    # Use a small backoff to keep the test fast.
+    fetcher.config['retry_backoff_ms'] = 50
+
+    call_count = [0]
+    async def fake_send(node_id, timestamps_and_epochs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # Simulate NotLeader: empty offsets, partition in retry set.
+            return ({}, {tp})
+        return ({tp: OffsetAndTimestamp(42, None, -1)}, set())
+    mocker.patch.object(fetcher, '_send_list_offsets_request',
+                        side_effect=fake_send)
+
+    start = time.monotonic()
+    manager.run(fetcher._reset_offsets_async, 1000)
+    elapsed = time.monotonic() - start
+
+    assert call_count[0] == 2, (
+        'expected two ListOffsets attempts after retriable error, got %d'
+        % call_count[0])
+    assert not fetcher._subscriptions.assignment[tp].awaiting_reset
+    assert fetcher._subscriptions.assignment[tp].position.offset == 42
+    assert elapsed >= 0.05, (
+        '_reset_offsets_async did not sleep for retry_backoff_ms; %.3fs'
+        % elapsed)
+
+
 def test__send_list_offsets_requests(fetcher, manager, net, mocker):
     tp = TopicPartition("topic_send_list_offsets", 1)
 


### PR DESCRIPTION
- test__reset_offsets_async_retries_after_retriable_failure
- next_offset_reset_retry_time
- Consumer: Improve retriable offset fetch error handling
