### PR TITLE
Consumer: Detect and handle Log Truncation (KIP-320)

### DIFF
--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -299,6 +299,11 @@ class ClusterMetadata:
         return self._partitions[partition.topic][partition.partition].leader_id
 
     def leader_epoch_for_partition(self, partition):
+        """Return leader_epoch for partition, or None if topic/partition is unknown."""
+        if partition.topic not in self._partitions:
+            return None
+        elif partition.partition not in self._partitions[partition.topic]:
+            return None
         return self._partitions[partition.topic][partition.partition].leader_epoch
 
     def partitions_for_broker(self, broker_id):

--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -10,7 +10,8 @@ from kafka.future import Future
 from kafka.metrics.stats import Avg, Count, Max, Rate
 from kafka.protocol.consumer import FetchRequest
 from kafka.protocol.consumer import (
-    ListOffsetsRequest, OffsetSpec, UNKNOWN_OFFSET, IsolationLevel
+    ListOffsetsRequest, OffsetForLeaderEpochRequest,
+    OffsetSpec, UNKNOWN_OFFSET, IsolationLevel,
 )
 from kafka.record import MemoryRecords
 from kafka.serializer import Deserializer
@@ -39,6 +40,8 @@ _FetchPartition = _FetchTopic.FetchPartition
 _ForgottenTopic = FetchRequest.ForgottenTopic
 _ListOffsetsTopic = ListOffsetsRequest.ListOffsetsTopic
 _ListOffsetsPartition = _ListOffsetsTopic.ListOffsetsPartition
+_OffsetForLeaderTopic = OffsetForLeaderEpochRequest.OffsetForLeaderTopic
+_OffsetForLeaderPartition = _OffsetForLeaderTopic.OffsetForLeaderPartition
 
 
 class RecordTooLargeError(Errors.KafkaError):
@@ -136,6 +139,11 @@ class Fetcher:
         # consumer.position blocking-await) share one fan-out instead of
         # racing duplicate ListOffsets requests.
         self._reset_task = None
+        # KIP-320 offset validation: same caching pattern, separate from
+        # reset (a partition can be awaiting-reset OR awaiting-validation,
+        # never both - awaiting-validation requires a valid position).
+        self._validation_task = None
+        self._cached_log_truncation = None
 
     @property
     def _enable_incremental_fetch_sessions(self):
@@ -808,6 +816,283 @@ class Fetcher:
             raise Errors.TopicAuthorizationFailedError(unauthorized_topics)
         return fetched_offsets, partitions_to_retry
 
+    # ------------------------------------------------------------------
+    # KIP-320: offset validation via OffsetForLeaderEpoch
+    # ------------------------------------------------------------------
+
+    def maybe_validate_positions(self):
+        """Walk assigned partitions; mark any whose cluster leader epoch has
+        advanced beyond the position's epoch as awaiting validation.
+
+        Cheap fire-and-forget marker; the actual RPC fan-out runs in
+        ``validate_offsets_if_needed`` -> ``_validate_offsets_async``.
+        Idempotent: partitions already awaiting validation, awaiting
+        reset, or with no recorded epoch are skipped inside
+        ``maybe_validate_position``.
+        """
+        for tp in self._subscriptions.assigned_partitions():
+            current_epoch = self._manager.cluster.leader_epoch_for_partition(tp)
+            self._subscriptions.maybe_validate_position_for_current_leader(tp, current_epoch)
+
+    def validate_offsets_if_needed(self, timeout_ms=None):
+        """Schedule any pending position validations and return the in-flight Task.
+
+        Mirrors :meth:`reset_offsets_if_needed`: returns a cached Future
+        shared across callers so concurrent ``consumer.poll`` and
+        ``consumer.position`` callers don't race the same partition into
+        duplicate OffsetForLeaderEpoch requests.
+
+        Raises:
+            LogTruncationError: if a previous validation detected truncation
+                on one or more partitions. The exception is cleared after
+                being raised so subsequent calls will re-attempt validation.
+        """
+        exc, self._cached_log_truncation = self._cached_log_truncation, None
+        if exc:
+            raise exc
+
+        if self._validation_task is not None and not self._validation_task.is_done:
+            return self._validation_task
+
+        if not self._subscriptions.partitions_needing_validation():
+            return None
+
+        self._validation_task = self._manager.call_soon(
+            self._validate_offsets_async, timeout_ms)
+        return self._validation_task
+
+    async def _validate_offsets_async(self, timeout_ms=None):
+        """Drive offset validations to completion or until the timer expires.
+
+        Same overall shape as ``_reset_offsets_async``: per-node fan-out.
+        After a retriable failure (FencedLeaderEpoch, etc.) a partition's
+        next_allowed_retry_time is set ``retry_backoff_ms`` in the future;
+        the loop sleeps until that time and retries rather than relying on
+        an external caller to redrive. Stops on first ``LogTruncationError``
+        accumulation; the next caller surfaces it.
+        """
+        if timeout_ms is None:
+            timeout_ms = self.config['request_timeout_ms']
+        timer = Timer(timeout_ms)
+        while not timer.expired:
+            if self._cached_log_truncation is not None:
+                return
+            partitions = self._subscriptions.partitions_needing_validation()
+            if not partitions:
+                next_retry = self._subscriptions.next_offset_validation_retry_time()
+                if next_retry is None:
+                    return
+                delay = max(0.0, next_retry - time.monotonic())
+                if timer.timeout_ms is not None:
+                    delay = min(delay, timer.timeout_ms / 1000)
+                if delay > 0:
+                    await self._manager._net.sleep(delay)
+                continue
+
+            positions = {}
+            for tp in partitions:
+                state = self._subscriptions.assignment[tp]
+                if state.position is not None and state.position.leader_epoch >= 0:
+                    positions[tp] = state.position
+            if not positions:
+                return
+
+            requests_by_node = self._group_offset_for_leader_epoch_requests(positions)
+            if not requests_by_node:
+                metadata_update = self._manager.cluster.request_update()
+                wait_ms = self.config['request_timeout_ms']
+                if timer.timeout_ms is not None:
+                    wait_ms = min(wait_ms, timer.timeout_ms)
+                try:
+                    await self._manager.wait_for(metadata_update, wait_ms)
+                except Errors.KafkaTimeoutError:
+                    pass
+                continue
+
+            log.debug('Validating offsets for %s', set(positions.keys()))
+            node_tasks = []
+            for node_id, payload in requests_by_node.items():
+                node_partitions = set(payload.keys())
+                expire_at = time.monotonic() + self.config['request_timeout_ms'] / 1000
+                self._subscriptions.set_validation_pending(node_partitions, expire_at)
+                node_tasks.append(self._manager.call_soon(
+                    self._validate_offsets_for_node, node_id, payload))
+            for task in node_tasks:
+                await task
+
+    async def _validate_offsets_for_node(self, node_id, partitions_to_positions):
+        try:
+            truncations = await self._send_offset_for_leader_epoch_request(
+                node_id, partitions_to_positions)
+        except Exception as error:
+            self._subscriptions.validation_failed(
+                set(partitions_to_positions),
+                time.monotonic() + self.config['retry_backoff_ms'] / 1000)
+            self._manager.cluster.request_update()
+            if not getattr(error, 'retriable', False):
+                log.error("Non-retriable error from OffsetForLeaderEpoch on node %s: %s",
+                          node_id, error)
+            return
+
+        if truncations:
+            if self._cached_log_truncation is None:
+                self._cached_log_truncation = Errors.LogTruncationError(truncations)
+            else:
+                self._cached_log_truncation.divergent_offsets.update(truncations)
+
+    def _group_offset_for_leader_epoch_requests(self, positions):
+        """Group {TopicPartition: OffsetAndMetadata} by leader node.
+
+        Partitions whose leader is unknown trigger a metadata refresh and
+        are dropped from this round. Partitions whose position lacks an
+        epoch are also dropped - they can't be validated.
+        """
+        by_node = collections.defaultdict(dict)
+        for tp, position in positions.items():
+            if position.leader_epoch < 0:
+                continue
+            node_id = self._manager.cluster.leader_for_partition(tp)
+            if node_id is None:
+                self._manager.cluster.add_topic(tp.topic)
+                self._manager.cluster.request_update()
+            elif node_id == -1:
+                self._manager.cluster.request_update()
+            else:
+                by_node[node_id][tp] = position
+        return dict(by_node)
+
+    async def _send_offset_for_leader_epoch_request(self, node_id, partitions_to_positions):
+        """Send one OffsetForLeaderEpoch request and return any truncations.
+
+        Returns:
+            dict[TopicPartition, OffsetAndMetadata]: partitions whose log
+            was truncated past their position. Successful validations
+            update :class:`SubscriptionState` directly via
+            ``complete_validation``; retriable per-partition errors leave
+            ``next_allowed_retry_time`` set so the outer loop will retry.
+
+        Raises:
+            TopicAuthorizationFailedError: if any topic returned an auth error.
+        """
+        by_topic = collections.defaultdict(list)
+        for tp, position in partitions_to_positions.items():
+            current_leader_epoch = self._manager.cluster.leader_epoch_for_partition(tp)
+            if current_leader_epoch is None or current_leader_epoch < 0:
+                current_leader_epoch = -1
+            by_topic[tp.topic].append(_OffsetForLeaderPartition(
+                partition=tp.partition,
+                current_leader_epoch=current_leader_epoch,
+                leader_epoch=position.leader_epoch,
+            ))
+
+        request = OffsetForLeaderEpochRequest(
+            replica_id=-1,
+            topics=list(by_topic.items()),
+        )
+
+        log.debug("Sending OffsetForLeaderEpochRequest %s to broker %s", request, node_id)
+        response = await self._manager.send(request, node_id=node_id)
+        return self._handle_offset_for_leader_epoch_response(response, partitions_to_positions)
+
+    def _handle_offset_for_leader_epoch_response(self, response, requested_positions):
+        """Parse an OffsetForLeaderEpoch response.
+
+        Side effects: calls ``complete_validation`` / ``validation_failed``
+        / ``request_position_validation`` on the subscription state as
+        appropriate for each partition's response code.
+
+        Returns:
+            dict[TopicPartition, OffsetAndMetadata]: subset of requested
+            partitions where end_offset < requested position (truncation).
+        """
+        truncations = {}
+        unauthorized_topics = set()
+        retry_at = time.monotonic() + self.config['retry_backoff_ms'] / 1000
+        retry = set()
+
+        for topic_data in response.topics:
+            for partition_info in topic_data.partitions:
+                tp = TopicPartition(topic_data.topic, partition_info.partition)
+                requested = requested_positions.get(tp)
+                if requested is None:
+                    continue
+                error_type = Errors.for_code(partition_info.error_code)
+
+                if error_type is Errors.NoError:
+                    end_offset = partition_info.end_offset
+                    end_epoch = partition_info.leader_epoch
+                    if end_epoch is None:
+                        end_epoch = -1
+                    current = self._subscriptions.assignment[tp].position if \
+                        self._subscriptions.is_assigned(tp) else None
+                    # Position may have changed (seek, rebalance) since request
+                    # was sent; skip stale completions.
+                    if current is None or current != requested:
+                        log.debug("Skipping validation completion for %s: position "
+                                  "changed since request was sent", tp)
+                        continue
+                    if end_offset < 0 or end_epoch < 0:
+                        # Broker has no record of our requested epoch
+                        # (UNDEFINED_EPOCH_OFFSET). Drop the epoch and accept
+                        # the offset as validated; the next fetch will tag
+                        # it with the current epoch.
+                        validated = OffsetAndMetadata(
+                            current.offset, current.metadata, -1)
+                        self._subscriptions.complete_validation(tp, validated)
+                    elif end_offset < current.offset:
+                        # Java behavior: apply auto_offset_reset before
+                        # raising so steady-state consumers recover without
+                        # the user catching LogTruncationError. With policy
+                        # NONE the caller is on the hook.
+                        if self._subscriptions.has_default_offset_reset_policy():
+                            log.warning("Log truncation detected on %s: end offset %d "
+                                        "(epoch %d) < current position %d (epoch %d). "
+                                        "Resetting offset per auto_offset_reset policy.",
+                                        tp, end_offset, end_epoch,
+                                        current.offset, current.leader_epoch)
+                            self._subscriptions.request_offset_reset(tp)
+                        else:
+                            log.warning("Log truncation detected on %s: end offset %d "
+                                        "(epoch %d) < current position %d (epoch %d)",
+                                        tp, end_offset, end_epoch,
+                                        current.offset, current.leader_epoch)
+                            truncations[tp] = OffsetAndMetadata(
+                                end_offset, current.metadata, end_epoch)
+                            # Clear awaiting_validation so caller can act
+                            # (seek, raise, etc.); position remains at the
+                            # diverging offset until the caller acts.
+                            self._subscriptions.complete_validation(tp)
+                    else:
+                        validated = OffsetAndMetadata(
+                            current.offset, current.metadata, end_epoch)
+                        self._subscriptions.complete_validation(tp, validated)
+
+                elif error_type in (Errors.FencedLeaderEpochError,
+                                    Errors.UnknownLeaderEpochError,
+                                    Errors.NotLeaderForPartitionError,
+                                    Errors.ReplicaNotAvailableError,
+                                    Errors.KafkaStorageError,
+                                    Errors.LeaderNotAvailableError):
+                    log.debug("OffsetForLeaderEpoch for %s returned retriable %s; "
+                              "will retry after backoff", tp, error_type.__name__)
+                    self._manager.cluster.request_update()
+                    retry.add(tp)
+                elif error_type is Errors.UnknownTopicOrPartitionError:
+                    log.warning("OffsetForLeaderEpoch for %s: unknown topic/partition", tp)
+                    retry.add(tp)
+                elif error_type is Errors.TopicAuthorizationFailedError:
+                    unauthorized_topics.add(tp.topic)
+                else:
+                    log.warning("OffsetForLeaderEpoch for %s failed with %s",
+                                tp, error_type.__name__)
+                    retry.add(tp)
+
+        if retry:
+            self._subscriptions.validation_failed(retry, retry_at)
+        if unauthorized_topics:
+            raise Errors.TopicAuthorizationFailedError(unauthorized_topics)
+        return truncations
+
     def _fetchable_partitions(self):
         fetchable = self._subscriptions.fetchable_partitions()
         # do not fetch a partition if we have a pending fetch response to process
@@ -1022,6 +1307,15 @@ class Fetcher:
                                 Errors.UnknownTopicOrPartitionError,
                                 Errors.KafkaStorageError):
                 log.debug("Error fetching partition %s: %s", tp, error_type.__name__)
+                self._manager.cluster.request_update()
+            elif error_type in (Errors.FencedLeaderEpochError,
+                                Errors.UnknownLeaderEpochError):
+                # KIP-320: the broker has a different view of the leader epoch
+                # than we do; ask for metadata refresh and queue position
+                # validation so we detect any truncation before continuing.
+                log.debug("Fetch for %s returned %s; marking position for validation",
+                          tp, error_type.__name__)
+                self._subscriptions.request_position_validation(tp)
                 self._manager.cluster.request_update()
             elif error_type is Errors.OffsetOutOfRangeError:
                 position = self._subscriptions.assignment[tp].position

--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -522,10 +522,10 @@ class Fetcher:
                 if highwater is not None and self._sensors:
                     self._sensors.records_fetch_lag.record(highwater - part.next_fetch_offset)
                 if update_offsets or not part_records:
-                    # TODO: save leader_epoch
                     log.debug("Updating fetch position for assigned partition %s to %s (leader epoch %s)",
                               tp, part.next_fetch_offset, part.leader_epoch)
-                    self._subscriptions.assignment[tp].position = OffsetAndMetadata(part.next_fetch_offset, '', -1)
+                    self._subscriptions.assignment[tp].position = OffsetAndMetadata(
+                        part.next_fetch_offset, '', part.leader_epoch)
                 return len(part_records)
 
             else:

--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -1031,36 +1031,42 @@ class Fetcher:
                         log.debug("Skipping validation completion for %s: position "
                                   "changed since request was sent", tp)
                         continue
+
+                    has_reset_policy = self._subscriptions.has_default_offset_reset_policy()
+
                     if end_offset < 0 or end_epoch < 0:
-                        # Broker has no record of our requested epoch
-                        # (UNDEFINED_EPOCH_OFFSET). Drop the epoch and accept
-                        # the offset as validated; the next fetch will tag
-                        # it with the current epoch.
-                        validated = OffsetAndMetadata(
-                            current.offset, current.metadata, -1)
-                        self._subscriptions.complete_validation(tp, validated)
-                    elif end_offset < current.offset:
-                        # Java behavior: apply auto_offset_reset before
-                        # raising so steady-state consumers recover without
-                        # the user catching LogTruncationError. With policy
-                        # NONE the caller is on the hook.
-                        if self._subscriptions.has_default_offset_reset_policy():
-                            log.warning("Log truncation detected on %s: end offset %d "
-                                        "(epoch %d) < current position %d (epoch %d). "
-                                        "Resetting offset per auto_offset_reset policy.",
-                                        tp, end_offset, end_epoch,
-                                        current.offset, current.leader_epoch)
+                        # UNDEFINED_EPOCH / UNDEFINED_EPOCH_OFFSET: broker has
+                        # no record of our requested epoch on this partition.
+                        # Mirror Java SubscriptionState.maybeCompleteValidation:
+                        # this is truncation with no known diverging offset.
+                        if has_reset_policy:
+                            log.info("Truncation detected for %s at position %s "
+                                     "(broker returned UNDEFINED end_offset/leader_epoch); "
+                                     "resetting offset per auto_offset_reset policy",
+                                     tp, current.offset)
                             self._subscriptions.request_offset_reset(tp)
                         else:
-                            log.warning("Log truncation detected on %s: end offset %d "
-                                        "(epoch %d) < current position %d (epoch %d)",
-                                        tp, end_offset, end_epoch,
-                                        current.offset, current.leader_epoch)
-                            truncations[tp] = OffsetAndMetadata(
-                                end_offset, current.metadata, end_epoch)
-                            # Clear awaiting_validation so caller can act
-                            # (seek, raise, etc.); position remains at the
-                            # diverging offset until the caller acts.
+                            log.warning("Truncation detected for %s at position %s "
+                                        "(broker returned UNDEFINED end_offset/leader_epoch), "
+                                        "but no reset policy is set", tp, current.offset)
+                            truncations[tp] = None
+                            self._subscriptions.complete_validation(tp)
+                    elif end_offset < current.offset:
+                        # Broker confirms the diverging point. Seek there
+                        # directly instead of resetting via policy, so the
+                        # consumer only re-reads records past the divergence
+                        # (Java: state.seekValidated(newPosition)).
+                        divergent = OffsetAndMetadata(end_offset, '', end_epoch)
+                        if has_reset_policy:
+                            log.info("Truncation detected for %s at position %s; "
+                                     "seeking to first diverging offset %s",
+                                     tp, current.offset, divergent)
+                            self._subscriptions.seek(tp, divergent)
+                        else:
+                            log.warning("Truncation detected for %s at position %s "
+                                        "(first diverging offset is %s), but no reset "
+                                        "policy is set", tp, current.offset, divergent)
+                            truncations[tp] = divergent
                             self._subscriptions.complete_validation(tp)
                     else:
                         validated = OffsetAndMetadata(

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -1219,7 +1219,8 @@ class KafkaConsumer:
                     log.debug("Not returning fetched records for partition %s"
                               " since it is no longer fetchable", tp)
                     break
-                self._subscription.assignment[tp].position = OffsetAndMetadata(record.offset + 1, '', -1)
+                self._subscription.assignment[tp].position = OffsetAndMetadata(
+                    record.offset + 1, '', record.leader_epoch)
                 yield record
 
     def __iter__(self):  # pylint: disable=non-iterator-returned

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -770,6 +770,11 @@ class KafkaConsumer:
         # _reset_offsets_async self-drives metadata refresh + retry-backoff
         # within request_timeout_ms.
         self._fetcher.reset_offsets_if_needed()
+        # KIP-320: mark any positions whose cluster leader epoch has advanced
+        # beyond the position's epoch, then drive OffsetForLeaderEpoch
+        # validation in the background. Truncation surfaces on the next call.
+        self._fetcher.maybe_validate_positions()
+        self._fetcher.validate_offsets_if_needed()
 
         # Cap the fetch wait by the heartbeat deadline so we don't block past
         # when the coordinator wants to send the next heartbeat.
@@ -805,6 +810,18 @@ class KafkaConsumer:
         if reset_task is not None and not timer.expired:
             try:
                 self._net.run(self._manager.wait_for, reset_task, timer.timeout_ms)
+            except Errors.KafkaTimeoutError:
+                pass
+        # Phase 3 (KIP-320): mark any positions whose cluster leader epoch
+        # has advanced beyond the position's epoch and await the validation
+        # RPC. Surfaces LogTruncationError to the caller if truncation is
+        # detected (and auto_offset_reset is NONE).
+        self._fetcher.maybe_validate_positions()
+        validation_task = self._fetcher.validate_offsets_if_needed(
+            timeout_ms=timer.timeout_ms)
+        if validation_task is not None and not timer.expired:
+            try:
+                self._net.run(self._manager.wait_for, validation_task, timer.timeout_ms)
             except Errors.KafkaTimeoutError:
                 pass
         position = self._subscription.assignment[partition].position

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -407,6 +407,52 @@ class SubscriptionState:
         return min(times) if times else None
 
     @synchronized
+    def maybe_validate_position_for_current_leader(self, partition, current_leader_epoch):
+        if partition not in self.assignment:
+            return False
+        return self.assignment[partition].maybe_validate_position(current_leader_epoch)
+
+    @synchronized
+    def request_position_validation(self, partition):
+        if partition not in self.assignment:
+            return False
+        return self.assignment[partition].request_position_validation()
+
+    @synchronized
+    def partitions_needing_validation(self):
+        partitions = set()
+        for tp, state in self.assignment.items():
+            if state.awaiting_validation and state.is_validation_allowed():
+                partitions.add(tp)
+        return partitions
+
+    @synchronized
+    def next_offset_validation_retry_time(self):
+        times = [state.next_allowed_retry_time
+                 for state in self.assignment.values()
+                 if state.awaiting_validation and state.next_allowed_retry_time is not None]
+        return min(times) if times else None
+
+    @synchronized
+    def set_validation_pending(self, partitions, next_allowed_retry_time):
+        for partition in partitions:
+            self.assignment[partition].set_validation_pending(next_allowed_retry_time)
+
+    @synchronized
+    def validation_failed(self, partitions, next_allowed_retry_time):
+        for partition in partitions:
+            self.assignment[partition].validation_failed(next_allowed_retry_time)
+
+    @synchronized
+    def complete_validation(self, partition, validated_position=None):
+        if partition in self.assignment:
+            self.assignment[partition].complete_validation(validated_position)
+
+    @synchronized
+    def is_offset_validation_needed(self, partition):
+        return partition in self.assignment and self.assignment[partition].awaiting_validation
+
+    @synchronized
     def is_assigned(self, partition):
         return partition in self.assignment
 
@@ -453,6 +499,10 @@ class TopicPartitionState:
         self.highwater = None
         self.drop_pending_record_batch = False
         self.next_allowed_retry_time = None
+        # KIP-320: offset validation state. _awaiting_validation gates fetches
+        # until OffsetForLeaderEpoch confirms the position is consistent with
+        # the current leader's log; mutually exclusive with awaiting_reset.
+        self._awaiting_validation = False
 
     def _set_position(self, offset):
         assert self.has_valid_position, 'Valid position required'
@@ -469,6 +519,7 @@ class TopicPartitionState:
         self.reset_strategy = strategy
         self._position = None
         self.next_allowed_retry_time = None
+        self._awaiting_validation = False
 
     def is_reset_allowed(self):
         return self.next_allowed_retry_time is None or self.next_allowed_retry_time < time.monotonic()
@@ -495,6 +546,7 @@ class TopicPartitionState:
         self.reset_strategy = None
         self.drop_pending_record_batch = True
         self.next_allowed_retry_time = None
+        self._awaiting_validation = False
 
     def pause(self):
         self.paused = True
@@ -503,7 +555,55 @@ class TopicPartitionState:
         self.paused = False
 
     def is_fetchable(self):
-        return not self.paused and self.has_valid_position
+        return not self.paused and self.has_valid_position and not self._awaiting_validation
+
+    @property
+    def awaiting_validation(self):
+        return self._awaiting_validation
+
+    def maybe_validate_position(self, current_leader_epoch):
+        """Mark for validation if current leader has advanced beyond our position's epoch.
+
+        Returns True if the partition is now awaiting validation.
+        """
+        if self.reset_strategy is not None:
+            return False
+        if self._position is None:
+            return False
+        if current_leader_epoch is None or current_leader_epoch < 0:
+            return False
+        # Positions without a known epoch (legacy data, post-seek to bare offset)
+        # can't be validated; treat as already-fetchable.
+        if self._position.leader_epoch < 0:
+            return False
+        if self._position.leader_epoch >= current_leader_epoch:
+            return False
+        self._awaiting_validation = True
+        self.next_allowed_retry_time = None
+        return True
+
+    def request_position_validation(self):
+        """Force validation (e.g., after FENCED/UNKNOWN epoch errors from the broker)."""
+        if self._position is None or self._position.leader_epoch < 0:
+            return False
+        self._awaiting_validation = True
+        self.next_allowed_retry_time = None
+        return True
+
+    def is_validation_allowed(self):
+        return self.next_allowed_retry_time is None or self.next_allowed_retry_time < time.monotonic()
+
+    def set_validation_pending(self, next_allowed_retry_time):
+        self.next_allowed_retry_time = next_allowed_retry_time
+
+    def validation_failed(self, next_allowed_retry_time):
+        self.next_allowed_retry_time = next_allowed_retry_time
+
+    def complete_validation(self, validated_position=None):
+        self._awaiting_validation = False
+        self.next_allowed_retry_time = None
+        if validated_position is not None:
+            self._position = validated_position
 
 
 class ConsumerRebalanceListener(metaclass=abc.ABCMeta):

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -566,7 +566,7 @@ class TopicPartitionState:
 
         Returns True if the partition is now awaiting validation.
         """
-        if self.reset_strategy is not None:
+        if self.awaiting_reset:
             return False
         if self._position is None:
             return False

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -913,7 +913,7 @@ class ConsumerCoordinator(BaseCoordinator):
                     leader_epoch, metadata, error_code = partition_data[2:]
                 else:
                     metadata, error_code = partition_data[2:]
-                    leader_epoch = -1 # noqa: F841
+                    leader_epoch = -1
                 tp = TopicPartition(topic, partition)
                 error_type = Errors.for_code(error_code)
                 if error_type is not Errors.NoError:
@@ -940,8 +940,7 @@ class ConsumerCoordinator(BaseCoordinator):
                 elif offset >= 0:
                     # record the position with the offset
                     # (-1 indicates no committed offset to fetch)
-                    # TODO: save leader_epoch
-                    offsets[tp] = OffsetAndMetadata(offset, metadata, -1)
+                    offsets[tp] = OffsetAndMetadata(offset, metadata, leader_epoch)
                 else:
                     log.debug("Group %s has no committed offset for partition"
                               " %s", self.group_id, tp)

--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -66,6 +66,30 @@ class NoOffsetForPartitionError(KafkaError):
     pass
 
 
+class LogTruncationError(KafkaError):
+    """The broker's log was truncated past the consumer's current position.
+
+    Raised by the offset-validation flow (KIP-320) when an
+    ``OffsetForLeaderEpoch`` response reports that the last offset written
+    under the consumer's leader_epoch is below the consumer's current
+    position. The consumer had advanced past records that no longer exist
+    under that epoch on the current leader - typically the result of an
+    unclean leader election that promoted a follower with a shorter log,
+    silently rolling back records the consumer thought it had consumed.
+
+    Distinct from :class:`OffsetOutOfRangeError`, which signals that
+    retention/compaction deleted records *below* the consumer's position.
+
+    Carries the topic-partition -> (offset, leader_epoch) mapping of the
+    diverging endpoints in ``divergent_offsets``: each value is the broker's
+    reported end-of-epoch offset (the safe point to seek back to).
+    """
+
+    def __init__(self, divergent_offsets, *args):
+        self.divergent_offsets = divergent_offsets
+        super().__init__(*args or ('Detected truncated partitions: %s' % (divergent_offsets,),))
+
+
 class NodeNotReadyError(KafkaError):
     retriable = True
 

--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -70,19 +70,25 @@ class LogTruncationError(KafkaError):
     """The broker's log was truncated past the consumer's current position.
 
     Raised by the offset-validation flow (KIP-320) when an
-    ``OffsetForLeaderEpoch`` response reports that the last offset written
-    under the consumer's leader_epoch is below the consumer's current
-    position. The consumer had advanced past records that no longer exist
-    under that epoch on the current leader - typically the result of an
-    unclean leader election that promoted a follower with a shorter log,
-    silently rolling back records the consumer thought it had consumed.
+    ``OffsetForLeaderEpoch`` response indicates the consumer has read past
+    records that no longer exist under its leader_epoch on the current
+    leader - typically the result of an unclean leader election that
+    promoted a follower with a shorter log, silently rolling back records
+    the consumer thought it had consumed.
 
     Distinct from :class:`OffsetOutOfRangeError`, which signals that
     retention/compaction deleted records *below* the consumer's position.
 
-    Carries the topic-partition -> (offset, leader_epoch) mapping of the
-    diverging endpoints in ``divergent_offsets``: each value is the broker's
-    reported end-of-epoch offset (the safe point to seek back to).
+    ``divergent_offsets`` is a ``dict[TopicPartition, Optional[OffsetAndMetadata]]``:
+
+    - When the broker reports a concrete diverging endpoint (its end_offset
+      for our epoch is below our position), the value is an
+      ``OffsetAndMetadata(end_offset, ..., end_epoch)`` - the safe point to
+      seek back to.
+    - When the broker has no record of our epoch at all (response carried
+      ``UNDEFINED_EPOCH`` / ``UNDEFINED_EPOCH_OFFSET``), the value is
+      ``None`` - we know truncation occurred but there is no known
+      recovery point on this broker.
     """
 
     def __init__(self, divergent_offsets, *args):

--- a/test/consumer/test_fetcher.py
+++ b/test/consumer/test_fetcher.py
@@ -17,7 +17,8 @@ from kafka.future import Future
 from kafka.protocol.broker_version_data import BrokerVersionData
 from kafka.protocol.consumer import (
     FetchRequest, FetchResponse,
-    ListOffsetsResponse, OffsetResetStrategy,
+    ListOffsetsResponse, OffsetForLeaderEpochResponse,
+    OffsetResetStrategy,
 )
 from kafka.errors import (
     StaleMetadata, NotLeaderForPartitionError,
@@ -1049,3 +1050,232 @@ class TestFetchOffsetsByTimes:
 
         result = fetcher.offsets_by_times(timestamps, timeout_ms=None)
         assert result == {tp: expected_offset}
+
+
+# ----------------------------------------------------------------------
+# KIP-320: offset validation via OffsetForLeaderEpoch
+# ----------------------------------------------------------------------
+
+_OffsetForLeaderTopicResult = OffsetForLeaderEpochResponse.OffsetForLeaderTopicResult
+_EpochEndOffset = _OffsetForLeaderTopicResult.EpochEndOffset
+
+
+def _build_offset_for_leader_epoch_response(entries):
+    """entries: list of (topic, partition, error_code, leader_epoch, end_offset)."""
+    by_topic = {}
+    for topic, partition, error_code, leader_epoch, end_offset in entries:
+        by_topic.setdefault(topic, []).append(_EpochEndOffset(
+            error_code=error_code, partition=partition,
+            leader_epoch=leader_epoch, end_offset=end_offset))
+    topics = [_OffsetForLeaderTopicResult(topic=t, partitions=ps)
+              for t, ps in by_topic.items()]
+    return OffsetForLeaderEpochResponse(throttle_time_ms=0, topics=topics)
+
+
+def test_maybe_validate_positions_marks_stale_epoch(fetcher, mocker):
+    """When cluster's leader_epoch advances beyond a position's epoch,
+    maybe_validate_positions should mark the partition for validation."""
+    tp = TopicPartition('foobar', 0)
+    fetcher._subscriptions.assignment[tp].seek(OffsetAndMetadata(100, '', 3))
+    mocker.patch.object(fetcher._manager.cluster, 'leader_epoch_for_partition',
+                        return_value=5)
+
+    fetcher.maybe_validate_positions()
+
+    assert fetcher._subscriptions.assignment[tp].awaiting_validation
+    assert not fetcher._subscriptions.is_fetchable(tp)
+
+
+def test_maybe_validate_positions_skips_position_without_epoch(fetcher, mocker):
+    """Positions seeded without a leader_epoch (-1, legacy/post-seek) can't
+    be validated and should be left alone."""
+    tp = TopicPartition('foobar', 0)
+    fetcher._subscriptions.assignment[tp].seek(OffsetAndMetadata(100, '', -1))
+    mocker.patch.object(fetcher._manager.cluster, 'leader_epoch_for_partition',
+                        return_value=5)
+
+    fetcher.maybe_validate_positions()
+
+    assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+    assert fetcher._subscriptions.is_fetchable(tp)
+
+
+def test_maybe_validate_positions_no_op_when_epoch_current(fetcher, mocker):
+    """Position's epoch matches cluster's epoch -> no validation needed."""
+    tp = TopicPartition('foobar', 0)
+    fetcher._subscriptions.assignment[tp].seek(OffsetAndMetadata(100, '', 5))
+    mocker.patch.object(fetcher._manager.cluster, 'leader_epoch_for_partition',
+                        return_value=5)
+
+    fetcher.maybe_validate_positions()
+
+    assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+
+
+def test_validate_offsets_async_clears_validation_on_matching_epoch(
+        fetcher, manager, mocker):
+    """OffsetForLeaderEpoch response with matching epoch and end_offset >=
+    position.offset clears awaiting_validation."""
+    tp = TopicPartition('foobar', 0)
+    fetcher._subscriptions.assignment[tp].seek(OffsetAndMetadata(50, '', 3))
+    fetcher._subscriptions.assignment[tp].maybe_validate_position(5)
+    assert fetcher._subscriptions.assignment[tp].awaiting_validation
+
+    mocker.patch.object(fetcher._manager.cluster, 'leader_for_partition',
+                        return_value=0)
+    mocker.patch.object(fetcher._manager.cluster, 'leader_epoch_for_partition',
+                        return_value=5)
+    mocker.patch.object(fetcher._client, 'ready', return_value=True)
+
+    async def fake_send(node_id, partitions_to_positions):
+        response = _build_offset_for_leader_epoch_response(
+            [('foobar', 0, 0, 5, 100)])
+        return fetcher._handle_offset_for_leader_epoch_response(
+            response, partitions_to_positions)
+    mocker.patch.object(fetcher, '_send_offset_for_leader_epoch_request',
+                        side_effect=fake_send)
+
+    manager.run(fetcher._validate_offsets_async, 1000)
+
+    assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+    assert fetcher._subscriptions.assignment[tp].position.leader_epoch == 5
+    assert fetcher._subscriptions.assignment[tp].position.offset == 50
+
+
+def test_validate_offsets_async_truncation_auto_resets_with_policy(
+        fetcher, manager, mocker):
+    """Java behavior: with a default reset policy, truncation triggers an
+    automatic offset reset rather than surfacing LogTruncationError."""
+    tp = TopicPartition('foobar', 0)
+    fetcher._subscriptions.assignment[tp].seek(OffsetAndMetadata(100, '', 3))
+    fetcher._subscriptions.assignment[tp].maybe_validate_position(5)
+
+    mocker.patch.object(fetcher._manager.cluster, 'leader_for_partition',
+                        return_value=0)
+    mocker.patch.object(fetcher._manager.cluster, 'leader_epoch_for_partition',
+                        return_value=5)
+    mocker.patch.object(fetcher._client, 'ready', return_value=True)
+
+    async def fake_send(node_id, partitions_to_positions):
+        response = _build_offset_for_leader_epoch_response(
+            [('foobar', 0, 0, 3, 80)])
+        return fetcher._handle_offset_for_leader_epoch_response(
+            response, partitions_to_positions)
+    mocker.patch.object(fetcher, '_send_offset_for_leader_epoch_request',
+                        side_effect=fake_send)
+
+    manager.run(fetcher._validate_offsets_async, 1000)
+
+    # No truncation surfaced: auto-reset was applied instead
+    assert fetcher._cached_log_truncation is None
+    assert fetcher._subscriptions.assignment[tp].awaiting_reset
+    # validate_offsets_if_needed should return None (no pending exception)
+    assert fetcher.validate_offsets_if_needed() is None
+
+
+def test_validate_offsets_async_detects_truncation_when_no_reset_policy(
+        client, metrics, mocker, topic):
+    """With offset_reset_strategy=NONE the user must catch
+    LogTruncationError - we don't silently move the position."""
+    # Build fetcher with explicit NONE policy
+    subs = SubscriptionState(offset_reset_strategy='none')
+    subs.subscribe(topics=[topic])
+    tp = TopicPartition(topic, 0)
+    subs.assign_from_subscribed([tp])
+    subs.seek(tp, OffsetAndMetadata(100, '', 3))
+    fetcher = Fetcher(client, subs, metrics=metrics)
+    fetcher._subscriptions.assignment[tp].maybe_validate_position(5)
+
+    mocker.patch.object(fetcher._manager.cluster, 'leader_for_partition',
+                        return_value=0)
+    mocker.patch.object(fetcher._manager.cluster, 'leader_epoch_for_partition',
+                        return_value=5)
+    mocker.patch.object(fetcher._client, 'ready', return_value=True)
+
+    async def fake_send(node_id, partitions_to_positions):
+        response = _build_offset_for_leader_epoch_response(
+            [(topic, 0, 0, 3, 80)])
+        return fetcher._handle_offset_for_leader_epoch_response(
+            response, partitions_to_positions)
+    mocker.patch.object(fetcher, '_send_offset_for_leader_epoch_request',
+                        side_effect=fake_send)
+
+    fetcher._manager._net.run(fetcher._validate_offsets_async, 1000)
+
+    assert fetcher._cached_log_truncation is not None
+    with pytest.raises(Errors.LogTruncationError) as exc_info:
+        fetcher.validate_offsets_if_needed()
+    assert tp in exc_info.value.divergent_offsets
+    divergent = exc_info.value.divergent_offsets[tp]
+    assert divergent.offset == 80
+    assert divergent.leader_epoch == 3
+    # awaiting_validation cleared so caller can act
+    assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+    # And no auto-reset
+    assert not fetcher._subscriptions.assignment[tp].awaiting_reset
+
+
+def test_validate_offsets_async_retries_on_fenced_epoch(
+        fetcher, manager, mocker):
+    """FENCED_LEADER_EPOCH on the validation RPC sleeps retry_backoff_ms
+    and retries within a single _validate_offsets_async invocation."""
+    tp = TopicPartition('foobar', 0)
+    fetcher._subscriptions.assignment[tp].seek(OffsetAndMetadata(50, '', 3))
+    fetcher._subscriptions.assignment[tp].maybe_validate_position(5)
+
+    mocker.patch.object(fetcher._manager.cluster, 'leader_for_partition',
+                        return_value=0)
+    mocker.patch.object(fetcher._manager.cluster, 'leader_epoch_for_partition',
+                        return_value=5)
+    mocker.patch.object(fetcher._client, 'ready', return_value=True)
+    fetcher.config['retry_backoff_ms'] = 50
+
+    call_count = [0]
+    async def fake_send(node_id, partitions_to_positions):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # First response: FENCED_LEADER_EPOCH (errno 74)
+            response = _build_offset_for_leader_epoch_response(
+                [('foobar', 0, 74, -1, -1)])
+        else:
+            response = _build_offset_for_leader_epoch_response(
+                [('foobar', 0, 0, 5, 100)])
+        return fetcher._handle_offset_for_leader_epoch_response(
+            response, partitions_to_positions)
+    mocker.patch.object(fetcher, '_send_offset_for_leader_epoch_request',
+                        side_effect=fake_send)
+
+    start = time.monotonic()
+    manager.run(fetcher._validate_offsets_async, 1000)
+    elapsed = time.monotonic() - start
+
+    assert call_count[0] == 2, (
+        'expected second OffsetForLeaderEpoch attempt after FENCED, got %d'
+        % call_count[0])
+    assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+    assert elapsed >= 0.05, (
+        '_validate_offsets_async did not sleep for retry_backoff_ms; %.3fs'
+        % elapsed)
+
+
+def test_fetch_response_fenced_epoch_marks_validation(fetcher, mocker):
+    """A FENCED_LEADER_EPOCH error in a Fetch response should mark the
+    partition for validation, not silently drop the records."""
+    tp = TopicPartition('foobar', 0)
+    fetcher._subscriptions.assignment[tp].seek(OffsetAndMetadata(50, '', 3))
+    mocker.patch.object(fetcher._manager.cluster, 'request_update')
+
+    # Build a CompletedFetch with FENCED_LEADER_EPOCH (errno 74)
+    completion = _build_completed_fetch(
+        tp, [], error=Errors.FencedLeaderEpochError, offset=50)
+    fetcher._parse_fetched_data(completion)
+
+    assert fetcher._subscriptions.assignment[tp].awaiting_validation
+    fetcher._manager.cluster.request_update.assert_called()
+
+
+def test_validate_offsets_if_needed_no_op_when_no_partitions(fetcher):
+    """No partitions awaiting validation -> validate_offsets_if_needed
+    returns None without scheduling a task."""
+    assert fetcher.validate_offsets_if_needed() is None
+    assert fetcher._validation_task is None

--- a/test/consumer/test_fetcher.py
+++ b/test/consumer/test_fetcher.py
@@ -1142,76 +1142,163 @@ def test_validate_offsets_async_clears_validation_on_matching_epoch(
     assert fetcher._subscriptions.assignment[tp].position.offset == 50
 
 
-def test_validate_offsets_async_truncation_auto_resets_with_policy(
-        fetcher, manager, mocker):
-    """Java behavior: with a default reset policy, truncation triggers an
-    automatic offset reset rather than surfacing LogTruncationError."""
-    tp = TopicPartition('foobar', 0)
-    fetcher._subscriptions.assignment[tp].seek(OffsetAndMetadata(100, '', 3))
-    fetcher._subscriptions.assignment[tp].maybe_validate_position(5)
-
-    mocker.patch.object(fetcher._manager.cluster, 'leader_for_partition',
-                        return_value=0)
-    mocker.patch.object(fetcher._manager.cluster, 'leader_epoch_for_partition',
-                        return_value=5)
-    mocker.patch.object(fetcher._client, 'ready', return_value=True)
-
+def _stub_validation_send(fetcher, mocker, response_entries):
+    """Stub _send_offset_for_leader_epoch_request to deliver a fixed
+    OffsetForLeaderEpochResponse and route it through the real handler so
+    SubscriptionState side-effects (seek / request_offset_reset /
+    complete_validation) actually fire."""
     async def fake_send(node_id, partitions_to_positions):
-        response = _build_offset_for_leader_epoch_response(
-            [('foobar', 0, 0, 3, 80)])
+        response = _build_offset_for_leader_epoch_response(response_entries)
         return fetcher._handle_offset_for_leader_epoch_response(
             response, partitions_to_positions)
     mocker.patch.object(fetcher, '_send_offset_for_leader_epoch_request',
                         side_effect=fake_send)
 
-    manager.run(fetcher._validate_offsets_async, 1000)
 
-    # No truncation surfaced: auto-reset was applied instead
-    assert fetcher._cached_log_truncation is None
-    assert fetcher._subscriptions.assignment[tp].awaiting_reset
-    # validate_offsets_if_needed should return None (no pending exception)
-    assert fetcher.validate_offsets_if_needed() is None
-
-
-def test_validate_offsets_async_detects_truncation_when_no_reset_policy(
-        client, metrics, mocker, topic):
-    """With offset_reset_strategy=NONE the user must catch
-    LogTruncationError - we don't silently move the position."""
-    # Build fetcher with explicit NONE policy
-    subs = SubscriptionState(offset_reset_strategy='none')
+def _make_validating_fetcher(client, metrics, topic, position, *,
+                              offset_reset_strategy='earliest',
+                              current_leader_epoch=5):
+    """Build a fetcher with `topic` subscribed, partition 0 assigned, the
+    given position, and `_awaiting_validation=True` against
+    `current_leader_epoch`."""
+    subs = SubscriptionState(offset_reset_strategy=offset_reset_strategy)
     subs.subscribe(topics=[topic])
     tp = TopicPartition(topic, 0)
     subs.assign_from_subscribed([tp])
-    subs.seek(tp, OffsetAndMetadata(100, '', 3))
+    subs.seek(tp, position)
     fetcher = Fetcher(client, subs, metrics=metrics)
-    fetcher._subscriptions.assignment[tp].maybe_validate_position(5)
+    subs.assignment[tp].maybe_validate_position(current_leader_epoch)
+    assert subs.assignment[tp].awaiting_validation
+    return fetcher, tp
 
+
+def _patch_leader(fetcher, mocker, node_id=0, leader_epoch=5):
     mocker.patch.object(fetcher._manager.cluster, 'leader_for_partition',
-                        return_value=0)
+                        return_value=node_id)
     mocker.patch.object(fetcher._manager.cluster, 'leader_epoch_for_partition',
-                        return_value=5)
+                        return_value=leader_epoch)
     mocker.patch.object(fetcher._client, 'ready', return_value=True)
 
-    async def fake_send(node_id, partitions_to_positions):
-        response = _build_offset_for_leader_epoch_response(
-            [(topic, 0, 0, 3, 80)])
-        return fetcher._handle_offset_for_leader_epoch_response(
-            response, partitions_to_positions)
-    mocker.patch.object(fetcher, '_send_offset_for_leader_epoch_request',
-                        side_effect=fake_send)
+
+# Truncation matrix (mirroring Java SubscriptionState.maybeCompleteValidation):
+#
+# | broker says        | reset policy   | expected outcome                  |
+# |--------------------|----------------|-----------------------------------|
+# | end < position     | earliest/latest| seek to (end_offset, end_epoch)   |
+# | end < position     | none           | LogTruncationError w/ divergent   |
+# | UNDEFINED          | earliest/latest| request_offset_reset              |
+# | UNDEFINED          | none           | LogTruncationError w/ None        |
+
+def test_validate_offsets_async_diverged_seeks_with_policy(
+        client, metrics, mocker, topic):
+    """Diverged endpoint (end_offset < current.offset, valid epoch) with a
+    reset policy: seek directly to (end_offset, end_epoch) - preserves
+    progress up to the divergence and tags the new position with the
+    broker-confirmed epoch."""
+    fetcher, tp = _make_validating_fetcher(
+        client, metrics, topic, OffsetAndMetadata(100, '', 3))
+    _patch_leader(fetcher, mocker)
+    _stub_validation_send(fetcher, mocker, [(topic, 0, 0, 3, 80)])
+
+    fetcher._manager._net.run(fetcher._validate_offsets_async, 1000)
+
+    assert fetcher._cached_log_truncation is None
+    assert not fetcher._subscriptions.assignment[tp].awaiting_reset
+    assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+    # Position was SEEKED to the diverging endpoint, not reset.
+    pos = fetcher._subscriptions.assignment[tp].position
+    assert pos.offset == 80
+    assert pos.leader_epoch == 3
+    assert fetcher.validate_offsets_if_needed() is None
+
+
+def test_validate_offsets_async_diverged_raises_when_no_reset_policy(
+        client, metrics, mocker, topic):
+    """Diverged endpoint with reset policy NONE: cache LogTruncationError
+    carrying the broker-reported divergent offset; do not move position."""
+    fetcher, tp = _make_validating_fetcher(
+        client, metrics, topic, OffsetAndMetadata(100, '', 3),
+        offset_reset_strategy='none')
+    _patch_leader(fetcher, mocker)
+    _stub_validation_send(fetcher, mocker, [(topic, 0, 0, 3, 80)])
 
     fetcher._manager._net.run(fetcher._validate_offsets_async, 1000)
 
     assert fetcher._cached_log_truncation is not None
     with pytest.raises(Errors.LogTruncationError) as exc_info:
         fetcher.validate_offsets_if_needed()
-    assert tp in exc_info.value.divergent_offsets
     divergent = exc_info.value.divergent_offsets[tp]
+    assert divergent is not None
     assert divergent.offset == 80
     assert divergent.leader_epoch == 3
-    # awaiting_validation cleared so caller can act
+    # Position untouched; caller acts on the exception.
+    assert fetcher._subscriptions.assignment[tp].position.offset == 100
     assert not fetcher._subscriptions.assignment[tp].awaiting_validation
-    # And no auto-reset
+    assert not fetcher._subscriptions.assignment[tp].awaiting_reset
+
+
+def test_validate_offsets_async_undefined_resets_with_policy(
+        client, metrics, mocker, topic):
+    """UNDEFINED response (broker has no record of our epoch) with a reset
+    policy: no known seek point, so fall back to auto_offset_reset."""
+    fetcher, tp = _make_validating_fetcher(
+        client, metrics, topic, OffsetAndMetadata(100, '', 3))
+    _patch_leader(fetcher, mocker)
+    # end_offset=-1 AND leader_epoch=-1 (UNDEFINED_EPOCH_OFFSET / UNDEFINED_EPOCH)
+    _stub_validation_send(fetcher, mocker, [(topic, 0, 0, -1, -1)])
+
+    fetcher._manager._net.run(fetcher._validate_offsets_async, 1000)
+
+    assert fetcher._cached_log_truncation is None
+    assert fetcher._subscriptions.assignment[tp].awaiting_reset
+    assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+
+
+def test_validate_offsets_async_undefined_only_end_offset_resets(
+        client, metrics, mocker, topic):
+    """Just end_offset=UNDEFINED (epoch valid) still treated as truncation."""
+    fetcher, tp = _make_validating_fetcher(
+        client, metrics, topic, OffsetAndMetadata(100, '', 3))
+    _patch_leader(fetcher, mocker)
+    _stub_validation_send(fetcher, mocker, [(topic, 0, 0, 3, -1)])
+
+    fetcher._manager._net.run(fetcher._validate_offsets_async, 1000)
+
+    assert fetcher._subscriptions.assignment[tp].awaiting_reset
+
+
+def test_validate_offsets_async_undefined_only_leader_epoch_resets(
+        client, metrics, mocker, topic):
+    """Just leader_epoch=UNDEFINED (offset valid) still treated as truncation."""
+    fetcher, tp = _make_validating_fetcher(
+        client, metrics, topic, OffsetAndMetadata(100, '', 3))
+    _patch_leader(fetcher, mocker)
+    _stub_validation_send(fetcher, mocker, [(topic, 0, 0, -1, 200)])
+
+    fetcher._manager._net.run(fetcher._validate_offsets_async, 1000)
+
+    assert fetcher._subscriptions.assignment[tp].awaiting_reset
+
+
+def test_validate_offsets_async_undefined_raises_when_no_reset_policy(
+        client, metrics, mocker, topic):
+    """UNDEFINED response with reset policy NONE: cache LogTruncationError
+    with divergent_offsets[tp] == None (no known recovery point)."""
+    fetcher, tp = _make_validating_fetcher(
+        client, metrics, topic, OffsetAndMetadata(100, '', 3),
+        offset_reset_strategy='none')
+    _patch_leader(fetcher, mocker)
+    _stub_validation_send(fetcher, mocker, [(topic, 0, 0, -1, -1)])
+
+    fetcher._manager._net.run(fetcher._validate_offsets_async, 1000)
+
+    with pytest.raises(Errors.LogTruncationError) as exc_info:
+        fetcher.validate_offsets_if_needed()
+    assert tp in exc_info.value.divergent_offsets
+    assert exc_info.value.divergent_offsets[tp] is None
+    # Position untouched.
+    assert fetcher._subscriptions.assignment[tp].position.offset == 100
+    assert not fetcher._subscriptions.assignment[tp].awaiting_validation
     assert not fetcher._subscriptions.assignment[tp].awaiting_reset
 
 

--- a/test/consumer/test_fetcher_mock_broker.py
+++ b/test/consumer/test_fetcher_mock_broker.py
@@ -1,0 +1,244 @@
+# pylint: skip-file
+"""Wire-level integration tests for KIP-320 offset validation.
+
+These tests drive the Fetcher through a real KafkaConnectionManager wired
+to a scriptable MockBroker, so every ``OffsetForLeaderEpochRequest`` and
+``FetchRequest`` actually goes through the protocol layer. Use these to
+verify end-to-end behavior that the pure-mock tests in
+``test_fetcher.py`` can't cover - request encoding, response decoding,
+and the interactions between Fetcher, ClusterMetadata, and SubscriptionState
+as metadata updates arrive over the wire.
+"""
+
+import time
+
+import pytest
+
+import kafka.errors as Errors
+from kafka.consumer.fetcher import Fetcher
+from kafka.consumer.subscription_state import SubscriptionState
+from kafka.protocol.consumer import (
+    FetchRequest, FetchResponse,
+    OffsetForLeaderEpochRequest, OffsetForLeaderEpochResponse,
+)
+from kafka.protocol.metadata import MetadataResponse
+from kafka.structs import OffsetAndMetadata, TopicPartition
+
+
+TOPIC = 'foobar'
+PARTITION = 0
+
+
+# --------------------------------------------------------------------------- #
+# Builders                                                                    #
+# --------------------------------------------------------------------------- #
+
+_MetaTopic = MetadataResponse.MetadataResponseTopic
+_MetaPartition = _MetaTopic.MetadataResponsePartition
+_MetaBroker = MetadataResponse.MetadataResponseBroker
+_OFLE_Topic = OffsetForLeaderEpochResponse.OffsetForLeaderTopicResult
+_OFLE_Partition = _OFLE_Topic.EpochEndOffset
+_FetchTopic = FetchResponse.FetchableTopicResponse
+_FetchPartition = _FetchTopic.PartitionData
+
+
+def _broker_metadata(broker, leader_epoch):
+    """Configure the MockBroker to advertise TOPIC/PARTITION with the
+    given leader_epoch, leader=node 0 (self)."""
+    broker.set_metadata(
+        brokers=[_MetaBroker(node_id=broker.node_id, host=broker.host,
+                             port=broker.port, rack=None)],
+        topics=[_MetaTopic(
+            error_code=0, name=TOPIC, is_internal=False,
+            partitions=[_MetaPartition(
+                error_code=0, partition_index=PARTITION,
+                leader_id=broker.node_id, leader_epoch=leader_epoch,
+                replica_nodes=[broker.node_id], isr_nodes=[broker.node_id],
+                offline_replicas=[])],
+        )],
+    )
+
+
+def _ofle_response(error_code, leader_epoch, end_offset):
+    return OffsetForLeaderEpochResponse(
+        throttle_time_ms=0,
+        topics=[_OFLE_Topic(topic=TOPIC, partitions=[_OFLE_Partition(
+            error_code=error_code, partition=PARTITION,
+            leader_epoch=leader_epoch, end_offset=end_offset)])])
+
+
+def _fetch_response_with_error(errno):
+    """FetchResponse for TOPIC/PARTITION carrying a single error code."""
+    return FetchResponse(
+        throttle_time_ms=0, error_code=0, session_id=0,
+        responses=[_FetchTopic(topic=TOPIC, partitions=[_FetchPartition(
+            partition_index=PARTITION, error_code=errno, high_watermark=-1,
+            last_stable_offset=-1, log_start_offset=-1,
+            aborted_transactions=[], preferred_read_replica=-1,
+            records=b'')])])
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def subscription_state():
+    return SubscriptionState()
+
+
+@pytest.fixture
+def fetcher(broker, client, manager, subscription_state, metrics):
+    """Fetcher wired to a bootstrapped client+manager+MockBroker."""
+    # Bootstrap so the manager has a connected node and cluster metadata.
+    _broker_metadata(broker, leader_epoch=3)
+    manager.bootstrap(timeout_ms=5000)
+
+    subscription_state.subscribe(topics=[TOPIC])
+    subscription_state.assign_from_subscribed([TopicPartition(TOPIC, PARTITION)])
+    fetcher = Fetcher(client, subscription_state, metrics=metrics,
+                      retry_backoff_ms=50)
+    return fetcher
+
+
+# --------------------------------------------------------------------------- #
+# Tests                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestKIP320OffsetValidation:
+    """End-to-end OffsetsForLeaderEpoch flow through the wire."""
+
+    def test_advanced_cluster_epoch_triggers_validation_request(
+            self, broker, manager, fetcher):
+        """When the metadata-cached leader_epoch advances past the
+        consumer's position epoch, the next ``maybe_validate_positions``
+        marks the partition and ``_validate_offsets_async`` issues an
+        OffsetForLeaderEpochRequest over the wire."""
+        tp = TopicPartition(TOPIC, PARTITION)
+        fetcher._subscriptions.seek(tp, OffsetAndMetadata(50, '', 3))
+
+        # Bump the broker's leader_epoch and force a metadata refresh so
+        # the consumer's cluster cache sees the new epoch.
+        _broker_metadata(broker, leader_epoch=5)
+        manager.cluster.request_update()
+        manager._net.run(manager.wait_for, manager.cluster.request_update(), 1000)
+
+        captured = {}
+
+        def handler(api_key, api_version, correlation_id, request_bytes):
+            captured['version'] = api_version
+            return _ofle_response(error_code=0, leader_epoch=5, end_offset=100)
+        broker.respond_fn(OffsetForLeaderEpochRequest, handler)
+
+        fetcher.maybe_validate_positions()
+        assert fetcher._subscriptions.assignment[tp].awaiting_validation
+
+        manager.run(fetcher._validate_offsets_async, 1000)
+
+        assert 'version' in captured, 'OffsetForLeaderEpochRequest never reached broker'
+        assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+        # Position's epoch advanced to the broker-confirmed epoch.
+        assert fetcher._subscriptions.assignment[tp].position.leader_epoch == 5
+        assert fetcher._subscriptions.assignment[tp].position.offset == 50
+
+    def test_truncation_triggers_auto_reset_with_policy(
+            self, broker, manager, fetcher):
+        """end_offset < position.offset on the wire response triggers
+        ``request_offset_reset`` instead of surfacing
+        LogTruncationError (default policy is 'earliest')."""
+        tp = TopicPartition(TOPIC, PARTITION)
+        fetcher._subscriptions.seek(tp, OffsetAndMetadata(100, '', 3))
+        fetcher._subscriptions.maybe_validate_position_for_current_leader(tp, 5)
+
+        broker.respond(OffsetForLeaderEpochRequest,
+                       _ofle_response(error_code=0, leader_epoch=3, end_offset=80))
+
+        manager.run(fetcher._validate_offsets_async, 1000)
+
+        # Auto-reset path: no cached truncation, partition awaiting reset
+        assert fetcher._cached_log_truncation is None
+        assert fetcher._subscriptions.assignment[tp].awaiting_reset
+        assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+
+    def test_truncation_raises_when_no_reset_policy(
+            self, broker, client, manager, metrics):
+        """With offset_reset_strategy=NONE, the same wire response
+        produces LogTruncationError carrying the diverging offsets."""
+        # Re-create the fetcher with explicit NONE policy.
+        _broker_metadata(broker, leader_epoch=3)
+        manager.bootstrap(timeout_ms=5000)
+        subs = SubscriptionState(offset_reset_strategy='none')
+        subs.subscribe(topics=[TOPIC])
+        tp = TopicPartition(TOPIC, PARTITION)
+        subs.assign_from_subscribed([tp])
+        subs.seek(tp, OffsetAndMetadata(100, '', 3))
+        fetcher = Fetcher(client, subs, metrics=metrics, retry_backoff_ms=50)
+        subs.maybe_validate_position_for_current_leader(tp, 5)
+
+        broker.respond(OffsetForLeaderEpochRequest,
+                       _ofle_response(error_code=0, leader_epoch=3, end_offset=80))
+
+        manager.run(fetcher._validate_offsets_async, 1000)
+
+        with pytest.raises(Errors.LogTruncationError) as exc_info:
+            fetcher.validate_offsets_if_needed()
+        divergent = exc_info.value.divergent_offsets
+        assert tp in divergent
+        assert divergent[tp].offset == 80
+        assert divergent[tp].leader_epoch == 3
+
+    def test_fenced_epoch_on_fetch_marks_validation_then_succeeds(
+            self, broker, manager, fetcher):
+        """A FENCED_LEADER_EPOCH on a real Fetch response routes through
+        ``request_position_validation``; a subsequent
+        ``_validate_offsets_async`` issues the OffsetForLeaderEpochRequest
+        and clears the flag."""
+        tp = TopicPartition(TOPIC, PARTITION)
+        fetcher._subscriptions.seek(tp, OffsetAndMetadata(50, '', 3))
+
+        # Script: one Fetch -> FENCED_LEADER_EPOCH, one OffsetForLeaderEpoch -> success
+        broker.respond(FetchRequest, _fetch_response_with_error(
+            Errors.FencedLeaderEpochError.errno))
+        broker.respond(OffsetForLeaderEpochRequest,
+                       _ofle_response(error_code=0, leader_epoch=3, end_offset=100))
+
+        # Drive a fetch+poll cycle. send_fetches schedules the request;
+        # we then await it and let the response handler run.
+        fetcher.send_fetches()
+        # Drain the fetch response into _completed_fetches and parse it.
+        # fetch_records pulls everything pending and runs _parse_fetched_data.
+        fetcher.fetch_records(timeout_ms=500)
+        assert fetcher._subscriptions.assignment[tp].awaiting_validation
+
+        # Now run the validation driver; it should send OffsetForLeaderEpoch
+        # and clear the flag.
+        manager.run(fetcher._validate_offsets_async, 1000)
+        assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+
+    def test_validation_retries_on_fenced_epoch_response(
+            self, broker, manager, fetcher):
+        """FENCED_LEADER_EPOCH in the OffsetForLeaderEpoch response itself
+        is retried after ``retry_backoff_ms`` within a single
+        ``_validate_offsets_async`` invocation."""
+        tp = TopicPartition(TOPIC, PARTITION)
+        fetcher._subscriptions.seek(tp, OffsetAndMetadata(50, '', 3))
+        fetcher._subscriptions.maybe_validate_position_for_current_leader(tp, 5)
+
+        # First response: FENCED_LEADER_EPOCH. Second: success.
+        broker.respond(OffsetForLeaderEpochRequest, _ofle_response(
+            error_code=Errors.FencedLeaderEpochError.errno,
+            leader_epoch=-1, end_offset=-1))
+        broker.respond(OffsetForLeaderEpochRequest, _ofle_response(
+            error_code=0, leader_epoch=5, end_offset=100))
+
+        start = time.monotonic()
+        manager.run(fetcher._validate_offsets_async, 2000)
+        elapsed = time.monotonic() - start
+
+        assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+        assert fetcher._subscriptions.assignment[tp].position.leader_epoch == 5
+        assert elapsed >= 0.05, (
+            '_validate_offsets_async did not sleep for retry_backoff_ms; %.3fs'
+            % elapsed)

--- a/test/consumer/test_fetcher_mock_broker.py
+++ b/test/consumer/test_fetcher_mock_broker.py
@@ -143,11 +143,12 @@ class TestKIP320OffsetValidation:
         assert fetcher._subscriptions.assignment[tp].position.leader_epoch == 5
         assert fetcher._subscriptions.assignment[tp].position.offset == 50
 
-    def test_truncation_triggers_auto_reset_with_policy(
+    def test_diverged_seeks_to_endpoint_with_policy(
             self, broker, manager, fetcher):
-        """end_offset < position.offset on the wire response triggers
-        ``request_offset_reset`` instead of surfacing
-        LogTruncationError (default policy is 'earliest')."""
+        """end_offset < position.offset (valid epoch) on the wire triggers
+        a seek to the broker-reported divergence point - preserves progress
+        and tags position with the confirmed epoch. Mirrors Java's
+        ``state.seekValidated(newPosition)``."""
         tp = TopicPartition(TOPIC, PARTITION)
         fetcher._subscriptions.seek(tp, OffsetAndMetadata(100, '', 3))
         fetcher._subscriptions.maybe_validate_position_for_current_leader(tp, 5)
@@ -157,16 +158,18 @@ class TestKIP320OffsetValidation:
 
         manager.run(fetcher._validate_offsets_async, 1000)
 
-        # Auto-reset path: no cached truncation, partition awaiting reset
         assert fetcher._cached_log_truncation is None
-        assert fetcher._subscriptions.assignment[tp].awaiting_reset
+        assert not fetcher._subscriptions.assignment[tp].awaiting_reset
         assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+        pos = fetcher._subscriptions.assignment[tp].position
+        assert pos.offset == 80
+        assert pos.leader_epoch == 3
 
-    def test_truncation_raises_when_no_reset_policy(
+    def test_diverged_raises_when_no_reset_policy(
             self, broker, client, manager, metrics):
         """With offset_reset_strategy=NONE, the same wire response
-        produces LogTruncationError carrying the diverging offsets."""
-        # Re-create the fetcher with explicit NONE policy.
+        produces LogTruncationError carrying the divergent offset and
+        leaves the position untouched."""
         _broker_metadata(broker, leader_epoch=3)
         manager.bootstrap(timeout_ms=5000)
         subs = SubscriptionState(offset_reset_strategy='none')
@@ -186,8 +189,55 @@ class TestKIP320OffsetValidation:
             fetcher.validate_offsets_if_needed()
         divergent = exc_info.value.divergent_offsets
         assert tp in divergent
+        assert divergent[tp] is not None
         assert divergent[tp].offset == 80
         assert divergent[tp].leader_epoch == 3
+        # Position untouched.
+        assert subs.assignment[tp].position.offset == 100
+
+    def test_undefined_response_resets_with_policy(
+            self, broker, manager, fetcher):
+        """UNDEFINED end_offset/leader_epoch (broker has no record of our
+        epoch) with a reset policy: no known seek point, so fall back to
+        auto_offset_reset rather than silently dropping the epoch."""
+        tp = TopicPartition(TOPIC, PARTITION)
+        fetcher._subscriptions.seek(tp, OffsetAndMetadata(100, '', 3))
+        fetcher._subscriptions.maybe_validate_position_for_current_leader(tp, 5)
+
+        broker.respond(OffsetForLeaderEpochRequest,
+                       _ofle_response(error_code=0, leader_epoch=-1, end_offset=-1))
+
+        manager.run(fetcher._validate_offsets_async, 1000)
+
+        assert fetcher._cached_log_truncation is None
+        assert fetcher._subscriptions.assignment[tp].awaiting_reset
+        assert not fetcher._subscriptions.assignment[tp].awaiting_validation
+
+    def test_undefined_response_raises_when_no_reset_policy(
+            self, broker, client, manager, metrics):
+        """UNDEFINED response with reset policy NONE: LogTruncationError
+        with divergent_offsets[tp] == None (no known recovery point)."""
+        _broker_metadata(broker, leader_epoch=3)
+        manager.bootstrap(timeout_ms=5000)
+        subs = SubscriptionState(offset_reset_strategy='none')
+        subs.subscribe(topics=[TOPIC])
+        tp = TopicPartition(TOPIC, PARTITION)
+        subs.assign_from_subscribed([tp])
+        subs.seek(tp, OffsetAndMetadata(100, '', 3))
+        fetcher = Fetcher(client, subs, metrics=metrics, retry_backoff_ms=50)
+        subs.maybe_validate_position_for_current_leader(tp, 5)
+
+        broker.respond(OffsetForLeaderEpochRequest,
+                       _ofle_response(error_code=0, leader_epoch=-1, end_offset=-1))
+
+        manager.run(fetcher._validate_offsets_async, 1000)
+
+        with pytest.raises(Errors.LogTruncationError) as exc_info:
+            fetcher.validate_offsets_if_needed()
+        assert tp in exc_info.value.divergent_offsets
+        assert exc_info.value.divergent_offsets[tp] is None
+        # Position untouched; caller decides.
+        assert subs.assignment[tp].position.offset == 100
 
     def test_fenced_epoch_on_fetch_marks_validation_then_succeeds(
             self, broker, manager, fetcher):

--- a/test/test_cluster.py
+++ b/test/test_cluster.py
@@ -8,6 +8,7 @@ import pytest
 from kafka.cluster import collect_hosts
 from kafka.future import Future
 from kafka.protocol.metadata import MetadataResponse
+from kafka.structs import TopicPartition
 
 Broker = MetadataResponse.MetadataResponseBroker
 Topic = MetadataResponse.MetadataResponseTopic
@@ -95,6 +96,41 @@ class TestClusterMetadataUpdateMetadata:
 
         # topic should be added to unauthorized list
         assert 'unauthorized-topic' in cluster.unauthorized_topics
+
+
+class TestClusterMetadataPartitionLookups:
+    """Cover the per-partition lookups (leader_for_partition,
+    leader_epoch_for_partition) for known and unknown partitions.
+
+    Regression for an issue where ``leader_epoch_for_partition`` raised
+    KeyError on an assigned-but-not-yet-known topic, breaking
+    ``Fetcher.maybe_validate_positions`` during the first poll after
+    ``KafkaConsumer.assign(...)``.
+    """
+
+    def _seed_topic(self, cluster, version=7):
+        response = _make_metadata_response(version)
+        response = MetadataResponse.decode(response.encode(), version=version)
+        cluster.update_metadata(response)
+
+    def test_known_partition_returns_leader_and_epoch(self, cluster):
+        self._seed_topic(cluster)
+        tp = TopicPartition('topic-1', 0)
+        assert cluster.leader_for_partition(tp) == 0
+        assert cluster.leader_epoch_for_partition(tp) == 0
+
+    def test_unknown_topic_returns_none(self, cluster):
+        # Cluster has no topics; both lookups should return None, not raise.
+        tp = TopicPartition('not-a-topic', 0)
+        assert cluster.leader_for_partition(tp) is None
+        assert cluster.leader_epoch_for_partition(tp) is None
+
+    def test_unknown_partition_returns_none(self, cluster):
+        # Topic exists with partition 0 only; partition 99 must not raise.
+        self._seed_topic(cluster)
+        tp = TopicPartition('topic-1', 99)
+        assert cluster.leader_for_partition(tp) is None
+        assert cluster.leader_epoch_for_partition(tp) is None
 
 
 class TestClusterMetadataTopics:


### PR DESCRIPTION
- Save leader epoch in OffsetAndMetadata
- Add LogTruncationError and offset-validation state
- Validate offsets via OffsetForLeaderEpochRequest
