### PR TITLE
Consumer: Retain subscription TopicPartitionState when possible

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -1426,15 +1426,23 @@ class Fetcher:
                 completed_fetch.metric_aggregator.record(tp, 0, 0)
 
             if error_type is not Errors.NoError:
-                # we move the partition to the end if there was an error. This way, it's more likely that partitions for
-                # the same topic can remain together (allowing for more efficient serialization).
+                # Rotate this partition to the back of the iteration
+                # order so we don't keep slamming the broken partition
+                # first on the next poll - healthier partitions get
+                # processed while this one's backoff / metadata
+                # refresh runs. Cheap LRU-style fairness across the
+                # assignment.
                 self._subscriptions.move_partition_to_end(tp)
 
         return parsed_records
 
     def _on_partition_records_drain(self, partition_records):
-        # we move the partition to the end if we received some bytes. This way, it's more likely that partitions
-        # for the same topic can remain together (allowing for more efficient serialization).
+        # Rotate this partition to the back of the iteration order so
+        # the next poll prioritizes partitions we haven't drained from
+        # recently. (Topic-grouping in the outgoing FetchRequest is
+        # done unconditionally by FetchRequestData.to_send via
+        # defaultdict, so this is purely round-robin fairness across
+        # partitions, not a serialization-efficiency thing.)
         if partition_records.bytes_read > 0:
             self._subscriptions.move_partition_to_end(partition_records.topic_partition)
 

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -750,8 +750,8 @@ class KafkaConsumer:
                 Default: Inherit value from max_poll_records.
 
         Returns:
-            dict: Topic to list of records since the last fetch for the
-                subscribed list of topics and partitions.
+            dict[TopicPartition, list[ConsumerRecord]]: records since the last
+                fetch for the subscribed list of topics and partitions.
         """
         # Note: update_offsets is an internal-use only argument. It is used to
         # support the python iterator interface, and which wraps consumer.poll()

--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -198,13 +198,14 @@ class SubscriptionState:
     def assign_from_user(self, partitions):
         """Manually assign a list of TopicPartitions to this consumer.
 
-        This interface does not allow for incremental assignment and will
-        replace the previous assignment (if there was one).
-
-        Manual topic assignment through this method does not use the consumer's
-        group management functionality. As such, there will be no rebalance
-        operation triggered when group membership or cluster and topic metadata
-        change. Note that it is not possible to use both manual partition
+        The new assignment replaces the previous one (this is not an
+        incremental-add API), but ``TopicPartitionState`` is preserved
+        for any partition that's present in both the old and new
+        assignment. Manual topic assignment through this method does
+        not use the consumer's group management functionality. As
+        such, there will be no rebalance operation triggered when
+        group membership or cluster and topic metadata change. Note
+        that it is not possible to use both manual partition
         assignment with assign() and group assignment with subscribe().
 
         Arguments:
@@ -214,23 +215,33 @@ class SubscriptionState:
             IllegalStateError: if consumer has already called subscribe()
         """
         self._set_subscription_type(SubscriptionType.USER_ASSIGNED)
-        if self._user_assignment != set(partitions):
-            self._user_assignment = set(partitions)
-            self._set_assignment({partition: self.assignment.get(partition, TopicPartitionState())
-                                  for partition in partitions})
+        if self._user_assignment == set(partitions):
+            return
+        self._user_assignment = set(partitions)
+        self._apply_assignment(partitions)
 
     @synchronized
     def assign_from_subscribed(self, assignments):
-        """Update the assignment to the specified partitions
+        """Update the assignment to the specified partitions.
 
         This method is called by the coordinator to dynamically assign
-        partitions based on the consumer's topic subscription. This is different
-        from assign_from_user() which directly sets the assignment from a
-        user-supplied TopicPartition list.
+        partitions based on the consumer's topic subscription. Differs
+        from :meth:`assign_from_user` which directly sets the assignment
+        from a user-supplied TopicPartition list.
+
+        Preserves ``TopicPartitionState`` (position, paused flag,
+        preferred read replica, fetch buffers tied to the partition)
+        for any partition present in both the prior and new assignments.
+
+        Validation raises ``ValueError`` BEFORE any mutation if a
+        partition's topic isn't subscribed.
 
         Arguments:
-            assignments (list of TopicPartition): partitions to assign to this
-                consumer instance.
+            assignments (list of TopicPartition): the *full* new
+                assignment (not a diff). Partitions present in both
+                the old and new assignment retain their state;
+                revoked partitions are dropped; new partitions get
+                fresh state.
         """
         if not self.partitions_auto_assigned():
             raise Errors.IllegalStateError(self._SUBSCRIPTION_EXCEPTION_MESSAGE)
@@ -239,22 +250,46 @@ class SubscriptionState:
             if tp.topic not in self.subscription:
                 raise ValueError("Assigned partition %s for non-subscribed topic." % (tp,))
 
-        # randomized ordering should improve balance for short-lived consumers
-        self._set_assignment({partition: TopicPartitionState() for partition in assignments}, randomize=True)
+        # randomize new-partition insertion order so short-lived
+        # consumers (CLI tools, one-shot jobs) that re-run from scratch
+        # don't keep starting on the same partition. The Fetcher
+        # iterates fetchable_partitions() in self.assignment insertion
+        # order; without the shuffle, partition 0 of the
+        # alphabetically-first topic always wins the first fetch and
+        # short-lived runs that bail before exhausting it never see
+        # later partitions.
+        self._apply_assignment(assignments, randomize=True)
         log.info("Updated partition assignment: %s", assignments)
 
-    def _set_assignment(self, partition_states, randomize=False):
-        """Batch partition assignment by topic (self.assignment is OrderedDict)"""
-        self.assignment.clear()
-        topics = [tp.topic for tp in partition_states]
+    def _apply_assignment(self, partitions, randomize=False):
+        """Mutate ``self.assignment`` in place to contain exactly
+        ``partitions``, preserving the existing ``TopicPartitionState``
+        for any partition present in both the old and new sets.
+
+        Shared between :meth:`assign_from_user` and
+        :meth:`assign_from_subscribed` - the algorithm is identical;
+        only the validation around it differs.
+
+        When ``randomize=True``, the *newly-added* partitions are
+        inserted in random order. Kept partitions retain their
+        existing position regardless. This is intended for the
+        coordinator-driven path (assign_from_subscribed) - see the
+        comment at that call site for rationale.
+        """
+        new_set = set(partitions)
+        # Drop revoked partitions (we mutate self.assignment, so list()
+        # the keys first to avoid "dict changed size during iteration").
+        for tp in list(self.assignment.keys()):
+            if tp not in new_set:
+                del self.assignment[tp]
+        # Add new partitions; kept partitions retain their existing
+        # TopicPartitionState (positions, paused flag, KIP-392 cache,
+        # etc.).
+        new_partitions = [tp for tp in partitions if tp not in self.assignment]
         if randomize:
-            random.shuffle(topics)
-        topic_partitions = OrderedDict({topic: [] for topic in topics})
-        for tp in partition_states:
-            topic_partitions[tp.topic].append(tp)
-        for topic in topic_partitions:
-            for tp in topic_partitions[topic]:
-                self.assignment[tp] = partition_states[tp]
+            random.shuffle(new_partitions)
+        for tp in new_partitions:
+            self.assignment[tp] = TopicPartitionState()
 
     @synchronized
     def unsubscribe(self):

--- a/test/consumer/test_coordinator.py
+++ b/test/consumer/test_coordinator.py
@@ -1556,6 +1556,47 @@ class TestKip429OnJoinComplete:
         finally:
             coord.close(timeout_ms=0)
 
+    def test_cooperative_preserves_state_on_kept_partition(
+            self, mocker, client, metrics):
+        """KIP-429: a partition the consumer retains across a
+        cooperative rebalance must keep its TopicPartitionState
+        (position, paused flag, KIP-392 preferred-replica cache).
+        Otherwise the rebalance would force a committed-offset
+        re-fetch for partitions that didn't move - defeating the
+        point of incremental cooperative."""
+        from kafka.structs import OffsetAndMetadata
+        coord = _cooperative_coordinator(client, metrics)
+        try:
+            coord.config['enable_auto_commit'] = False
+            coord._subscription.subscribe(topics=['t'])
+            coord._subscription.assign_from_subscribed([
+                TopicPartition('t', 0), TopicPartition('t', 1)])
+            # Seed state on partition 0 that must survive the rebalance.
+            tp0 = TopicPartition('t', 0)
+            coord._subscription.assignment[tp0].seek(
+                OffsetAndMetadata(offset=500, metadata='', leader_epoch=-1))
+            coord._subscription.assignment[tp0].update_preferred_read_replica(
+                3, time.monotonic() + 60)
+            original_state = coord._subscription.assignment[tp0]
+
+            # Rebalance: keep partition 0, drop 1, add 2.
+            assignment_bytes = self._make_assignment_bytes('t', [0, 2])
+            coord._manager.run(
+                coord._on_join_complete_async,
+                42, 'member-1', 'cooperative-sticky', assignment_bytes)
+
+            # The TopicPartitionState object is the SAME instance - not
+            # a fresh one with the same fields. Identity matters because
+            # the Fetcher and other components hold references.
+            assert coord._subscription.assignment[tp0] is original_state
+            assert coord._subscription.assignment[tp0].position.offset == 500
+            assert coord._subscription.assignment[tp0].preferred_read_replica() == 3
+            # New partition got fresh state.
+            assert not coord._subscription.assignment[
+                TopicPartition('t', 2)].has_valid_position
+        finally:
+            coord.close(timeout_ms=0)
+
     def test_cooperative_assignment_for_unsubscribed_topic_bails(
             self, mocker, client, metrics):
         """If the leader hands us a partition for a topic we're not

--- a/test/consumer/test_subscription_state.py
+++ b/test/consumer/test_subscription_state.py
@@ -1,7 +1,10 @@
+import time
+
 import pytest
 
 from kafka import TopicPartition
 from kafka.consumer.subscription_state import SubscriptionState, TopicPartitionState
+from kafka.structs import OffsetAndMetadata
 
 
 def test_type_error():
@@ -33,18 +36,6 @@ def test_group_subscribe():
     assert s._group_subscription == set(['foo'])
 
 
-def test_assign_from_subscribed():
-    s = SubscriptionState()
-    s.subscribe(topics=['foo'])
-    with pytest.raises(ValueError):
-        s.assign_from_subscribed([TopicPartition('bar', 0)])
-
-    s.assign_from_subscribed([TopicPartition('foo', 0), TopicPartition('foo', 1)])
-    assert set(s.assignment.keys()) == set([TopicPartition('foo', 0), TopicPartition('foo', 1)])
-    assert all([isinstance(tps, TopicPartitionState) for tps in s.assignment.values()])
-    assert all([not tps.has_valid_position for tps in s.assignment.values()])
-
-
 def test_change_subscription_after_assignment():
     s = SubscriptionState()
     s.subscribe(topics=['foo'])
@@ -52,3 +43,139 @@ def test_change_subscription_after_assignment():
     # Changing subscription retains existing assignment until next rebalance
     s.change_subscription(['bar'])
     assert set(s.assignment.keys()) == set([TopicPartition('foo', 0), TopicPartition('foo', 1)])
+
+
+# ---------------------------------------------------------------------------
+# assign_from_subscribed: state-preserving (Java-faithful) assignment update
+# ---------------------------------------------------------------------------
+
+
+class TestAssignFromSubscribed:
+    """``assign_from_subscribed`` preserves ``TopicPartitionState`` for
+    partitions present in both the old and new assignment. New partitions
+    get fresh state; revoked partitions are dropped. This is what
+    makes KIP-429 cooperative rebalancing efficient (and what makes
+    EAGER rebalances avoid wiping state for partitions that didn't
+    move)."""
+
+    def _subscribed(self):
+        s = SubscriptionState()
+        s.subscribe(topics=['foo'])
+        return s
+
+    def test_initial_assignment(self):
+        """First-call behaviour (no prior assignment to preserve)."""
+        s = self._subscribed()
+        with pytest.raises(ValueError):
+            s.assign_from_subscribed([TopicPartition('bar', 0)])
+
+        s.assign_from_subscribed([TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        assert set(s.assignment.keys()) == set([
+            TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        assert all(isinstance(tps, TopicPartitionState)
+                   for tps in s.assignment.values())
+        assert all(not tps.has_valid_position for tps in s.assignment.values())
+
+    def test_preserves_position_on_kept_partition(self):
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        # Seed state on partition 0 that should survive the rebalance.
+        s.assignment[TopicPartition('foo', 0)].seek(
+            OffsetAndMetadata(offset=100, metadata='', leader_epoch=-1))
+
+        # Rebalance: keep partition 0, drop partition 1, add partition 2.
+        s.assign_from_subscribed([
+            TopicPartition('foo', 0), TopicPartition('foo', 2)])
+
+        # Kept partition retains its position.
+        assert s.assignment[TopicPartition('foo', 0)].position.offset == 100
+        # New partition has fresh (no-position) state.
+        assert not s.assignment[TopicPartition('foo', 2)].has_valid_position
+        # Revoked partition is gone.
+        assert TopicPartition('foo', 1) not in s.assignment
+
+    def test_preserves_paused_state_on_kept_partition(self):
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0)])
+        s.pause(TopicPartition('foo', 0))
+        assert s.is_paused(TopicPartition('foo', 0))
+
+        s.assign_from_subscribed([
+            TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        # Pause survived.
+        assert s.is_paused(TopicPartition('foo', 0))
+        # New partition isn't paused by default.
+        assert not s.is_paused(TopicPartition('foo', 1))
+
+    def test_preserves_preferred_read_replica_on_kept_partition(self):
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0)])
+        s.assignment[TopicPartition('foo', 0)].update_preferred_read_replica(
+            5, time.monotonic() + 60)
+        assert s.assignment[TopicPartition('foo', 0)].preferred_read_replica() == 5
+
+        s.assign_from_subscribed([
+            TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        # KIP-392 cache survives.
+        assert s.assignment[TopicPartition('foo', 0)].preferred_read_replica() == 5
+        # New partition starts with no preferred replica.
+        assert s.assignment[TopicPartition('foo', 1)].preferred_read_replica() is None
+
+    def test_object_identity_for_kept_partition_state(self):
+        """The actual TopicPartitionState instance must survive - not a
+        copy with the same field values. This matters for callers (like
+        the Fetcher) that hold references to TopicPartitionState
+        instances across rebalances."""
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0)])
+        original = s.assignment[TopicPartition('foo', 0)]
+        s.assign_from_subscribed([
+            TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        assert s.assignment[TopicPartition('foo', 0)] is original
+
+    def test_revoked_partition_state_is_dropped(self):
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        original = s.assignment[TopicPartition('foo', 1)]
+
+        s.assign_from_subscribed([TopicPartition('foo', 0)])
+        assert TopicPartition('foo', 1) not in s.assignment
+        # The revoked TopicPartitionState is no longer referenced by the
+        # subscription (caller may still hold the reference, but the
+        # dict has dropped it).
+        assert original not in s.assignment.values()
+
+    def test_validates_topic_subscribed_before_mutation(self):
+        """A bad topic must raise BEFORE any mutation. Half-applied
+        state would leave the consumer in an inconsistent place."""
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0)])
+        original_keys = list(s.assignment.keys())
+
+        with pytest.raises(ValueError):
+            s.assign_from_subscribed([
+                TopicPartition('foo', 2),
+                TopicPartition('not-subscribed', 0)])
+        # Nothing was added or removed.
+        assert list(s.assignment.keys()) == original_keys
+
+    def test_full_replace_drops_all_old_partitions(self):
+        """A new assignment with zero overlap drops every old partition."""
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        s.assign_from_subscribed([TopicPartition('foo', 2)])
+        assert set(s.assignment.keys()) == {TopicPartition('foo', 2)}
+
+    def test_no_op_assignment_preserves_everything(self):
+        """Same assignment in/out: every state field survives identical."""
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        s.assignment[TopicPartition('foo', 0)].seek(
+            OffsetAndMetadata(offset=50, metadata='', leader_epoch=-1))
+        s.pause(TopicPartition('foo', 1))
+
+        s.assign_from_subscribed([
+            TopicPartition('foo', 0), TopicPartition('foo', 1)])
+
+        assert s.assignment[TopicPartition('foo', 0)].position.offset == 50
+        assert s.is_paused(TopicPartition('foo', 1))


### PR DESCRIPTION
- SubscriptionState: Retain TopicPartitionState when possible
- Fetcher: Fixup move_partition_to_end comments
- KafkaConsumer: Fixup poll() return docstring
- coordinator test for kip-429 retained partition state
- expand assign_from_subscribed test coverage
