### PR TITLE
Rebalance Listener: raise errors, block fetches on revoked, pre-revoke unsubscribed

### DIFF
--- a/kafka/consumer/subscription_state.py
+++ b/kafka/consumer/subscription_state.py
@@ -508,6 +508,24 @@ class SubscriptionState:
         self.assignment[partition].resume()
 
     @synchronized
+    def mark_pending_revocation(self, partitions):
+        """KIP-429: gate ``is_fetchable()`` for each partition's state
+        so the fetcher would skip them while an on_partitions_revoked /
+        on_partitions_lost listener runs. Called immediately before
+        invoking the listener. The flag is single-shot - the
+        surrounding ``assign_from_subscribed`` drops the
+        ``TopicPartitionState`` for revoked partitions when the
+        listener returns.
+
+        Currently a no-op while the user thread is blocked in ``_net.run``
+        during rebalance and so the only path that calls ``send_fetches``
+        cannot fire. Kept as a defensive gate in case this changes in
+        the future."""
+        for tp in partitions:
+            if tp in self.assignment:
+                self.assignment[tp].mark_pending_revocation()
+
+    @synchronized
     def reset_failed(self, partitions, next_retry_time):
         for partition in partitions:
             self.assignment[partition].reset_failed(next_retry_time)
@@ -544,6 +562,13 @@ class TopicPartitionState:
         # replica-related errors so the next fetch goes to the leader.
         self._preferred_read_replica = None
         self._preferred_read_replica_expiration = None
+        # KIP-429 (Java parity): set while an on_partitions_revoked /
+        # on_partitions_lost listener is running for this partition.
+        # Gates fetches so records aren't pulled for a partition the
+        # user is in the middle of releasing. The TopicPartitionState
+        # is dropped from the assignment when the listener returns,
+        # so the flag only matters for the listener-call window.
+        self._pending_revocation = False
 
     def _set_position(self, offset):
         assert self.has_valid_position, 'Valid position required'
@@ -597,8 +622,18 @@ class TopicPartitionState:
     def resume(self):
         self.paused = False
 
+    def mark_pending_revocation(self):
+        """KIP-429: gate fetches while an on_partitions_revoked /
+        on_partitions_lost listener is in progress for this partition.
+        Single-shot: the surrounding ``assign_from_subscribed`` drops
+        the state object once the listener returns."""
+        self._pending_revocation = True
+
     def is_fetchable(self):
-        return not self.paused and self.has_valid_position and not self._awaiting_validation
+        return (not self.paused
+                and not self._pending_revocation
+                and self.has_valid_position
+                and not self._awaiting_validation)
 
     def preferred_read_replica(self):
         """Return the currently-cached preferred read replica (KIP-392),

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -517,6 +517,7 @@ class ConsumerCoordinator(BaseCoordinator):
             if lost:
                 log.info("Group %s lost membership; forcibly revoking %s",
                          self.group_id, lost)
+                self._subscription.mark_pending_revocation(lost)
                 if self._subscription.rebalance_listener:
                     try:
                         await self._invoke_rebalance_listener_async(
@@ -560,17 +561,19 @@ class ConsumerCoordinator(BaseCoordinator):
         # replaces it via assign_from_subscribed - this listener call
         # is a *notification*, not the actual state mutation.
         #
-        # Under COOPERATIVE we skip the notification entirely: members
-        # keep their assignment across JoinGroup and only the
-        # individual partitions that actually moved are revoked in
-        # _on_join_complete_async (computed from the owned-vs-assigned
-        # diff).
+        # Under COOPERATIVE we keep most of the assignment across
+        # JoinGroup, but partitions whose topic is no longer in the
+        # subscription (e.g. the user just unsubscribed from a topic)
+        # are revoked here, before the JoinGroup, so the listener
+        # gets to commit those offsets while we're still the
+        # recognised owner.
         if self._rebalance_protocol == RebalanceProtocol.EAGER:
             log.info("Revoking previously assigned partitions %s for group %s",
                      self._subscription.assigned_partitions(), self.group_id)
             if self._subscription.rebalance_listener:
                 try:
                     revoked = set(self._subscription.assigned_partitions())
+                    self._subscription.mark_pending_revocation(revoked)
                     await self._invoke_rebalance_listener_async(
                         'on_partitions_revoked', revoked)
                 except Exception as exc:
@@ -578,6 +581,25 @@ class ConsumerCoordinator(BaseCoordinator):
                                   " for group %s failed on_partitions_revoked",
                                   self._subscription.rebalance_listener, self.group_id)
                     listener_exc = exc
+
+        elif self._rebalance_protocol == RebalanceProtocol.COOPERATIVE:
+            owned = set(self._subscription.assigned_partitions())
+            subscribed_topics = self._subscription.subscription or set()
+            revoked = {tp for tp in owned if tp.topic not in subscribed_topics}
+            if revoked:
+                log.info("Cooperative pre-rebalance for group %s: revoking %s"
+                         " (no longer in subscription)", self.group_id, revoked)
+                self._subscription.mark_pending_revocation(revoked)
+                if self._subscription.rebalance_listener:
+                    try:
+                        await self._invoke_rebalance_listener_async(
+                            'on_partitions_revoked', revoked)
+                    except Exception as exc:
+                        log.exception("User provided subscription rebalance listener %s"
+                                      " for group %s failed on_partitions_revoked",
+                                      self._subscription.rebalance_listener, self.group_id)
+                        listener_exc = exc
+                self._subscription.assign_from_subscribed(sorted(owned - revoked))
 
         self._is_leader = False
         self._subscription.reset_group_subscription()

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -303,6 +303,14 @@ class ConsumerCoordinator(BaseCoordinator):
         # the newly-added ones. If we lost any partitions, request a
         # follow-up rebalance so the revoked partitions can land on
         # their intended new owner.
+        # Listener hook exceptions are captured, cleanup completes,
+        # and we re-raise at the end as a KafkaError.
+        # In the cooperative branch both listeners (revoked + assigned)
+        # are invoked even if the first throws - matches Java's
+        # invokePartitionsRevoked / invokePartitionsAssigned pattern
+        # where the later call overwrites the captured exception.
+        listener_exc = None
+
         if self._rebalance_protocol == RebalanceProtocol.COOPERATIVE:
             currently_owned = set(self._subscription.assigned_partitions())
             revoked = currently_owned - new_assigned
@@ -329,22 +337,24 @@ class ConsumerCoordinator(BaseCoordinator):
                     try:
                         await self._invoke_rebalance_listener_async(
                             'on_partitions_revoked', revoked)
-                    except Exception:
+                    except Exception as exc:
                         log.exception(
                             "User provided rebalance listener %s for group %s"
                             " failed on_partitions_revoked: %s",
                             self._subscription.rebalance_listener,
                             self.group_id, revoked)
+                        listener_exc = exc
                 if added:
                     try:
                         await self._invoke_rebalance_listener_async(
                             'on_partitions_assigned', added)
-                    except Exception:
+                    except Exception as exc:
                         log.exception(
                             "User provided rebalance listener %s for group %s"
                             " failed on_partitions_assigned: %s",
                             self._subscription.rebalance_listener,
                             self.group_id, added)
+                        listener_exc = exc
 
             if revoked:
                 # Round 2: the partitions we just revoked should now
@@ -355,6 +365,10 @@ class ConsumerCoordinator(BaseCoordinator):
                          " complete cooperative move of %d partition(s)",
                          self.group_id, len(revoked))
                 self.request_rejoin()
+
+            if listener_exc is not None:
+                raise Errors.KafkaError(
+                    "User rebalance callback throws an error") from listener_exc
             return
 
         # EAGER mode (legacy): replace the full assignment and invoke
@@ -383,11 +397,16 @@ class ConsumerCoordinator(BaseCoordinator):
             try:
                 await self._invoke_rebalance_listener_async(
                     'on_partitions_assigned', assigned)
-            except Exception:
+            except Exception as exc:
                 log.exception("User provided rebalance listener %s for group %s"
                               " failed on partition assignment: %s",
                               self._subscription.rebalance_listener, self.group_id,
                               assigned)
+                listener_exc = exc
+
+        if listener_exc is not None:
+            raise Errors.KafkaError(
+                "User rebalance callback throws an error") from listener_exc
 
     def poll(self, timeout_ms=None):
         """
@@ -488,6 +507,11 @@ class ConsumerCoordinator(BaseCoordinator):
         return group_assignment
 
     async def _on_join_prepare_async(self, generation, member_id, timeout_ms=None):
+        # Exceptions raised by user rebalance-listener callbacks are captured
+        # here, do not abort the cleanup, and are re-raised at the end as a
+        # KafkaError so the caller (consumer.poll()) sees them. Matches Java.
+        listener_exc = None
+
         if self._generation.is_lost():
             lost = set(self._subscription.assigned_partitions())
             if lost:
@@ -497,13 +521,17 @@ class ConsumerCoordinator(BaseCoordinator):
                     try:
                         await self._invoke_rebalance_listener_async(
                             'on_partitions_lost', lost)
-                    except Exception:
+                    except Exception as exc:
                         log.exception("User provided subscription rebalance listener %s"
                                       " for group %s failed on_partitions_lost",
                                       self._subscription.rebalance_listener, self.group_id)
+                        listener_exc = exc
                 self._subscription.assign_from_subscribed([])
                 self._is_leader = False
                 self._subscription.reset_group_subscription()
+                if listener_exc is not None:
+                    raise Errors.KafkaError(
+                        "User rebalance callback throws an error") from listener_exc
                 return
             # else: generation is lost but we have no partitions to
             # lose - this is the initial-join case. Fall through to the
@@ -545,13 +573,18 @@ class ConsumerCoordinator(BaseCoordinator):
                     revoked = set(self._subscription.assigned_partitions())
                     await self._invoke_rebalance_listener_async(
                         'on_partitions_revoked', revoked)
-                except Exception:
+                except Exception as exc:
                     log.exception("User provided subscription rebalance listener %s"
                                   " for group %s failed on_partitions_revoked",
                                   self._subscription.rebalance_listener, self.group_id)
+                    listener_exc = exc
 
         self._is_leader = False
         self._subscription.reset_group_subscription()
+
+        if listener_exc is not None:
+            raise Errors.KafkaError(
+                "User rebalance callback throws an error") from listener_exc
 
     def need_rejoin(self):
         """Check whether the group should be rejoined

--- a/test/consumer/test_coordinator.py
+++ b/test/consumer/test_coordinator.py
@@ -1522,6 +1522,95 @@ class TestKip429OnJoinPrepare:
         finally:
             coord.close(timeout_ms=0)
 
+    def test_cooperative_revokes_unsubscribed_topic_partitions_early(
+            self, mocker, client, metrics):
+        """Java parity: under COOPERATIVE, _on_join_prepare revokes
+        partitions whose topic is no longer in the subscription
+        *before* the JoinGroup, so the listener can commit those
+        offsets while we're still the recognised owner. Partitions
+        for still-subscribed topics stay in the assignment."""
+        coord = _cooperative_coordinator(client, metrics)
+        try:
+            coord.config['enable_auto_commit'] = False
+            listener = mocker.MagicMock(spec=ConsumerRebalanceListener)
+            # Member previously owned partitions for two topics; then
+            # the user changed the subscription to drop 'old'.
+            coord._subscription.subscribe(topics=['t', 'old'], listener=listener)
+            coord._subscription.assign_from_subscribed([
+                TopicPartition('t', 0), TopicPartition('t', 1),
+                TopicPartition('old', 0), TopicPartition('old', 1)])
+            coord._subscription.change_subscription(['t'])
+            coord._generation = Generation(42, 'mbr-1', 'cooperative-sticky')
+
+            coord._manager.run(coord._on_join_prepare_async, 42, 'mbr-1')
+
+            # Only the unsubscribed-topic partitions should be revoked,
+            # and only those should be dropped from the assignment.
+            listener.on_partitions_revoked.assert_called_once_with(
+                {TopicPartition('old', 0), TopicPartition('old', 1)})
+            assert coord._subscription.assigned_partitions() == {
+                TopicPartition('t', 0), TopicPartition('t', 1)}
+        finally:
+            coord.close(timeout_ms=0)
+
+    def test_cooperative_pre_revoke_marks_pending_revocation(
+            self, mocker, client, metrics):
+        """KIP-429: the cooperative pre-revoke must mark the
+        about-to-be-revoked partitions as pending revocation BEFORE
+        invoking the listener so the fetcher won't pull records from
+        them while the listener is running. Verified by checking the
+        flag at listener-call time."""
+        coord = _cooperative_coordinator(client, metrics)
+        try:
+            coord.config['enable_auto_commit'] = False
+
+            class Capturing(ConsumerRebalanceListener):
+                def __init__(self, sub):
+                    self.sub = sub
+                    self.fetchable_at_revoke = None
+                def on_partitions_revoked(self, revoked):
+                    self.fetchable_at_revoke = {
+                        tp: self.sub.is_fetchable(tp) for tp in revoked}
+                def on_partitions_assigned(self, assigned):
+                    pass
+
+            listener = Capturing(coord._subscription)
+            coord._subscription.subscribe(topics=['t', 'old'], listener=listener)
+            coord._subscription.assign_from_subscribed([
+                TopicPartition('t', 0),
+                TopicPartition('old', 0)])
+            coord._subscription.change_subscription(['t'])
+            coord._generation = Generation(42, 'mbr-1', 'cooperative-sticky')
+
+            coord._manager.run(coord._on_join_prepare_async, 42, 'mbr-1')
+
+            assert listener.fetchable_at_revoke == {
+                TopicPartition('old', 0): False}
+        finally:
+            coord.close(timeout_ms=0)
+
+    def test_cooperative_no_unsubscribed_topics_skips_listener(
+            self, mocker, client, metrics):
+        """If every owned partition is still in the subscription,
+        nothing is revoked in the prepare phase and the listener is
+        not called - the diff is left for _on_join_complete_async."""
+        coord = _cooperative_coordinator(client, metrics)
+        try:
+            coord.config['enable_auto_commit'] = False
+            listener = mocker.MagicMock(spec=ConsumerRebalanceListener)
+            coord._subscription.subscribe(topics=['t'], listener=listener)
+            coord._subscription.assign_from_subscribed([
+                TopicPartition('t', 0), TopicPartition('t', 1)])
+            coord._generation = Generation(42, 'mbr-1', 'cooperative-sticky')
+
+            coord._manager.run(coord._on_join_prepare_async, 42, 'mbr-1')
+
+            listener.on_partitions_revoked.assert_not_called()
+            assert coord._subscription.assigned_partitions() == {
+                TopicPartition('t', 0), TopicPartition('t', 1)}
+        finally:
+            coord.close(timeout_ms=0)
+
 
 class TestKip429OnJoinComplete:
     """Under COOPERATIVE, _on_join_complete computes the owned-vs-

--- a/test/consumer/test_coordinator.py
+++ b/test/consumer/test_coordinator.py
@@ -282,14 +282,22 @@ def test_slow_rebalance_listener_logs_warning(mocker, coordinator):
     assert method == 'on_partitions_revoked'
 
 
-def test_on_join_prepare_async_listener_exception_is_caught(mocker, coordinator):
+def test_on_join_prepare_async_listener_exception_propagates(mocker, coordinator):
+    """Java parity: a throwing rebalance listener fails the prepare phase
+    with a KafkaError that chains the user exception as __cause__. The
+    cleanup (is_leader, reset_group_subscription) still runs before the
+    exception is raised."""
     coordinator.config['enable_auto_commit'] = False
+    coordinator._generation = Generation(42, 'member-foo', 'range')
     listener = mocker.MagicMock(spec=ConsumerRebalanceListener)
-    listener.on_partitions_revoked.side_effect = RuntimeError('listener crash')
+    crash = RuntimeError('listener crash')
+    listener.on_partitions_revoked.side_effect = crash
     coordinator._subscription.subscribe(topics=['foobar'], listener=listener)
 
-    # Should not raise; should still complete the post-listener cleanup.
-    coordinator._manager.run(coordinator._on_join_prepare_async, 0, 'member-foo')
+    with pytest.raises(Errors.KafkaError) as exc_info:
+        coordinator._manager.run(coordinator._on_join_prepare_async, 42, 'member-foo')
+    assert exc_info.value.__cause__ is crash
+    # Cleanup still ran before the exception bubbled out.
     assert coordinator._is_leader is False
 
 
@@ -356,18 +364,22 @@ def test_on_join_complete_async_awaits_async_listener(coordinator):
         {TopicPartition('foobar', 0), TopicPartition('foobar', 1)})]
 
 
-def test_on_join_complete_async_listener_exception_is_caught(mocker, coordinator):
+def test_on_join_complete_async_listener_exception_propagates(mocker, coordinator):
+    """Java parity: a throwing on_partitions_assigned fails the complete
+    phase with a KafkaError that chains the user exception."""
     listener = mocker.MagicMock(spec=ConsumerRebalanceListener)
-    listener.on_partitions_assigned.side_effect = RuntimeError('listener crash')
+    crash = RuntimeError('listener crash')
+    listener.on_partitions_assigned.side_effect = crash
     coordinator._subscription.subscribe(topics=['foobar'], listener=listener)
     assignor = RoundRobinPartitionAssignor()
     coordinator._assignors = {assignor.name: assignor}
     assignment = ConsumerProtocolAssignment(0, [('foobar', [0, 1])], b'')
 
-    # Should not raise.
-    coordinator._manager.run(
-        coordinator._on_join_complete_async,
-        12, 'member-foo', 'roundrobin', assignment.encode())
+    with pytest.raises(Errors.KafkaError) as exc_info:
+        coordinator._manager.run(
+            coordinator._on_join_complete_async,
+            12, 'member-foo', 'roundrobin', assignment.encode())
+    assert exc_info.value.__cause__ is crash
 
 
 def test_need_rejoin(coordinator):
@@ -1897,20 +1909,25 @@ class TestKip429OnPartitionsLost:
 
         assert calls == [('lost', {TopicPartition('t', 0)})]
 
-    def test_lost_listener_exception_is_caught(self, mocker, coordinator):
-        """A throwing on_partitions_lost must not abort the prepare path."""
+    def test_lost_listener_exception_propagates(self, mocker, coordinator):
+        """Java parity: a throwing on_partitions_lost still runs the
+        cleanup (clear assignment, reset_group_subscription) but then
+        raises a KafkaError chaining the user exception."""
         coordinator.config['enable_auto_commit'] = False
         listener = mocker.MagicMock(spec=ConsumerRebalanceListener)
-        listener.on_partitions_lost.side_effect = RuntimeError('listener crash')
+        crash = RuntimeError('listener crash')
+        listener.on_partitions_lost.side_effect = crash
         coordinator._subscription.subscribe(topics=['t'], listener=listener)
         coordinator._subscription.assign_from_subscribed([TopicPartition('t', 0)])
         coordinator.reset_generation()
 
-        # Must not raise; assignment still cleared.
-        coordinator._manager.run(
-            coordinator._on_join_prepare_async, 0, 'member-foo')
+        with pytest.raises(Errors.KafkaError) as exc_info:
+            coordinator._manager.run(
+                coordinator._on_join_prepare_async, 0, 'member-foo')
+        assert exc_info.value.__cause__ is crash
 
         listener.on_partitions_lost.assert_called_once()
+        # Cleanup still ran before the exception bubbled out.
         assert coordinator._subscription.assigned_partitions() == set()
 
 
@@ -1979,6 +1996,72 @@ class TestKip429MemberIdPreservation:
             coordinator._handle_offset_commit_response(
                 offsets, time.monotonic(), response)
         assert coordinator._generation.has_member_id() is False
+
+
+class TestListenerExceptionPropagation:
+    """Java parity (Diff 3): listener exceptions are captured during
+    cleanup and re-raised at the end of the rebalance phase as a
+    KafkaError chaining the user exception."""
+
+    def _make_assignment_bytes(self, topic, partitions):
+        from kafka.protocol.consumer.metadata import ConsumerProtocolAssignment
+        a = ConsumerProtocolAssignment(
+            version=1,
+            assigned_partitions=[(topic, sorted(partitions))],
+            user_data=b'')
+        return a.encode()
+
+    def test_cooperative_both_listeners_called_even_if_revoked_throws(
+            self, mocker, client, metrics):
+        """Java's invokePartitionsRevoked / invokePartitionsAssigned
+        pattern: even if on_partitions_revoked throws, on_partitions_assigned
+        still runs (so the user gets a chance to react to the new
+        assignment). The final raised exception is the last one captured."""
+        coord = _cooperative_coordinator(client, metrics)
+        try:
+            coord.config['enable_auto_commit'] = False
+            listener = mocker.MagicMock(spec=ConsumerRebalanceListener)
+            revoked_crash = RuntimeError('revoked crash')
+            listener.on_partitions_revoked.side_effect = revoked_crash
+            coord._subscription.subscribe(topics=['t'], listener=listener)
+            coord._subscription.assign_from_subscribed([
+                TopicPartition('t', 0), TopicPartition('t', 1)])
+
+            assignment_bytes = self._make_assignment_bytes('t', [1, 2])
+            with pytest.raises(Errors.KafkaError):
+                coord._manager.run(
+                    coord._on_join_complete_async,
+                    42, 'member-1', 'cooperative-sticky', assignment_bytes)
+
+            # Both listeners were called - revoked even though it threw.
+            listener.on_partitions_revoked.assert_called_once_with(
+                {TopicPartition('t', 0)})
+            listener.on_partitions_assigned.assert_called_once_with(
+                {TopicPartition('t', 2)})
+        finally:
+            coord.close(timeout_ms=0)
+
+    def test_cooperative_assigned_throw_propagates(
+            self, mocker, client, metrics):
+        """If only on_partitions_assigned throws, that's the captured
+        exception."""
+        coord = _cooperative_coordinator(client, metrics)
+        try:
+            coord.config['enable_auto_commit'] = False
+            listener = mocker.MagicMock(spec=ConsumerRebalanceListener)
+            assigned_crash = RuntimeError('assigned crash')
+            listener.on_partitions_assigned.side_effect = assigned_crash
+            coord._subscription.subscribe(topics=['t'], listener=listener)
+            coord._subscription.assign_from_subscribed([TopicPartition('t', 0)])
+
+            assignment_bytes = self._make_assignment_bytes('t', [0, 1])
+            with pytest.raises(Errors.KafkaError) as exc_info:
+                coord._manager.run(
+                    coord._on_join_complete_async,
+                    42, 'member-1', 'cooperative-sticky', assignment_bytes)
+            assert exc_info.value.__cause__ is assigned_crash
+        finally:
+            coord.close(timeout_ms=0)
 
 
 class TestOnJoinCompleteBailOnInvalidAssignment:

--- a/test/consumer/test_subscription_state.py
+++ b/test/consumer/test_subscription_state.py
@@ -107,6 +107,40 @@ class TestAssignFromSubscribed:
         # New partition isn't paused by default.
         assert not s.is_paused(TopicPartition('foo', 1))
 
+    def test_mark_pending_revocation_blocks_fetches(self):
+        """KIP-429: a partition flagged for pending revocation must
+        report not-fetchable so the fetcher skips it while a revoke
+        listener is running."""
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0)])
+        # Give it a valid position so is_fetchable would otherwise be True.
+        s.assignment[TopicPartition('foo', 0)].seek(
+            OffsetAndMetadata(offset=0, metadata='', leader_epoch=-1))
+        assert s.is_fetchable(TopicPartition('foo', 0))
+
+        s.mark_pending_revocation({TopicPartition('foo', 0)})
+        assert not s.is_fetchable(TopicPartition('foo', 0))
+        # The pending-revocation flag is dropped along with the state
+        # object on the next assign_from_subscribed that excludes the
+        # partition (single-shot).
+        s.assign_from_subscribed([TopicPartition('foo', 1)])
+        s.assign_from_subscribed([
+            TopicPartition('foo', 0), TopicPartition('foo', 1)])
+        s.assignment[TopicPartition('foo', 0)].seek(
+            OffsetAndMetadata(offset=0, metadata='', leader_epoch=-1))
+        assert s.is_fetchable(TopicPartition('foo', 0))
+
+    def test_mark_pending_revocation_ignores_unknown_partition(self):
+        """mark_pending_revocation must not raise if a partition isn't
+        currently assigned - the assignment may have shifted between
+        the caller's snapshot and the call."""
+        s = self._subscribed()
+        s.assign_from_subscribed([TopicPartition('foo', 0)])
+        s.mark_pending_revocation({
+            TopicPartition('foo', 0), TopicPartition('foo', 99)})
+        # Still gates the assigned one.
+        assert s.assignment[TopicPartition('foo', 0)]._pending_revocation is True
+
     def test_preserves_preferred_read_replica_on_kept_partition(self):
         s = self._subscribed()
         s.assign_from_subscribed([TopicPartition('foo', 0)])


### PR DESCRIPTION
- Raise Exceptions from user-defined rebalance listener (after cleanup)
- Mark revoked partitions as non-fetchable during user rebalance handler; pre-revoke unsubscribed topic partitions in prepare
