### PR TITLE
docs: add manual offset commit example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -94,7 +94,7 @@ KafkaConsumer
 
 .. code:: python
 
-    from kafka import KafkaConsumer
+    from kafka import KafkaConsumer, OffsetAndMetadata, TopicPartition
     import json
     import msgpack
 
@@ -108,6 +108,26 @@ KafkaConsumer
         print ("%s:%d:%d: key=%s value=%s" % (message.topic, message.partition,
                                               message.offset, message.key,
                                               message.value))
+    
+    # Manually commit offsets (disable auto-commit)
+    consumer = KafkaConsumer('my-topic',
+                         group_id='my-group',
+                         enable_auto_commit=False,
+                         bootstrap_servers=['localhost:9092'],
+                         )
+    for message in consumer:
+        # process message
+        process_message(message)
+        # TopicPartition for this record
+        tp = TopicPartition(message.topic, message.partition)
+        # Commit the next offset to consume (message.offset + 1)
+        consumer.commit({
+            tp: OffsetAndMetadata(message.offset + 1, '', -1)
+        })
+    
+    # When committing offsets manually, commit the next offset the consumer
+    # should read. For example, after successfully processing a message at
+    # offset 42, commit offset 43.
 
     # consume earliest available messages, don't commit offsets
     KafkaConsumer(auto_offset_reset='earliest', enable_auto_commit=False)


### PR DESCRIPTION
Add a short KafkaConsumer example showing manual offset commits with TopicPartition and OffsetAndMetadata. Clarifies that you should commit the next offset to consume (e.g. commit message.offset + 1).

Quick example:

from kafka import KafkaConsumer, OffsetAndMetadata, TopicPartition
consumer = KafkaConsumer('my-topic', group_id='g', enable_auto_commit=False)
for msg in consumer:
    process_message(msg)
    tp = TopicPartition(msg.topic, msg.partition)
    consumer.commit({tp: OffsetAndMetadata(msg.offset + 1, '', -1)})