### PR TITLE
chore: improve kafka-python maintenance path

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -7,6 +7,7 @@ from kafka.util import ensure_valid_topic_name
 @pytest.mark.parametrize(('topic_name', 'expectation'), [
     (0, pytest.raises(TypeError)),
     (None, pytest.raises(TypeError)),
+    (b'bytes-topic', pytest.raises(TypeError)),
     ('', pytest.raises(ValueError)),
     ('.', pytest.raises(ValueError)),
     ('..', pytest.raises(ValueError)),
@@ -22,3 +23,15 @@ def test_topic_name_validation(topic_name, expectation):
     with expectation:
         ensure_valid_topic_name(topic_name)
 
+
+@pytest.mark.parametrize('topic_name', [
+    'a',
+    'topic',
+    'my-topic',
+    'my_topic',
+    'my.topic',
+    'topic123',
+    'a' * 249,
+])
+def test_topic_name_validation_success(topic_name):
+    assert ensure_valid_topic_name(topic_name) is None


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in test/test_util.py, test/test_codec.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.