### PR TITLE
kafka.net: per-request timeouts

### DIFF
--- a/kafka/net/connection.py
+++ b/kafka/net/connection.py
@@ -147,11 +147,15 @@ class KafkaConnection:
         correlation_id = self.parser.send_request(request)
         log.debug('%s Request %d: %s', self, correlation_id, request)
         if request.expect_response():
-            if not self.in_flight_requests:
-                self._timeout_task = self.net.call_at(timeout_at, self._maybe_timeout_ifrs)
-            elif timeout_at < self.in_flight_requests[-1][-1]:
-                raise ValueError('New request timeout cannot be lower than in-flight request!')
-            self.in_flight_requests.append((correlation_id, future, sent_time, timeout_at))
+            # Each in-flight request owns its own timer so heterogeneous
+            # per-request timeouts (e.g. JoinGroup with a rebalance-sized
+            # deadline interleaved with default-timeout MetadataRequests)
+            # don't require monotonic-deadline FIFO ordering.
+            timeout_task = self.net.call_at(
+                timeout_at,
+                lambda: self._request_timed_out(future, sent_time, timeout_at))
+            self.in_flight_requests.append(
+                (correlation_id, future, sent_time, timeout_at, timeout_task))
         else:
             future.success(None)
 
@@ -170,14 +174,15 @@ class KafkaConnection:
             request, future, timeout_at = self._request_buffer.popleft()
             self._send_request(request, future=future, timeout_at=timeout_at)
 
-    def _maybe_timeout_ifrs(self):
-        if not self.in_flight_requests:
+    def _request_timed_out(self, future, sent_at, timeout_at):
+        # Defensive: a response and its timer can both be dispatched within a
+        # single _poll_once iteration; if data_received resolved the future
+        # first, skip the connection-close.
+        if self.closed or future.is_done:
             return
-        _, _, sent_at, timeout_at = self.in_flight_requests[0]
-        if time.monotonic() > timeout_at:
-            timeout_ms = (timeout_at - sent_at) * 1000
-            log.warning('%s: Request timed out after %d ms. Closing connection.', self, timeout_ms)
-            self.close(Errors.RequestTimedOutError('Request timed out after %d ms' % timeout_ms))
+        timeout_ms = (timeout_at - sent_at) * 1000
+        log.warning('%s: Request timed out after %d ms. Closing connection.', self, timeout_ms)
+        self.close(Errors.RequestTimedOutError('Request timed out after %d ms' % timeout_ms))
 
     def data_received(self, data):
         """ Called when some data is received."""
@@ -189,13 +194,14 @@ class KafkaConnection:
         # augment responses w/ correlation_id, future, and timestamp
         for i, (resp_correlation_id, response) in enumerate(responses):
             try:
-                (req_correlation_id, future, sent_time, _timeout_at) = self.in_flight_requests.popleft()
+                (req_correlation_id, future, sent_time, _timeout_at, timeout_task) = self.in_flight_requests.popleft()
             except IndexError:
                 return self.close(Errors.KafkaConnectionError('Received response with no in-flight-requests!'))
 
             if req_correlation_id != resp_correlation_id:
                 return self.close(Errors.KafkaConnectionError('Received unrecognized correlation id'))
 
+            self.net.unschedule(timeout_task)
             latency_ms = (time.monotonic() - sent_time) * 1000
             if self._sensors:
                 self._sensors.request_time.record(latency_ms)
@@ -205,12 +211,6 @@ class KafkaConnection:
             future.success(response)
         if 'max_in_flight' in self.paused and len(self.in_flight_requests) < self.config['max_in_flight_requests_per_connection']:
             self.unpause('max_in_flight')
-        if self.in_flight_requests:
-            next_timeout_at = self.in_flight_requests[0][3]
-            self.net.reschedule(next_timeout_at, self._timeout_task)
-        else:
-            self.net.unschedule(self._timeout_task)
-            self._timeout_task = None
 
     def eof_received(self):
         """ Called when the other end calls write_eof() or equivalent.
@@ -247,7 +247,8 @@ class KafkaConnection:
             _, future, _ = self._request_buffer.popleft()
             future.failure(error)
         while self.in_flight_requests:
-            _, future, _, _ = self.in_flight_requests.popleft()
+            _, future, _, _, timeout_task = self.in_flight_requests.popleft()
+            self.net.unschedule(timeout_task)
             future.failure(error)
 
     def connection_made(self, transport):

--- a/kafka/net/manager.py
+++ b/kafka/net/manager.py
@@ -287,14 +287,14 @@ class KafkaConnectionManager:
                                      if not conn.init_future.is_done else None)
         return conn
 
-    def send(self, request, node_id=None):
+    def send(self, request, node_id=None, request_timeout_ms=None):
         node_id = node_id if node_id is not None else self.least_loaded_node()
         try:
             conn = self.get_connection(node_id)
         except Errors.NodeNotReadyError as e:
             return Future().failure(e)
         else:
-            return conn.send_request(request)
+            return conn.send_request(request, request_timeout_ms=request_timeout_ms)
 
     def least_loaded_node(self):
         """Choose the node with fewest outstanding requests, with fallbacks.

--- a/test/net/test_connection.py
+++ b/test/net/test_connection.py
@@ -203,6 +203,51 @@ class TestKafkaConnectionSendRequest:
             connection.send_request(MagicMock())
         assert len(connection._request_buffer) == 3
 
+    def _make_send_ready(self, connection):
+        connection.initializing = False
+        connection.connected = True
+        transport = MagicMock()
+        transport.getPeer.return_value = ('127.0.0.1', 9092, 0, 0)
+        connection.transport = transport
+        connection.parser = MagicMock()
+        cid = [0]
+        def alloc_cid(_req):
+            cid[0] += 1
+            return cid[0]
+        connection.parser.send_request.side_effect = alloc_cid
+        connection.parser.send_bytes.return_value = b'data'
+
+    def test_send_request_heterogeneous_timeouts_no_longer_raise(self, connection):
+        """Per-request timers: a longer-timeout request followed by a
+        shorter-timeout one must not raise ValueError. Each request owns
+        its own timer.
+        """
+        self._make_send_ready(connection)
+        long_req = MagicMock()
+        long_req.expect_response.return_value = True
+        long_req.API_VERSION = 1
+        short_req = MagicMock()
+        short_req.expect_response.return_value = True
+        short_req.API_VERSION = 1
+
+        # JoinGroup-style: 305s timeout
+        connection.send_request(long_req, request_timeout_ms=305000)
+        # Metadata-style: 30s timeout - would have raised under the old
+        # monotonic-deadline constraint.
+        connection.send_request(short_req, request_timeout_ms=30000)
+
+        assert len(connection.in_flight_requests) == 2
+
+    def test_send_request_uses_per_request_timeout(self, connection):
+        self._make_send_ready(connection)
+        request = MagicMock()
+        request.expect_response.return_value = True
+        request.API_VERSION = 1
+        now = time.monotonic()
+        connection.send_request(request, request_timeout_ms=305000)
+        (_, _, sent_time, timeout_at, _task) = connection.in_flight_requests[0]
+        assert (timeout_at - sent_time) == pytest.approx(305.0, abs=0.05)
+
 
 class TestKafkaConnectionConnectionLifecycle:
     def test_connection_made(self, connection):
@@ -308,8 +353,11 @@ class TestKafkaConnectionFailInFlight:
     def test_fail_in_flight_requests(self, connection):
         f1 = Future()
         f2 = Future()
-        connection.in_flight_requests.append((1, f1, time.monotonic(), time.monotonic() + 30))
-        connection.in_flight_requests.append((2, f2, time.monotonic(), time.monotonic() + 30))
+        now = time.monotonic()
+        t1 = connection.net.call_at(now + 30, lambda: None)
+        t2 = connection.net.call_at(now + 30, lambda: None)
+        connection.in_flight_requests.append((1, f1, now, now + 30, t1))
+        connection.in_flight_requests.append((2, f2, now, now + 30, t2))
 
         connection.close(Errors.Cancelled())
         assert f1.failed()

--- a/test/net/test_manager.py
+++ b/test/net/test_manager.py
@@ -213,6 +213,20 @@ class TestKafkaConnectionManagerSend:
         assert f.failed()
         assert isinstance(f.exception, Errors.NodeNotReadyError)
 
+    def test_send_forwards_request_timeout_ms_to_connection(self, manager):
+        request = MagicMock()
+        request.expect_response.return_value = True
+        request.API_VERSION = 1
+        captured = {}
+        with patch.object(KafkaConnection, 'send_request', autospec=True) as mock:
+            def capture(self_, req, request_timeout_ms=None):
+                captured['request_timeout_ms'] = request_timeout_ms
+                return Future()
+            mock.side_effect = capture
+            # Ensure node exists so get_connection returns a KafkaConnection.
+            manager.send(request, node_id='bootstrap-0', request_timeout_ms=305000)
+        assert captured['request_timeout_ms'] == 305000
+
 
 class TestKafkaConnectionManagerBootstrap:
     def test_bootstrap_async_returns_future(self, manager):


### PR DESCRIPTION
- kafka.net.manager: send() accepts request_timeout_ms kwarg
- kafka.net.connection: per-request timeout tasks
