### PR TITLE
kafka.net: support socket_connection_setup_timeout_ms w/ exp backoff (KIP-601)

### DIFF
--- a/kafka/net/connection.py
+++ b/kafka/net/connection.py
@@ -269,7 +269,6 @@ class KafkaConnection:
             client_id=self.config['client_id'],
             receive_message_max_bytes=self.config['receive_message_max_bytes'],
             ident=log_prefix)
-        self.net.call_soon(self._check_version)
 
     def pause(self, v):
         self.paused.add(v)
@@ -345,18 +344,28 @@ class KafkaConnection:
             self._throttle_time = 0
             self.unpause('throttle')
 
-    async def _check_version(self, timeout_ms=None):
+    async def initialize(self, timeout_at=None):
+        if timeout_at is None:
+            timeout_at = self._timeout_at()
+        try:
+            await self._get_api_versions(timeout_at)
+            if self.sasl_enabled:
+                await self._sasl_authenticate(timeout_at)
+        except Exception as error:
+            self.close(error)
+        else:
+            self._init_complete()
+
+    async def _get_api_versions(self, timeout_at=None):
+        if timeout_at is None:
+            timeout_at = self._timeout_at()
         if self.broker_version_data is not None:
             try:
                 self._api_versions_idx = self.broker_version_data.api_version(ApiVersionsRequest)
             except Errors.IncompatibleBrokerVersion:
                 log.debug('%s: Using pre-configured api_version %s for ApiVersions', self, self.broker_version)
-                self._init_complete()
                 return
 
-        if timeout_ms is not None:
-            timeout_ms = self.config['api_version_auto_timeout_ms']
-        timeout_at = self._timeout_at(timeout_ms=timeout_ms)
         while timeout_at > time.monotonic():
             version = self._api_versions_idx
             request = ApiVersionsRequest(
@@ -364,12 +373,7 @@ class KafkaConnection:
                 client_software_name=self.config['client_software_name'],
                 client_software_version=self.config['client_software_version'],
             )
-            try:
-                response = await self._send_request(request, timeout_at=timeout_at)
-            except Exception as exc:
-                self.close(exc)
-                return
-
+            response = await self._send_request(request, timeout_at=timeout_at)
             error_type = Errors.for_code(response.error_code)
             if error_type is Errors.NoError:
                 break
@@ -382,44 +386,36 @@ class KafkaConnection:
                     self._api_versions_idx = 0
                 continue
             else:
-                self.close(error_type())
-                return
+                raise error_type()
+        else:
+            raise Errors.KafkaTimeoutError('Timeout during ApiVersions check')
 
         api_versions = {api_version.api_key: (api_version.min_version, api_version.max_version)
                         for api_version in response.api_keys}
         self.broker_version_data = BrokerVersionData(api_versions=api_versions)
         log.info('%s: Broker version identified as %s', self, '.'.join(map(str, self.broker_version)))
-        if self.sasl_enabled:
-            await self._sasl_authenticate()
-        if self.initializing:
-            self._init_complete()
 
     @property
     def sasl_enabled(self):
         return self.config['security_protocol'] in ('SASL_PLAINTEXT', 'SASL_SSL')
 
-    async def _sasl_authenticate(self):
+    async def _sasl_authenticate(self, timeout_at=None):
+        if timeout_at is None:
+            timeout_at = self._timeout_at()
         # Step 1: SaslHandshake to negotiate mechanism
         request = SaslHandshakeRequest(
             mechanism=self.config['sasl_mechanism'],
             max_version=1)
-        try:
-            response = await self._send_request(request)
-        except Exception as exc:
-            self.close(Errors.KafkaConnectionError('SaslHandshake failed: %s' % exc))
-            return
-
+        response = await self._send_request(request, timeout_at=timeout_at)
         error_type = Errors.for_code(response.error_code)
         if error_type is not Errors.NoError:
             log.error('%s: SaslHandshake failed: %s', self, error_type.__name__)
-            self.close(error_type())
-            return
+            raise error_type()
 
         if self.config['sasl_mechanism'] not in response.mechanisms:
-            self.close(Errors.UnsupportedSaslMechanismError(
+            raise Errors.UnsupportedSaslMechanismError(
                 'Kafka broker does not support %s sasl mechanism. Enabled mechanisms: %s'
-                % (self.config['sasl_mechanism'], response.mechanisms)))
-            return
+                % (self.config['sasl_mechanism'], response.mechanisms))
 
         # Step 2: SASL authentication exchange
         version = response.API_VERSION
@@ -427,47 +423,37 @@ class KafkaConnection:
         # mechanisms like GSSAPI construct service principals against the
         # user-supplied name, not whichever IP getaddrinfo handed us.
         sasl_host = self.transport.host if self.transport.host else self.transport.getPeer()[0]
-        try:
-            mechanism = get_sasl_mechanism(self.config['sasl_mechanism'])(
-                host=sasl_host, **self.config)
-        except Exception as exc:
-            self.close(exc)
-            return
+        mechanism = get_sasl_mechanism(self.config['sasl_mechanism'])(
+            host=sasl_host, **self.config)
 
-        while not mechanism.is_done():
+        while not mechanism.is_done() and timeout_at > time.monotonic():
             token = mechanism.auth_bytes()
             if version == 1:
                 auth_request = SaslAuthenticateRequest(token, version=0)
             else:
                 auth_request = SaslBytesRequest(token)
-
-            try:
-                auth_response = await self._send_request(auth_request)
-            except Exception as exc:
-                self.close(Errors.KafkaConnectionError('SaslAuthenticate failed: %s' % exc))
-                return
-
+            auth_response = await self._send_request(auth_request, timeout_at=timeout_at)
             error_type = Errors.for_code(auth_response.error_code)
             if error_type is not Errors.NoError:
-                self.close(Errors.SaslAuthenticationFailedError(
-                    '%s: %s' % (error_type.__name__, auth_response.error_message)))
-                return
+                raise Errors.SaslAuthenticationFailedError(
+                    '%s: %s' % (error_type.__name__, auth_response.error_message))
 
             # GSSAPI does not get a final recv in v0 unframed mode
             if version == 0 and mechanism.is_done():
                 break
-
             mechanism.receive(auth_response.auth_bytes)
 
-        if not mechanism.is_authenticated():
-            self.close(Errors.SaslAuthenticationFailedError(
-                'Failed to authenticate via SASL %s' % self.config['sasl_mechanism']))
-            return
+        if time.monotonic() > timeout_at:
+            raise Errors.KafkaTimeoutError('SASL Authentication timed out')
+        elif not mechanism.is_authenticated():
+            raise Errors.SaslAuthenticationFailedError(
+                'Failed to authenticate via SASL %s' % self.config['sasl_mechanism'])
 
         log.info('%s: %s', self, mechanism.auth_details())
 
     def _init_complete(self):
-        self.initializing = False
-        self.connected = True
-        self.send_buffered()
-        self._init_future.success(True)
+        if self.initializing:
+            self.initializing = False
+            self.connected = True
+            self.send_buffered()
+            self._init_future.success(True)

--- a/kafka/net/inet.py
+++ b/kafka/net/inet.py
@@ -1,6 +1,7 @@
 import errno
 import logging
 import socket
+import time
 from urllib.parse import urlparse
 
 import kafka.errors as Errors
@@ -9,7 +10,7 @@ import kafka.errors as Errors
 log = logging.getLogger(__name__)
 
 
-async def create_connection(net, host, port, socket_options=(), proxy_url=None):
+async def create_connection(net, host, port, socket_options=(), proxy_url=None, timeout_at=None):
     """Connect to host:port; raises KafkaConnectionError on failure"""
     socket_factory = KafkaNetSocket(proxy_url)
     addrs = socket_factory.dns_lookup(host, port)
@@ -17,10 +18,12 @@ async def create_connection(net, host, port, socket_options=(), proxy_url=None):
     for res in addrs:
         try:
             log.debug('%s: Attempting to connect to %s (options: %s)', socket_factory, res, socket_options)
-            sock = await socket_factory.connect(net, res, socket_options)
+            sock = await socket_factory.connect(net, res, socket_options, timeout_at=timeout_at)
         except (socket.error, OSError) as e:
             exceptions.append(Errors.KafkaConnectionError('unable to connect: %s' % (e,)))
             continue
+        except Errors.KafkaTimeoutError:
+            raise Errors.KafkaConnectionError('Connection timed out')
         except Errors.KafkaConnectionError as e:
             exceptions.append(e)
             continue
@@ -79,17 +82,17 @@ class KafkaNetSocket:
     def socket(self, family=socket.AF_UNSPEC, sock_type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP):
         return socket.socket(family, sock_type, proto)
 
-    async def connect(self, net, addrinfo, socket_options=()):
+    async def connect(self, net, addrinfo, socket_options=(), timeout_at=None):
         """Create non-blocking socket (with options) and connect to addrinfo tuple"""
         family, sock_type, proto, _canonname, sockaddr = addrinfo
         sock = self.socket(family, sock_type, proto)
         sock.setblocking(False)
         for option in socket_options:
             sock.setsockopt(*option)
-        return await self.sock_connect(net, sock, sockaddr)
+        return await self.sock_connect(net, sock, sockaddr, timeout_at=timeout_at)
 
-    async def sock_connect(self, net, sock, sockaddr):
-        while True:
+    async def sock_connect(self, net, sock, sockaddr, timeout_at=None):
+        while timeout_at is None or time.monotonic() < timeout_at:
             ret = None
             try:
                 ret = self.connect_ex(sock, sockaddr)
@@ -112,6 +115,8 @@ class KafkaNetSocket:
             else:
                 errstr = errno.errorcode.get(ret, 'UNKNOWN')
                 raise Errors.KafkaConnectionError('{} {}'.format(ret, errstr))
+        else:
+            raise Errors.KafkaTimeoutError('Connection timed out')
 
     def connect_ex(self, sock, sockaddr):
         return sock.connect_ex(sockaddr)

--- a/kafka/net/inet.py
+++ b/kafka/net/inet.py
@@ -109,7 +109,7 @@ class KafkaNetSocket:
             # Needs retry
             # WSAEINVAL == 10022, but errno.WSAEINVAL is not available on non-win systems
             elif ret in (errno.EINPROGRESS, errno.EALREADY, errno.EWOULDBLOCK, 10022):
-                await net.wait_write(sock)
+                await net.wait_write(sock, timeout_at=timeout_at)
 
             # Connection failed
             else:

--- a/kafka/net/manager.py
+++ b/kafka/net/manager.py
@@ -120,7 +120,9 @@ class KafkaConnectionManager:
             bootstrap_broker = random.choice(self.cluster.bootstrap_brokers())
             log.debug('Attempting bootstrap with %s', bootstrap_broker)
             try:
+                timeout_ms = (deadline - time.monotonic()) * 1000 if deadline is not None else None
                 conn = self.get_connection(bootstrap_broker.node_id,
+                                           timeout_ms=timeout_ms,
                                            pop_on_close=False,
                                            refresh_metadata_on_err=False,
                                            reset_backoff_on_connect=False)

--- a/kafka/net/manager.py
+++ b/kafka/net/manager.py
@@ -30,7 +30,8 @@ class KafkaConnectionManager:
         'reconnect_backoff_ms': 50,
         'reconnect_backoff_max_ms': 30000,
         'request_timeout_ms': 30000,
-        'socket_connection_timeout_ms': 5000,
+        'socket_connection_setup_timeout_ms': 10000,
+        'socket_connection_setup_timeout_max_ms': 30000,
         'socket_options': [
             (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),
             (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
@@ -86,7 +87,7 @@ class KafkaConnectionManager:
         )
         self.cluster.attach(self)
         self._conns = {}
-        self._backoff = dict() # node_id => (failures, backoff_until)
+        self._backoff = dict() # node_id => (failures, backoff_until, socket_connect_setup_timeout_ms)
         # Cache the most recent SASL / SSL / auth failure per node so we can
         # surface it to the user instead of silently retrying forever.
         # Cleared on successful connect.
@@ -282,7 +283,7 @@ class KafkaConnectionManager:
             conn.close_future.add_errback(lambda _: self.cluster.request_update())
         self._conns[node_id] = conn
         if timeout_ms is None:
-            timeout_ms = self.config['socket_connection_timeout_ms']
+            timeout_ms = self.socket_connection_setup_timeout_ms(node_id)
         timeout_at = time.monotonic() + timeout_ms / 1000
         self._net.call_soon(lambda: self._connect(node, conn, reset_backoff_on_connect=reset_backoff_on_connect, timeout_at=timeout_at))
         return conn
@@ -334,18 +335,29 @@ class KafkaConnectionManager:
         except KeyError:
             pass
 
-    def reconnect_jitter_pct(self):
+    def jitter_pct(self):
         return random.uniform(0.8, 1.2)
 
+    def _calculate_exp_timeout(self, key, failures):
+        max_keys = {
+            'reconnect_backoff_ms': 'reconnect_backoff_max_ms',
+            'socket_connection_setup_timeout_ms': 'socket_connection_setup_timeout_max_ms',
+        }
+        timeout_ms = self.config[key] * 2 ** (failures - 1)
+        if key in max_keys:
+            max_ms = self.config[max_keys[key]]
+            timeout_ms = min(max_ms, timeout_ms)
+        return timeout_ms * self.jitter_pct()
+
     def update_backoff(self, node_id):
-        failures, _ = self._backoff.get(node_id, (0, 0))
+        failures, _, _ = self._backoff.get(node_id, (0, 0, 0))
         failures += 1
-        backoff_ms = self.config['reconnect_backoff_ms'] * 2 ** (failures - 1)
-        backoff_ms = min(backoff_ms, self.config['reconnect_backoff_max_ms'])
-        backoff_ms *= self.reconnect_jitter_pct()
-        log.debug('%s reconnect backoff %d ms after %s failures', node_id, backoff_ms, failures)
+        backoff_ms = self._calculate_exp_timeout('reconnect_backoff_ms', failures)
+        connect_ms = self._calculate_exp_timeout('socket_connection_setup_timeout_ms', failures)
+        log.debug('%s reconnect backoff %d ms / connect timeout %d ms after %s failures',
+                  node_id, backoff_ms, connect_ms, failures)
         backoff_until_time = time.monotonic() + (backoff_ms / 1000)
-        self._backoff[node_id] = (failures, backoff_until_time)
+        self._backoff[node_id] = (failures, backoff_until_time, connect_ms)
 
     def connection_delay(self, node_id):
         """Connection delay in seconds.
@@ -355,6 +367,11 @@ class KafkaConnectionManager:
         if node_id not in self._backoff:
             return 0
         return max(0, self._backoff[node_id][1] - time.monotonic())
+
+    def socket_connection_setup_timeout_ms(self, node_id):
+        if node_id not in self._backoff:
+            return self.config['socket_connection_setup_timeout_ms']
+        return self._backoff[node_id][2]
 
     def auth_failure(self, node_id):
         """Return the most recent auth-class failure for ``node_id``,

--- a/kafka/net/manager.py
+++ b/kafka/net/manager.py
@@ -218,10 +218,11 @@ class KafkaConnectionManager:
             ctx.verify_flags |= ssl.VERIFY_CRL_CHECK_LEAF
         return ctx
 
-    async def _build_transport(self, node):
+    async def _build_transport(self, node, timeout_at=None):
         sock = await create_connection(self._net, node.host, node.port,
                                        self.config['socket_options'],
-                                       proxy_url=self.config['proxy_url'])
+                                       proxy_url=self.config['proxy_url'],
+                                       timeout_at=timeout_at)
         if self.ssl_enabled:
             transport = KafkaSSLTransport(self._net, sock, self._build_ssl_context(),
                                           host=node.host, ssl_check_hostname=self.config['ssl_check_hostname'])
@@ -235,9 +236,9 @@ class KafkaConnectionManager:
         else:
             return transport
 
-    async def _connect(self, node, conn, reset_backoff_on_connect=True):
+    async def _connect(self, node, conn, reset_backoff_on_connect=True, timeout_at=None):
         try:
-            transport = await self._build_transport(node)
+            transport = await self._build_transport(node, timeout_at=timeout_at)
             conn.connection_made(transport)
             await conn.init_future
         except Exception as exc:
@@ -280,12 +281,10 @@ class KafkaConnectionManager:
         if refresh_metadata_on_err:
             conn.close_future.add_errback(lambda _: self.cluster.request_update())
         self._conns[node_id] = conn
-        self._net.call_soon(lambda: self._connect(node, conn, reset_backoff_on_connect=reset_backoff_on_connect))
         if timeout_ms is None:
             timeout_ms = self.config['socket_connection_timeout_ms']
-        self._net.call_later(timeout_ms / 1000,
-                             lambda: conn.close(Errors.KafkaConnectionError('Connection timed out'))
-                                     if not conn.init_future.is_done else None)
+        timeout_at = time.monotonic() + timeout_ms / 1000
+        self._net.call_soon(lambda: self._connect(node, conn, reset_backoff_on_connect=reset_backoff_on_connect, timeout_at=timeout_at))
         return conn
 
     def send(self, request, node_id=None, request_timeout_ms=None):

--- a/kafka/net/manager.py
+++ b/kafka/net/manager.py
@@ -243,7 +243,7 @@ class KafkaConnectionManager:
         try:
             transport = await self._build_transport(node, timeout_at=timeout_at)
             conn.connection_made(transport)
-            await conn.init_future
+            await conn.initialize(timeout_at=timeout_at)
         except Exception as exc:
             log.error('Connection failed: %s', exc)
             conn.connection_lost(exc)

--- a/kafka/net/selector.py
+++ b/kafka/net/selector.py
@@ -62,7 +62,14 @@ class Task:
         return id(self) < id(other)
 
     def __call__(self, arg=None):
-        ret, exc = (None, arg) if isinstance(arg, Exception) else (arg, None)
+        if self.is_done:
+            raise RuntimeError('Task is already done!')
+        elif self._exc is not None:
+            exc, self._exc = self._exc, None
+            ret = None
+        else:
+            ret = None
+            exc = None
         while True:
             coro = self._stack[0]
             if callable(coro) and not inspect.isgenerator(coro) and not inspect.iscoroutine(coro):
@@ -105,6 +112,15 @@ class Task:
 
     def push_stack(self, coro):
         self._stack = (_initialize_coro(coro), self._stack)
+
+    def inject_exc(self, exc):
+        if self.is_done:
+            raise RuntimeError('Task is already done!')
+        elif not isinstance(exc, BaseException):
+            raise TypeError('exc is not a BaseException')
+        elif self._exc is not None:
+            raise RuntimeError('Task exception is already set!')
+        self._exc = exc
 
     @property
     def is_done(self):

--- a/kafka/net/selector.py
+++ b/kafka/net/selector.py
@@ -96,7 +96,7 @@ class Task:
                     self._res = final.value
                     raise
                 else:
-                    #ret = final.value
+                    ret = final.value
                     exc = None
 
             except BaseException as e:

--- a/kafka/net/selector.py
+++ b/kafka/net/selector.py
@@ -378,19 +378,46 @@ class NetworkSelector:
     def _sleep(self, delay):
         self.call_later(delay, self._current)
 
-    def wait_write(self, fileobj):
-        return KernelEvent('_wait_write', fileobj)
+    def wait_write(self, fileobj, timeout_at=None):
+        return KernelEvent('_wait_write', fileobj, timeout_at)
 
-    def _wait_write(self, fileobj):
-        self.register_event(fileobj, selectors.EVENT_WRITE, self._current)
-        self._current.push_stack(lambda: self.unregister_event(fileobj, selectors.EVENT_WRITE))
+    def _wait_write(self, fileobj, timeout_at=None):
+        self._wait_io(fileobj, selectors.EVENT_WRITE, timeout_at)
 
-    def wait_read(self, fileobj):
-        return KernelEvent('_wait_read', fileobj)
+    def wait_read(self, fileobj, timeout_at=None):
+        return KernelEvent('_wait_read', fileobj, timeout_at)
 
-    def _wait_read(self, fileobj):
-        self.register_event(fileobj, selectors.EVENT_READ, self._current)
-        self._current.push_stack(lambda: self.unregister_event(fileobj, selectors.EVENT_READ))
+    def _wait_read(self, fileobj, timeout_at=None):
+        self._wait_io(fileobj, selectors.EVENT_READ, timeout_at)
+
+    def _wait_io(self, fileobj, event, timeout_at):
+        suspended = self._current
+        self.register_event(fileobj, event, suspended)
+        if timeout_at is None or self._closed:
+            suspended.push_stack(lambda: self.unregister_event(fileobj, event))
+            return
+
+        state = {'fired': False, 'timer': None}
+
+        def on_resume():
+            state['fired'] = True
+            if state['timer'] is not None:
+                try:
+                    self.unschedule(state['timer'])
+                except ValueError:
+                    pass
+            self.unregister_event(fileobj, event)
+
+        def on_timeout():
+            if state['fired']:
+                return
+            state['fired'] = True
+            self.unregister_event(fileobj, event)
+            suspended.inject_exc(Errors.KafkaTimeoutError('I/O wait timed out'))
+            self._ready.append(suspended)
+
+        suspended.push_stack(on_resume)
+        state['timer'] = self.call_at(timeout_at, on_timeout)
 
     def _schedule_tasks(self):
         while self._scheduled and self._scheduled[0][0] <= time.monotonic():
@@ -499,7 +526,12 @@ class NetworkSelector:
                 step_start = time.monotonic() if threshold else None
                 try:
                     log_trace('Calling task %s', self._current)
-                    event = self._current()
+                    inject = self._current._exc
+                    if inject is not None:
+                        self._current._exc = None
+                        event = self._current(inject)
+                    else:
+                        event = self._current()
 
                 except StopIteration:
                     # Task ran to completion. Drop the strong ref so the Task

--- a/test/mock_broker.py
+++ b/test/mock_broker.py
@@ -378,7 +378,7 @@ class MockBroker:
         """
         broker = self
 
-        async def _mock_build_transport(node):
+        async def _mock_build_transport(node, timeout_at=None):
             return MockTransport(
                 manager._net, broker,
                 node_id=node.node_id, host=node.host, port=node.port)

--- a/test/net/test_connection.py
+++ b/test/net/test_connection.py
@@ -61,8 +61,8 @@ class TestKafkaConnectionInit:
         assert 'test-0' in s
 
 
-class TestKafkaConnectionCheckVersion:
-    """Test ApiVersionsRequest version negotiation in _check_version."""
+class TestKafkaConnectionCheckApiVersions:
+    """Test ApiVersionsRequest version negotiation in _get_api_versions."""
 
     def _make_conn(self, net, **kwargs):
         conn = KafkaConnection(net, node_id='test-0', **kwargs)
@@ -83,8 +83,8 @@ class TestKafkaConnectionCheckVersion:
             response.api_keys = api_keys or []
         return response
 
-    def _run_check_version(self, net, conn, responses):
-        """Run _check_version with mocked _send_request returning given responses.
+    def _run_initialize(self, net, conn, responses):
+        """Run initialize() with mocked _send_request returning given responses.
         Returns list of (request_version,) for each call."""
         requests_sent = []
         response_iter = iter(responses)
@@ -105,13 +105,13 @@ class TestKafkaConnectionCheckVersion:
             return f
 
         conn._send_request = mock_send_request
-        net.run(conn._check_version())
+        net.run(conn.initialize())
         return requests_sent
 
     def test_first_request_is_max_version(self, net):
         conn = self._make_conn(net)
         response = self._make_api_versions_response(error_code=0, broker_version=(1, 0))
-        versions = self._run_check_version(net, conn, [response])
+        versions = self._run_initialize(net, conn, [response])
         assert versions[0] == ApiVersionsRequest.max_version
         assert conn.broker_version == (1, 0)
 
@@ -126,7 +126,7 @@ class TestKafkaConnectionCheckVersion:
         unsupported = self._make_api_versions_response(
             error_code=35, api_keys=[api_key_entry])  # 35 = UnsupportedVersionError
         # Second response: success at version 2
-        versions = self._run_check_version(net, conn, [unsupported])
+        versions = self._run_initialize(net, conn, [unsupported])
         assert versions[0] == ApiVersionsRequest.max_version
         assert versions[1] == 2
 
@@ -135,7 +135,7 @@ class TestKafkaConnectionCheckVersion:
         # First response: UnsupportedVersionError with no matching api_key
         unsupported = self._make_api_versions_response(error_code=35, api_keys=[])
         # Second response: success at version 0
-        versions = self._run_check_version(net, conn, [unsupported])
+        versions = self._run_initialize(net, conn, [unsupported])
         assert versions[0] == ApiVersionsRequest.max_version
         assert versions[1] == 0
 
@@ -143,7 +143,7 @@ class TestKafkaConnectionCheckVersion:
         # Pre-configure with 1.0, which supports ApiVersions 0+1
         conn = self._make_conn(net)
         conn.broker_version_data = BrokerVersionData((1, 0))
-        versions = self._run_check_version(net, conn, [])
+        versions = self._run_initialize(net, conn, [])
         assert versions[0] == 1
 
     def test_preconfigured_version_without_api_versions_skips(self, net):
@@ -151,14 +151,14 @@ class TestKafkaConnectionCheckVersion:
         conn = self._make_conn(net)
         conn.broker_version_data = BrokerVersionData((0, 9))
         # Should not send any request -- just call _init_complete
-        versions = self._run_check_version(net, conn, [])
+        versions = self._run_initialize(net, conn, [])
         assert versions == []
         assert conn.connected
         assert conn.init_future.succeeded()
 
     def test_request_failure_closes_connection(self, net):
         conn = self._make_conn(net)
-        versions = self._run_check_version(
+        versions = self._run_initialize(
             net, conn, [Errors.KafkaConnectionError('disconnected')])
         assert versions == [ApiVersionsRequest.max_version]
         # Connection should be closed
@@ -434,7 +434,7 @@ class TestKafkaConnectionSasl:
         f.success(handshake_response)
         conn._send_request = MagicMock(return_value=f)
 
-        net.run(conn._sasl_authenticate())
+        net.run(conn.initialize())
         transport.abort.assert_called_once()
 
     def test_sasl_authenticate_mechanism_not_supported(self, net):
@@ -459,7 +459,7 @@ class TestKafkaConnectionSasl:
         f.success(handshake_response)
         conn._send_request = MagicMock(return_value=f)
 
-        net.run(conn._sasl_authenticate())
+        net.run(conn.initialize())
         transport.abort.assert_called_once()
 
     def test_sasl_authenticate_success(self, net):
@@ -489,15 +489,16 @@ class TestKafkaConnectionSasl:
         auth_response.auth_bytes = b''
 
         responses = iter([handshake_response, auth_response])
-        def mock_send_request(request):
+        def mock_send_request(request, **kwargs):
             f = Future()
             f.success(next(responses))
             return f
         conn._send_request = mock_send_request
 
-        net.run(conn._sasl_authenticate())
+        net.run(conn.initialize())
         # Should not have closed -- auth succeeded
-        assert conn.initializing  # still initializing, _init_complete not called by _sasl_authenticate
+        assert conn.connected
+        assert conn.init_future.succeeded()
 
     def test_sasl_authenticate_auth_failure(self, net):
         conn = KafkaConnection(net, node_id='test',
@@ -526,13 +527,13 @@ class TestKafkaConnectionSasl:
         auth_response.error_message = 'Authentication failed'
 
         responses = iter([handshake_response, auth_response])
-        def mock_send_request(request):
+        def mock_send_request(request, **kwargs):
             f = Future()
             f.success(next(responses))
             return f
         conn._send_request = mock_send_request
 
-        net.run(conn._sasl_authenticate())
+        net.run(conn.initialize())
         transport.abort.assert_called_once()
 
     def _drive_handshake_with_recording_mechanism(self, net, conn):
@@ -546,7 +547,7 @@ class TestKafkaConnectionSasl:
         auth_response.error_code = 0
         auth_response.auth_bytes = b''
         responses = iter([handshake_response, auth_response])
-        def mock_send_request(_):
+        def mock_send_request(request, **kwargs):
             f = Future()
             f.success(next(responses))
             return f
@@ -562,7 +563,7 @@ class TestKafkaConnectionSasl:
                 super().__init__(**config)
         register_sasl_mechanism('PLAIN', RecordingPlain, overwrite=True)
         try:
-            net.run(conn._sasl_authenticate())
+            net.run(conn.initialize())
         finally:
             register_sasl_mechanism('PLAIN', SaslMechanismPlain, overwrite=True)
         return captured

--- a/test/net/test_inet.py
+++ b/test/net/test_inet.py
@@ -157,7 +157,7 @@ class TestCreateConnectionWithProxy:
              patch('kafka.net.socks5.Socks5Proxy.connect', return_value=mock_sock) as mock_connect:
             result = net.run(
                 create_connection(net, 'broker', 9092, proxy_url='socks5://proxy:1080'))
-            mock_connect.assert_called_once_with(net, fake_addr, ())
+            mock_connect.assert_called_once_with(net, fake_addr, (), timeout_at=None)
             assert result is mock_sock
 
     def test_proxy_remote_dns_skips_local_lookup(self):
@@ -342,8 +342,8 @@ class TestKafkaNetSocketExtensionPattern:
             SCHEMES = ('test-asyncio',)
             def __init__(self, proxy_url):
                 self.proxy_url = proxy_url
-            async def connect(self, net, addrinfo, socket_options=()):
-                connect_calls.append((addrinfo, tuple(socket_options)))
+            async def connect(self, net, addrinfo, socket_options=(), timeout_at=None):
+                connect_calls.append((addrinfo, tuple(socket_options), timeout_at))
                 return 'asyncio-stream-handle'
 
         try:
@@ -353,9 +353,10 @@ class TestKafkaNetSocketExtensionPattern:
                  patch('kafka.net.inet.socket.socket') as mock_sock_cls:
                 result = net.run(
                     create_connection(net, 'broker', 9092,
-                                      proxy_url='test-asyncio://x'))
+                                      proxy_url='test-asyncio://x',
+                                      timeout_at=123))
             assert result == 'asyncio-stream-handle'
-            assert connect_calls == [(fake_addr, ())]
+            assert connect_calls == [(fake_addr, (), 123)]
             mock_sock_cls.assert_not_called()
         finally:
             KafkaNetSocket._registry.pop('test-asyncio', None)

--- a/test/net/test_manager.py
+++ b/test/net/test_manager.py
@@ -24,7 +24,8 @@ class TestKafkaConnectionManagerConfig:
         m = KafkaConnectionManager(net)
         assert m.config['reconnect_backoff_ms'] == 50
         assert m.config['reconnect_backoff_max_ms'] == 30000
-        assert m.config['socket_connection_timeout_ms'] == 5000
+        assert m.config['socket_connection_setup_timeout_ms'] == 10000
+        assert m.config['socket_connection_setup_timeout_max_ms'] == 30000
         assert m.config['max_in_flight_requests_per_connection'] == 5
 
     def test_config_override(self, net):
@@ -106,18 +107,20 @@ class TestKafkaConnectionManagerBackoff:
     def test_update_backoff(self, manager):
         manager.update_backoff('node-1')
         assert manager.connection_delay('node-1') > 0
-        failures, _ = manager._backoff['node-1']
+        failures, _, _ = manager._backoff['node-1']
         assert failures == 1
 
     def test_exponential_backoff(self, manager):
         manager.update_backoff('node-1')
-        _, backoff1 = manager._backoff['node-1']
+        _, backoff1, connect1 = manager._backoff['node-1']
         manager.update_backoff('node-1')
-        _, backoff2 = manager._backoff['node-1']
-        failures, _ = manager._backoff['node-1']
+        _, backoff2, connect2 = manager._backoff['node-1']
+        failures, _, _ = manager._backoff['node-1']
         assert failures == 2
         # Second backoff should be later (exponential)
         assert backoff2 > backoff1
+        # Second connect timeout should be greater
+        assert connect2 > connect1
 
     def test_reset_backoff(self, manager):
         manager.update_backoff('node-1')
@@ -242,13 +245,14 @@ class TestKafkaConnectionManagerBootstrap:
     def test_bootstrap_connection_failure(self, net):
         manager = KafkaConnectionManager(net,
                                          bootstrap_servers=['localhost:1'],
-                                         socket_connection_timeout_ms=500,
+                                         socket_connection_setup_timeout_ms=500,
+                                         socket_connection_setup_timeout_max_ms=500,
                                          reconnect_backoff_ms=10,
                                          reconnect_backoff_max_ms=100)
         with pytest.raises(Errors.KafkaTimeoutError):
             manager.bootstrap(timeout_ms=2000)
         assert not manager._conns
-        failures, _ = manager._backoff['bootstrap-0']
+        failures, _, _ = manager._backoff['bootstrap-0']
         assert failures > 1
 
     def test_bootstrapped_property(self, manager):
@@ -319,7 +323,7 @@ class TestKafkaConnectionManagerConnectionTimeout:
         blocker.connect(('127.0.0.1', port))
 
         try:
-            manager = KafkaConnectionManager(net, bootstrap_servers=['127.0.0.1:%d' % port], socket_connection_timeout_ms=100)
+            manager = KafkaConnectionManager(net, bootstrap_servers=['127.0.0.1:%d' % port], socket_connection_setup_timeout_ms=100)
             conn = manager.get_connection('bootstrap-0')
             net.poll(timeout_ms=1000, future=conn.init_future)
             assert conn.init_future.is_done


### PR DESCRIPTION
- kafka.net.inet: Support timeout_at for inet connections
- kafka.net.manager: Use socket timeout kwarg instead of call_later disconnect
- kafka.net.selector: throw `self._exc` (if set) into pending coro
- kafka.net.selector: Add timeout_at to wait_write/wait_read
- Capture final.value from inner coro
- kafka.net: support socket_connection_setup_timeout_ms w/ exp backoff (KIP-601)
- bootstrap: pass timeout to get_connection
- kafka.net.connection: wrap version check + sasl with initialize() with optional timeout
