### PR TITLE
KIP-699: FindCoordinatorRequest v4 -- multi-group support

### DIFF
--- a/kafka/admin/_groups.py
+++ b/kafka/admin/_groups.py
@@ -72,13 +72,20 @@ class GroupAdminMixin:
         return results
 
     async def _async_describe_groups(self, group_ids, group_coordinator_id=None):
+        # Bucket groups by coordinator. One DescribeGroups per coordinator.
+        coordinators_groups = defaultdict(list)
+        if group_coordinator_id is not None:
+            coordinators_groups[group_coordinator_id] = list(group_ids)
+        else:
+            coordinator_ids = await self._find_coordinator_ids(group_ids)
+            for group_id, coordinator_id in coordinator_ids.items():
+                coordinators_groups[coordinator_id].append(group_id)
+
         results = {}
-        for group_id in group_ids:
-            coordinator_id = group_coordinator_id or await self._find_coordinator_id(group_id)
-            request = self._describe_groups_request(group_id)
+        for coordinator_id, coordinator_group_ids in coordinators_groups.items():
+            request = self._describe_groups_request(coordinator_group_ids)
             response = await self._manager.send(request, node_id=coordinator_id)
             results.update(self._describe_groups_process_response(response))
-        # Combine key/vals from multiple requests into single dict
         return results
 
     def describe_groups(self, group_ids, group_coordinator_id=None, include_authorized_operations=False):
@@ -251,8 +258,8 @@ class GroupAdminMixin:
     async def _async_list_group_offsets(self, group_specs):
         # Bucket groups by coordinator. One OffsetFetch per coordinator.
         coordinators_groups = defaultdict(list)
-        for group_id in group_specs:
-            coordinator_id = await self._find_coordinator_id(group_id)
+        coordinator_ids = await self._find_coordinator_ids(list(group_specs))
+        for group_id, coordinator_id in coordinator_ids.items():
             coordinators_groups[coordinator_id].append(group_id)
 
         results = {}
@@ -317,8 +324,8 @@ class GroupAdminMixin:
         if group_coordinator_id is not None:
             coordinators_groups[group_coordinator_id] = group_ids
         else:
-            for group_id in group_ids:
-                coordinator_id = await self._find_coordinator_id(group_id)
+            coordinator_ids = await self._find_coordinator_ids(group_ids)
+            for group_id, coordinator_id in coordinator_ids.items():
                 coordinators_groups[coordinator_id].append(group_id)
 
         results = []

--- a/kafka/admin/_groups.py
+++ b/kafka/admin/_groups.py
@@ -464,7 +464,6 @@ class GroupAdminMixin:
         if group_coordinator_id is None:
             group_coordinator_id = await self._find_coordinator_id(group_id)
 
-        #import pdb; pdb.set_trace()
         current = (await self._async_list_group_offsets({group_id: list(all_tps)}))[group_id]
         earliest = await self._async_list_partition_offsets({tp: OffsetSpec.EARLIEST for tp in all_tps})
         latest = await self._async_list_partition_offsets({tp: OffsetSpec.LATEST for tp in all_tps})

--- a/kafka/admin/_groups.py
+++ b/kafka/admin/_groups.py
@@ -37,16 +37,15 @@ class GroupAdminMixin:
 
     # -- Describe groups ----------------------------------------------
 
-    def _describe_groups_request(self, group_id):
+    def _describe_groups_request(self, group_ids):
         request = DescribeGroupsRequest(
-            groups=[group_id],
+            groups=list(group_ids),
             include_authorized_operations=True
         )
         return request
 
     def _describe_groups_process_response(self, response):
         """Process a DescribeGroupsResponse into a group description."""
-        assert len(response.groups) == 1
         for group in response.groups:
             for member in group.members:
                 if member.member_metadata:

--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -280,24 +280,59 @@ class KafkaAdminClient(
         else:
             raise Errors.NodeNotReadyError('controller')
 
-    async def _find_coordinator_id(self, group_id):
-        """Find the broker node_id of the coordinator for a consumer group.
+    async def _find_coordinator_ids(self, group_ids):
+        """Find broker node_ids of the coordinators for a set of consumer groups.
 
-        Results are cached; subsequent calls for the same group_id return
-        the cached value without a network round-trip.
+        Returns a dict mapping group_id -> node_id. Results are cached;
+        only groups not already in the cache hit the network. On brokers
+        supporting FindCoordinator v4+ (KIP-699, Apache Kafka 3.0+), all
+        unknown groups are resolved in a single batched request; older brokers
+        fall back to one request per group.
         """
-        cached = self._coordinator_cache.get(group_id)
-        if cached is not None:
-            return cached
-        request = FindCoordinatorRequest(group_id, 0, max_version=2)  # key_type=0 for group
-        response = await self._manager.send(request)
-        error_type = Errors.for_code(response.error_code)
-        if error_type is not Errors.NoError:
-            raise error_type(
-                "FindCoordinatorRequest failed with response '{}'."
-                .format(response))
-        self._coordinator_cache[group_id] = response.node_id
-        return response.node_id
+        result = {}
+        unknown = []
+        for group_id in group_ids:
+            cached = self._coordinator_cache.get(group_id)
+            if cached is not None:
+                result[group_id] = cached
+            else:
+                unknown.append(group_id)
+        if not unknown:
+            return result
+
+        if self._manager.broker_version_data.api_version(FindCoordinatorRequest) >= 4:
+            request = FindCoordinatorRequest(key_type=0,  # group
+                                             coordinator_keys=unknown,
+                                             min_version=4)
+            response = await self._manager.send(request)
+            for coordinator in response.coordinators:
+                error_type = Errors.for_code(coordinator.error_code)
+                if error_type is not Errors.NoError:
+                    raise error_type(
+                        "FindCoordinatorRequest failed for group '{}': {}"
+                        .format(coordinator.key, coordinator.error_message))
+                self._coordinator_cache[coordinator.key] = coordinator.node_id
+                result[coordinator.key] = coordinator.node_id
+        else:
+            # Broker does not support batch api; fan-out request per-group
+            for group_id in unknown:
+                request = FindCoordinatorRequest(key=group_id,
+                                                 key_type=0,  # group
+                                                 max_version=3)
+                response = await self._manager.send(request)
+                error_type = Errors.for_code(response.error_code)
+                if error_type is not Errors.NoError:
+                    raise error_type(
+                        "FindCoordinatorRequest failed with response '{}'."
+                        .format(response))
+                self._coordinator_cache[group_id] = response.node_id
+                result[group_id] = response.node_id
+        return result
+
+    async def _find_coordinator_id(self, group_id):
+        """Single-group wrapper for _find_coordinator_ids()"""
+        ids = await self._find_coordinator_ids([group_id])
+        return ids[group_id]
 
     async def _send_request_to_controller(self, request, get_errors_fn=lambda r: (), raise_errors=True, ignore_errors=()):
         """Send a Kafka protocol message to the cluster controller.

--- a/kafka/coordinator/base.py
+++ b/kafka/coordinator/base.py
@@ -789,10 +789,13 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
         if node_id is None:
             raise Errors.NodeNotReadyError('coordinator')
 
-        max_version = 3
+        # Setting key, key_type, and coordinator_keys all at once lets the
+        # connection layer negotiate any version: v0-v3 emit `key`/`key_type`,
+        # v4+ (KIP-699) emit `key_type`/`coordinator_keys`.
         request = FindCoordinatorRequest(
             key=self.group_id,
-            max_version=max_version)
+            key_type=0,
+            coordinator_keys=[self.group_id])
         log.debug("Sending group coordinator request for group %s to broker %s: %s",
                   self.group_id, node_id, request)
 
@@ -806,10 +809,13 @@ class BaseCoordinator(metaclass=abc.ABCMeta):
     def _handle_find_coordinator_response(self, response):
         log.debug("Received find coordinator response %s", response)
 
-        error_type = Errors.for_code(response.error_code)
+        # v4+ returns results in a Coordinators array; we always send a single
+        # key, so the first entry is ours. v0-v3 returns top-level fields.
+        result = response.coordinators[0] if response.coordinators else response
+        error_type = Errors.for_code(result.error_code)
         if error_type is Errors.NoError:
             with self._lock:
-                coordinator_id = self._cluster.add_coordinator(response, 'group', self.group_id)
+                coordinator_id = self._cluster.add_coordinator(result, 'group', self.group_id)
                 if not coordinator_id:
                     # This could happen if coordinator metadata is different
                     # than broker metadata

--- a/kafka/producer/transaction_manager.py
+++ b/kafka/producer/transaction_manager.py
@@ -1075,10 +1075,13 @@ class FindCoordinatorHandler(TxnRequestHandler):
             coord_type_int8 = 1
         else:
             raise ValueError("Unrecognized coordinator type: %s" % (coord_type,))
+        # Setting key, key_type, and coordinator_keys all at once lets the
+        # connection layer negotiate any version: v0-v3 emit `key`/`key_type`,
+        # v4+ (KIP-699) emit `key_type`/`coordinator_keys`.
         self.request = FindCoordinatorRequest(
             key=coord_key,
             key_type=coord_type_int8,
-            max_version=3,
+            coordinator_keys=[coord_key],
         )
 
     @property
@@ -1094,11 +1097,14 @@ class FindCoordinatorHandler(TxnRequestHandler):
         return None
 
     def handle_response(self, response):
-        error_type = Errors.for_code(response.error_code)
+        # v4+ returns results in a Coordinators array; we always send a single
+        # key, so the first entry is ours. v0-v3 returns top-level fields.
+        result = response.coordinators[0] if response.coordinators else response
+        error_type = Errors.for_code(result.error_code)
 
         if error_type is Errors.NoError:
             coordinator_id = self.transaction_manager._metadata.add_coordinator(
-                response, self._coord_type, self._coord_key)
+                result, self._coord_type, self._coord_key)
             if self._coord_type == 'group':
                 self.transaction_manager._consumer_group_coordinator = coordinator_id
             elif self._coord_type == 'transaction':

--- a/test/admin/test_admin_groups.py
+++ b/test/admin/test_admin_groups.py
@@ -12,7 +12,11 @@ from kafka.errors import (
     UnknownMemberIdError,
     UnsupportedVersionError,
 )
-from kafka.protocol.admin import ListGroupsRequest, ListGroupsResponse
+from kafka.protocol.admin import (
+    DeleteGroupsRequest, DeleteGroupsResponse,
+    DescribeGroupsRequest, DescribeGroupsResponse,
+    ListGroupsRequest, ListGroupsResponse,
+)
 from kafka.protocol.consumer import (
     LeaveGroupRequest, LeaveGroupResponse,
     ListOffsetsRequest, ListOffsetsResponse,
@@ -26,6 +30,24 @@ from kafka.protocol.metadata import (
 )
 from kafka.protocol.consumer.group import DEFAULT_GENERATION_ID, UNKNOWN_MEMBER_ID
 from kafka.structs import OffsetAndMetadata, TopicPartition
+
+
+def _find_coordinator_response(group_id, node_id=0):
+    """Build a FindCoordinatorResponse that decodes correctly at any version.
+
+    Sets both the v0-v3 top-level fields and the v4+ coordinators array;
+    the encoder picks whichever shape matches the negotiated version.
+    """
+    Coordinator = FindCoordinatorResponse.Coordinator
+    return FindCoordinatorResponse(
+        throttle_time_ms=0,
+        error_code=0,
+        error_message=None,
+        node_id=node_id, host='localhost', port=9092,
+        coordinators=[Coordinator(
+            key=group_id, node_id=node_id, host='localhost', port=9092,
+            error_code=0, error_message=None)],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -586,7 +608,7 @@ def _offset_commit_response(partitions):
 class TestResetGroupOffsetsMockBroker:
     def test_clamps_explicit_offset_above_latest(self, broker, admin):
         _set_metadata_for_topic(broker, 'topic-a', num_partitions=1)
-        broker.respond(FindCoordinatorRequest, FindCoordinatorResponse(node_id=0)),
+        broker.respond(FindCoordinatorRequest, _find_coordinator_response('g1')),
         broker.respond(OffsetFetchRequest, _offset_fetch_response(
             [('topic-a', 0, 50, '', 0)]))
         # Bounds: earliest=10, latest=100
@@ -615,7 +637,7 @@ class TestResetGroupOffsetsMockBroker:
 
     def test_clamps_explicit_offset_below_earliest(self, broker, admin):
         _set_metadata_for_topic(broker, 'topic-a', num_partitions=1)
-        broker.respond(FindCoordinatorRequest, FindCoordinatorResponse(node_id=0)),
+        broker.respond(FindCoordinatorRequest, _find_coordinator_response('g1')),
         broker.respond(OffsetFetchRequest, _offset_fetch_response(
             [('topic-a', 0, 50, '', 0)]))
         broker.respond(ListOffsetsRequest, _list_offsets_response(
@@ -643,7 +665,7 @@ class TestResetGroupOffsetsMockBroker:
     def test_clamps_unknown_offset_to_latest(self, broker, admin):
         # Simulate a timestamp beyond the last record: ListOffsets returns -1.
         _set_metadata_for_topic(broker, 'topic-a', num_partitions=1)
-        broker.respond(FindCoordinatorRequest, FindCoordinatorResponse(node_id=0)),
+        broker.respond(FindCoordinatorRequest, _find_coordinator_response('g1')),
         broker.respond(OffsetFetchRequest, _offset_fetch_response(
             [('topic-a', 0, 50, '', 0)]))
         broker.respond(ListOffsetsRequest, _list_offsets_response(
@@ -672,7 +694,7 @@ class TestResetGroupOffsetsMockBroker:
 
     def test_offset_in_range_not_clamped(self, broker, admin):
         _set_metadata_for_topic(broker, 'topic-a', num_partitions=1)
-        broker.respond(FindCoordinatorRequest, FindCoordinatorResponse(node_id=0)),
+        broker.respond(FindCoordinatorRequest, _find_coordinator_response('g1')),
         broker.respond(OffsetFetchRequest, _offset_fetch_response(
             [('topic-a', 0, 50, 'm', 3)]))
         broker.respond(ListOffsetsRequest, _list_offsets_response(
@@ -833,3 +855,222 @@ class TestListGroupOffsetsMockBroker:
         assert sorted(captured['group_ids']) == ['g1', 'g2']
         assert captured['api_version'] == 7  # negotiated to v7 on 2.8
         assert set(result.keys()) == {'g1', 'g2'}
+
+
+# ---------------------------------------------------------------------------
+# FindCoordinator batching (KIP-699 / v4)
+# ---------------------------------------------------------------------------
+
+
+def _empty_describe_groups_response(group_ids):
+    Group = DescribeGroupsResponse.DescribedGroup
+    if isinstance(group_ids, str):
+        group_ids = [group_ids]
+    return DescribeGroupsResponse(
+        throttle_time_ms=0,
+        groups=[Group(
+            error_code=0, error_message=None,
+            group_id=gid, group_state='Empty',
+            protocol_type='consumer', protocol_data='',
+            members=[], authorized_operations=set()) for gid in group_ids])
+
+
+def _delete_groups_response(group_ids):
+    Result = DeleteGroupsResponse.DeletableGroupResult
+    return DeleteGroupsResponse(
+        throttle_time_ms=0,
+        results=[Result(group_id=g, error_code=0) for g in group_ids])
+
+
+class TestFindCoordinatorBatched:
+    def test_v4_batched_single_request_for_many_groups(self, broker, admin):
+        captured = {}
+
+        def find_handler(api_key, api_version, correlation_id, request_bytes):
+            req = FindCoordinatorRequest.decode(
+                request_bytes, version=api_version, header=True)
+            captured['api_version'] = api_version
+            captured['key_type'] = req.key_type
+            captured['coordinator_keys'] = list(req.coordinator_keys)
+            captured['count'] = captured.get('count', 0) + 1
+            Coordinator = FindCoordinatorResponse.Coordinator
+            return FindCoordinatorResponse(
+                throttle_time_ms=0,
+                error_code=0, error_message=None,
+                node_id=0, host='localhost', port=9092,
+                coordinators=[Coordinator(
+                    key=k, node_id=0, host='localhost', port=9092,
+                    error_code=0, error_message=None) for k in req.coordinator_keys])
+
+        broker.respond_fn(FindCoordinatorRequest, find_handler)
+        broker.respond(DescribeGroupsRequest,
+                       _empty_describe_groups_response(['g1', 'g2', 'g3']))
+
+        admin.describe_groups(['g1', 'g2', 'g3'])
+
+        assert captured['count'] == 1
+        assert captured['api_version'] >= 4
+        assert captured['key_type'] == 0
+        assert sorted(captured['coordinator_keys']) == ['g1', 'g2', 'g3']
+        assert admin._coordinator_cache == {'g1': 0, 'g2': 0, 'g3': 0}
+
+    def test_v4_batched_per_key_error_raises(self, broker, admin):
+        def find_handler(api_key, api_version, correlation_id, request_bytes):
+            req = FindCoordinatorRequest.decode(
+                request_bytes, version=api_version, header=True)
+            Coordinator = FindCoordinatorResponse.Coordinator
+            coordinators = []
+            for key in req.coordinator_keys:
+                if key == 'g2':
+                    coordinators.append(Coordinator(
+                        key=key, node_id=-1, host='', port=-1,
+                        error_code=Errors.GroupAuthorizationFailedError.errno,
+                        error_message='nope'))
+                else:
+                    coordinators.append(Coordinator(
+                        key=key, node_id=0, host='localhost', port=9092,
+                        error_code=0, error_message=None))
+            return FindCoordinatorResponse(
+                throttle_time_ms=0,
+                error_code=0, error_message=None,
+                node_id=0, host='localhost', port=9092,
+                coordinators=coordinators)
+
+        broker.respond_fn(FindCoordinatorRequest, find_handler)
+        with pytest.raises(Errors.GroupAuthorizationFailedError):
+            admin.describe_groups(['g1', 'g2'])
+
+    @pytest.mark.parametrize("broker", [(2, 8, 0)], indirect=True)
+    def test_v3_fallback_issues_one_request_per_group(self, broker, admin):
+        # Kafka 2.8 caps FindCoordinator at v3 -> no batch, fan out one request
+        # per group with the single-key shape.
+        captured = {'count': 0, 'keys': [], 'used_coordinator_keys': []}
+
+        def find_handler(api_key, api_version, correlation_id, request_bytes):
+            req = FindCoordinatorRequest.decode(
+                request_bytes, version=api_version, header=True)
+            captured['count'] += 1
+            captured['api_version'] = api_version
+            captured['keys'].append(req.key)
+            captured['used_coordinator_keys'].append(list(req.coordinator_keys))
+            return _find_coordinator_response(req.key, node_id=0)
+
+        broker.respond_fn(FindCoordinatorRequest, find_handler)
+        broker.respond_fn(FindCoordinatorRequest, find_handler)
+        broker.respond_fn(FindCoordinatorRequest, find_handler)
+        broker.respond(DescribeGroupsRequest,
+                       _empty_describe_groups_response(['g1', 'g2', 'g3']))
+
+        admin.describe_groups(['g1', 'g2', 'g3'])
+
+        assert captured['count'] == 3
+        assert captured['api_version'] == 3
+        assert sorted(captured['keys']) == ['g1', 'g2', 'g3']
+        assert captured['used_coordinator_keys'] == [[], [], []]  # v3 has no batch field
+
+    def test_cache_reuse_skips_already_resolved_groups(self, broker, admin):
+        admin._coordinator_cache['g1'] = 0
+        captured = {}
+
+        def find_handler(api_key, api_version, correlation_id, request_bytes):
+            req = FindCoordinatorRequest.decode(
+                request_bytes, version=api_version, header=True)
+            captured['coordinator_keys'] = list(req.coordinator_keys)
+            Coordinator = FindCoordinatorResponse.Coordinator
+            return FindCoordinatorResponse(
+                throttle_time_ms=0,
+                error_code=0, error_message=None,
+                node_id=0, host='localhost', port=9092,
+                coordinators=[Coordinator(
+                    key=k, node_id=0, host='localhost', port=9092,
+                    error_code=0, error_message=None) for k in req.coordinator_keys])
+
+        broker.respond_fn(FindCoordinatorRequest, find_handler)
+        broker.respond(DescribeGroupsRequest,
+                       _empty_describe_groups_response(['g1', 'g2']))
+
+        admin.describe_groups(['g1', 'g2'])
+
+        # Only g2 should have hit the network; g1 came from the cache.
+        assert captured['coordinator_keys'] == ['g2']
+        assert admin._coordinator_cache == {'g1': 0, 'g2': 0}
+
+    def test_delete_groups_uses_batched_lookup(self, broker, admin):
+        captured = {}
+
+        def find_handler(api_key, api_version, correlation_id, request_bytes):
+            req = FindCoordinatorRequest.decode(
+                request_bytes, version=api_version, header=True)
+            captured['coordinator_keys'] = list(req.coordinator_keys)
+            captured['count'] = captured.get('count', 0) + 1
+            Coordinator = FindCoordinatorResponse.Coordinator
+            return FindCoordinatorResponse(
+                throttle_time_ms=0,
+                error_code=0, error_message=None,
+                node_id=0, host='localhost', port=9092,
+                coordinators=[Coordinator(
+                    key=k, node_id=0, host='localhost', port=9092,
+                    error_code=0, error_message=None) for k in req.coordinator_keys])
+
+        broker.respond_fn(FindCoordinatorRequest, find_handler)
+        broker.respond(DeleteGroupsRequest, _delete_groups_response(['g1', 'g2']))
+
+        result = admin.delete_groups(['g1', 'g2'])
+
+        assert captured['count'] == 1
+        assert sorted(captured['coordinator_keys']) == ['g1', 'g2']
+        assert result == {'g1': 'OK', 'g2': 'OK'}
+
+    def test_list_group_offsets_uses_batched_lookup(self, broker, admin):
+        captured = {}
+
+        def find_handler(api_key, api_version, correlation_id, request_bytes):
+            req = FindCoordinatorRequest.decode(
+                request_bytes, version=api_version, header=True)
+            captured['coordinator_keys'] = list(req.coordinator_keys)
+            captured['count'] = captured.get('count', 0) + 1
+            Coordinator = FindCoordinatorResponse.Coordinator
+            return FindCoordinatorResponse(
+                throttle_time_ms=0,
+                error_code=0, error_message=None,
+                node_id=0, host='localhost', port=9092,
+                coordinators=[Coordinator(
+                    key=k, node_id=0, host='localhost', port=9092,
+                    error_code=0, error_message=None) for k in req.coordinator_keys])
+
+        _Group = OffsetFetchResponse.OffsetFetchResponseGroup
+        broker.respond_fn(FindCoordinatorRequest, find_handler)
+        broker.respond(OffsetFetchRequest, OffsetFetchResponse(
+            throttle_time_ms=0, error_code=0, topics=[],
+            groups=[
+                _Group(group_id='g1', error_code=0, topics=[]),
+                _Group(group_id='g2', error_code=0, topics=[]),
+            ]))
+
+        admin.list_group_offsets(['g1', 'g2'])
+
+        assert captured['count'] == 1
+        assert sorted(captured['coordinator_keys']) == ['g1', 'g2']
+
+    def test_describe_groups_batches_request_per_coordinator(self, broker, admin):
+        # All three groups share coordinator 0, so describe_groups should send
+        # exactly one DescribeGroups containing all three group_ids.
+        admin._coordinator_cache['g1'] = 0
+        admin._coordinator_cache['g2'] = 0
+        admin._coordinator_cache['g3'] = 0
+        captured = {'count': 0, 'groups_per_request': []}
+
+        def describe_handler(api_key, api_version, correlation_id, request_bytes):
+            req = DescribeGroupsRequest.decode(
+                request_bytes, version=api_version, header=True)
+            captured['count'] += 1
+            captured['groups_per_request'].append(list(req.groups))
+            return _empty_describe_groups_response(list(req.groups))
+
+        broker.respond_fn(DescribeGroupsRequest, describe_handler)
+
+        result = admin.describe_groups(['g1', 'g2', 'g3'])
+
+        assert captured['count'] == 1
+        assert sorted(captured['groups_per_request'][0]) == ['g1', 'g2', 'g3']
+        assert set(result.keys()) == {'g1', 'g2', 'g3'}

--- a/test/producer/test_transaction_manager_mock_broker.py
+++ b/test/producer/test_transaction_manager_mock_broker.py
@@ -612,6 +612,9 @@ class TestAddPartitionsToTxnHandlerMockBroker:
 class TestFindCoordinatorHandlerMockBroker:
 
     def _response(self, error_code=0, node_id=0, host='localhost', port=9092):
+        # Set both the v0-v3 top-level fields and the v4+ Coordinators array so
+        # the encoder picks the right shape regardless of the negotiated version.
+        Coordinator = FindCoordinatorResponse.Coordinator
         return FindCoordinatorResponse(
             throttle_time_ms=0,
             error_code=error_code,
@@ -619,7 +622,9 @@ class TestFindCoordinatorHandlerMockBroker:
             node_id=node_id,
             host=host,
             port=port,
-            coordinators=[],
+            coordinators=[Coordinator(
+                key=_TXN_ID, node_id=node_id, host=host, port=port,
+                error_code=error_code, error_message='')],
         )
 
     @pytest.mark.parametrize("error", [


### PR DESCRIPTION
- Support multi-group DescribeGroupRequests
- Add _find_coordinator_ids(); _find_coordinator_id becomes simple wrapper
- Use _find_coordinator_ids() to batch lookups in groups admin apis
- fixup
- Use FindCoordinatorRequest v4 in consumer/coordinator
- Use FindCoordinatorRequest v4 in producer
