### PR TITLE
KIP-654: Txn Producer aborts with non-fatal TransactionAbortedError

### DIFF
--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -126,7 +126,10 @@ class UnsupportedCodecError(KafkaError):
 
 
 class TransactionAbortedError(KafkaError):
-    pass
+    """Raised on undrained batches when a transaction is aborted with no
+    underlying cause -- the user chose to abort (KIP-654). Non-fatal: the
+    producer remains usable for the next transaction."""
+    message = 'Failing batch since transaction was aborted'
 
 
 class BrokerResponseError(KafkaError):

--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -590,7 +590,11 @@ class RecordAccumulator:
             tp = batch.topic_partition
             with self._tp_lock(tp):
                 aborted = False
-                if not batch.is_done:
+                # Skip in-flight batches (already drained, awaiting broker
+                # response): drain() popped them from _batches[tp], so
+                # .remove() would ValueError; and we want their futures to
+                # resolve via the broker response, not be cancelled locally.
+                if not batch.is_done and batch.drained is None:
                     aborted = True
                     batch.records.close()
                     self._batches[tp].remove(batch)

--- a/kafka/producer/record_accumulator.py
+++ b/kafka/producer/record_accumulator.py
@@ -565,23 +565,31 @@ class RecordAccumulator:
         # This is a tight loop but should be able to get through very quickly.
         error = Errors.IllegalStateError("Producer is closed forcefully.")
         while True:
-            self._abort_batches(error)
+            self.abort_batches(error)
             if not self._appends_in_progress.get():
                 break
         # After this point, no thread will append any messages because they will see the close
         # flag set. We need to do the last abort after no thread was appending in case the there was a new
         # batch appended by the last appending thread.
-        self._abort_batches(error)
+        self.abort_batches(error)
         self._batches.clear()
 
-    def _abort_batches(self, error):
-        """Go through incomplete batches and abort them."""
+    def abort_batches(self, error):
+        """Abort every incomplete batch, including in-flight (drained but
+        not-yet-acked) ones. Use for fatal-error / force-close paths where
+        the user's pending futures must resolve immediately rather than
+        hang waiting for broker responses that aren't coming."""
         for batch in self._incomplete.all():
             tp = batch.topic_partition
-            # Close the batch before aborting
             with self._tp_lock(tp):
                 batch.records.close()
-                self._batches[tp].remove(batch)
+                # Drained batches were popleft()'d out of _batches[tp] -- only
+                # remove if still present (matches Java's LinkedList.remove,
+                # which returns false rather than raising).
+                try:
+                    self._batches[tp].remove(batch)
+                except ValueError:
+                    pass
             batch.abort(error)
             self.deallocate(batch)
 

--- a/kafka/producer/sender.py
+++ b/kafka/producer/sender.py
@@ -292,7 +292,12 @@ class Sender(threading.Thread):
     def _maybe_send_pending_request(self):
         if self._transaction_manager.is_completing() and self._accumulator.has_incomplete:
             if self._transaction_manager.is_aborting():
-                self._accumulator.abort_undrained_batches(Errors.KafkaError("Failing batch since transaction was aborted"))
+                # KIP-654: prefer the last error that triggered the abort;
+                # otherwise the user chose to abort with no underlying cause --
+                # surface a non-fatal TransactionAbortedError on the
+                # in-accumulator batches.
+                exception = self._transaction_manager.last_error or Errors.TransactionAbortedError()
+                self._accumulator.abort_undrained_batches(exception)
             # There may still be requests left which are being retried. Since we do not know whether they had
             # been successfully appended to the broker log, we must resend them until their final status is clear.
             # If they had been appended and we did not receive the error, then our sequence number would no longer
@@ -346,6 +351,9 @@ class Sender(threading.Thread):
     def _maybe_abort_batches(self, exc):
         if self._accumulator.has_incomplete:
             log.error("%s: Aborting producer batches due to fatal error: %s", str(self), exc)
+            # Fatal: fail everything including in-flight batches; their broker
+            # responses won't recover us, and the user's pending futures need
+            # to resolve so close() can return.
             self._accumulator.abort_batches(exc)
 
     def initiate_close(self):

--- a/test/producer/test_record_accumulator.py
+++ b/test/producer/test_record_accumulator.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import kafka.errors as Errors
 from kafka.cluster import ClusterMetadata
 from kafka.producer.record_accumulator import RecordAccumulator
 from kafka.record.default_records import DefaultRecordBatchBuilder
@@ -178,6 +179,36 @@ def test_abort_on_new_batch_returns_sentinel(tp):
     assert abort is True
     # And no batch was actually allocated.
     assert tp not in accum._batches or not accum._batches[tp]
+
+
+def test_abort_undrained_batches_skips_in_flight(tp, cluster):
+    """abort_undrained_batches must not touch batches that have already been
+    drained -- drain() popleft()s them out of _batches[tp], so attempting to
+    .remove() them raises ValueError; and we want their futures to resolve
+    via the broker response, not be cancelled locally."""
+    accum = RecordAccumulator(linger_ms=0, batch_size=64)
+
+    # First batch: append, drain (now in-flight), still in _incomplete.
+    inflight_future, *_ = accum.append(tp, 0, b'k1', b'v1', [], now=0)
+    ready, _, _ = accum.ready(cluster, now=0)
+    assert ready == {0}
+    drained = accum.drain(cluster, ready, 2147483647, now=0)[0]
+    assert len(drained) == 1
+    inflight_batch = drained[0]
+    assert inflight_batch.drained is not None
+    assert tp not in accum._batches or inflight_batch not in accum._batches[tp]
+
+    # Second batch: append, leave undrained.
+    undrained_future, *_ = accum.append(tp, 0, b'k2', b'v2', [], now=0)
+    assert accum.has_incomplete
+
+    # Must not ValueError on the in-flight batch's missing _batches[tp] entry.
+    accum.abort_undrained_batches(Errors.TransactionAbortedError())
+
+    assert undrained_future.failed()
+    assert isinstance(undrained_future.exception, Errors.TransactionAbortedError)
+    # In-flight batch's future is left alone for the broker response to resolve.
+    assert not inflight_future.is_done
 
 
 def test_abort_on_new_batch_appends_to_existing(tp):

--- a/test/producer/test_record_accumulator.py
+++ b/test/producer/test_record_accumulator.py
@@ -181,6 +181,33 @@ def test_abort_on_new_batch_returns_sentinel(tp):
     assert tp not in accum._batches or not accum._batches[tp]
 
 
+def test_abort_batches_handles_in_flight(tp, cluster):
+    """abort_batches must fail in-flight (drained but not-yet-acked) batches
+    too -- used on fatal-error / force-close paths where the user's pending
+    futures must resolve immediately. Drained batches were popleft()'d out
+    of _batches[tp]; the .remove() call must not ValueError."""
+    accum = RecordAccumulator(linger_ms=0, batch_size=64)
+
+    # In-flight batch.
+    inflight_future, *_ = accum.append(tp, 0, b'k1', b'v1', [], now=0)
+    ready, _, _ = accum.ready(cluster, now=0)
+    drained = accum.drain(cluster, ready, 2147483647, now=0)[0]
+    assert len(drained) == 1
+    assert drained[0].drained is not None
+
+    # Undrained batch.
+    undrained_future, *_ = accum.append(tp, 0, b'k2', b'v2', [], now=0)
+
+    err = Errors.KafkaError('fatal')
+    accum.abort_batches(err)
+
+    assert inflight_future.failed()
+    assert undrained_future.failed()
+    assert isinstance(inflight_future.exception, Errors.KafkaError)
+    assert isinstance(undrained_future.exception, Errors.KafkaError)
+    assert not accum.has_incomplete
+
+
 def test_abort_undrained_batches_skips_in_flight(tp, cluster):
     """abort_undrained_batches must not touch batches that have already been
     drained -- drain() popleft()s them out of _batches[tp], so attempting to

--- a/test/producer/test_sender.py
+++ b/test/producer/test_sender.py
@@ -324,6 +324,45 @@ def test_out_of_order_sequence_number_reset_producer_id(sender, accumulator, tra
     batch.done.assert_called_with(top_level_exception=error(None), record_exceptions_fn=mocker.ANY)
 
 
+def test_transaction_aborted_error_on_user_abort_with_undrained_batches(client, mocker):
+    """KIP-654: when the user calls abort_transaction() while records are
+    still un-flushed in the accumulator, those per-record futures should
+    resolve with the non-fatal TransactionAbortedError -- not a generic
+    KafkaError that callers have to treat as fatal."""
+    cluster = client.cluster
+    tm = TransactionManager(
+        transactional_id='txn-id',
+        transaction_timeout_ms=60000,
+        retry_backoff_ms=100,
+        api_version=(2, 1),
+        metadata=cluster)
+    tm.set_producer_id_and_epoch(ProducerIdAndEpoch(1000, 0))
+    # Move to READY without going through InitProducerIdHandler
+    from kafka.producer.transaction_manager import TransactionState
+    tm._transition_to(TransactionState.INITIALIZING)
+    tm._transition_to(TransactionState.READY)
+    tm.begin_transaction()
+
+    acc = RecordAccumulator(transaction_manager=tm)
+    sender = Sender(client, cluster, acc, transaction_manager=tm)
+
+    tp = TopicPartition('foo', 0)
+    tm.maybe_add_partition_to_transaction(tp)
+    future, _, _, _ = acc.append(tp, 0, None, b'value', [])
+
+    tm.begin_abort()
+    assert tm.is_aborting()
+    assert tm.last_error is None
+
+    # Short-circuit the EndTxnHandler dispatch so we don't need a live
+    # coordinator -- the abort happens before next_request_handler is consulted.
+    mocker.patch.object(tm, 'next_request_handler', return_value=None)
+    sender._maybe_send_pending_request()
+
+    assert future.failed()
+    assert isinstance(future.exception, Errors.TransactionAbortedError)
+
+
 def test_handle_produce_response():
     pass
 


### PR DESCRIPTION
- **RecordAccumulator: skip drained batches in abort_undrained_batches**
- **RecordAccumulator: abort_batches should not raise ValueError if batch was drained**
- **KIP-654: Txn Producer aborts with non-fatal TransactionAbortedError**
