### PR TITLE
Improve connection logging; dont log version check if matches expected

### DIFF
--- a/kafka/cli/admin/cluster/versions.py
+++ b/kafka/cli/admin/cluster/versions.py
@@ -30,4 +30,4 @@ class GetBrokerVersion:
     def command(cls, client, args):
         broker_id = int(args.broker)
         bvd = client.get_broker_version_data(broker_id)
-        return {broker_id: '.'.join(map(str, bvd.broker_version))}
+        return {broker_id: bvd.broker_version_str}

--- a/kafka/net/connection.py
+++ b/kafka/net/connection.py
@@ -400,11 +400,15 @@ class KafkaConnection:
         api_versions = {api_version.api_key: (api_version.min_version, api_version.max_version)
                         for api_version in response.api_keys}
         bvd = BrokerVersionData(api_versions=api_versions)
-        log.info('%s: Broker version identified as %s', self, '.'.join(map(str, bvd.broker_version)))
-        if self.broker_version_data is None or self.broker_version_data > bvd:
+        if self.broker_version_data is None:
+            log.info('%s: Broker version identified as %s', self, bvd.broker_version_str)
             self.broker_version_data = bvd
-        else:
-            log.info('%s: Clamping client to user-supplied broker version %s', self, '.'.join(map(str, self.broker_version)))
+        elif self.broker_version_data > bvd:
+            log.info('%s: Broker version identified as %s (lower than user-supplied %s)', self, bvd.broker_version_str, self.broker_version_data.broker_version_str)
+            self.broker_version_data = bvd
+        elif self.broker_version_data is not None and self.broker_version_data < bvd:
+            log.info('%s: Broker version identified as %s; clamping to user-supplied %s', self, bvd.broker_version_str, self.broker_version_data.broker_version_str)
+        # No log if user-supplied api_version is the same as broker-identified version
 
     @property
     def sasl_enabled(self):

--- a/kafka/net/connection.py
+++ b/kafka/net/connection.py
@@ -242,6 +242,10 @@ class KafkaConnection:
                 self._close_future.success(None)
             else:
                 self._close_future.failure(exc)
+        if exc:
+            log.error('%s: Connection lost: %s', self, exc)
+        else:
+            log.info('%s: Connection closed', self)
 
     def fail_in_flight_requests(self, error):
         if not self.closed:
@@ -276,6 +280,7 @@ class KafkaConnection:
             client_id=self.config['client_id'],
             receive_message_max_bytes=self.config['receive_message_max_bytes'],
             ident=log_prefix)
+        log.info('%s: Connected', self)
 
     def pause(self, v):
         self.paused.add(v)

--- a/kafka/net/connection.py
+++ b/kafka/net/connection.py
@@ -280,7 +280,7 @@ class KafkaConnection:
             client_id=self.config['client_id'],
             receive_message_max_bytes=self.config['receive_message_max_bytes'],
             ident=log_prefix)
-        log.info('%s: Connected', self)
+        log.debug('%s: Connection made', self)
 
     def pause(self, v):
         self.paused.add(v)
@@ -367,6 +367,7 @@ class KafkaConnection:
             self.close(error)
         else:
             self._init_complete()
+            log.info('%s: Connected', self)
 
     async def _get_api_versions(self, timeout_at=None):
         if timeout_at is None:

--- a/kafka/net/inet.py
+++ b/kafka/net/inet.py
@@ -103,7 +103,7 @@ class KafkaNetSocket:
 
             # Connection succeeded
             if not ret or ret == errno.EISCONN:
-                log.info('Connected: %s', sock)
+                log.debug('Connected: %s', sock)
                 return sock
 
             # Needs retry

--- a/kafka/net/inet.py
+++ b/kafka/net/inet.py
@@ -103,7 +103,7 @@ class KafkaNetSocket:
 
             # Connection succeeded
             if not ret or ret == errno.EISCONN:
-                log.debug('Connected: %s', sock)
+                log.info('Connected: %s', sock)
                 return sock
 
             # Needs retry

--- a/kafka/net/manager.py
+++ b/kafka/net/manager.py
@@ -158,6 +158,7 @@ class KafkaConnectionManager:
                 log.info('Bootstrap complete: %s', self.cluster)
                 return True
             finally:
+                log.info('Closing bootstrap connection %s', bootstrap_broker.node_id)
                 self._conns.pop(bootstrap_broker.node_id, conn).close()
         else:
             raise Errors.KafkaTimeoutError(

--- a/kafka/net/manager.py
+++ b/kafka/net/manager.py
@@ -275,6 +275,7 @@ class KafkaConnectionManager:
         node = self.cluster.broker_metadata(node_id)
         if node is None:
             raise Errors.UnknownBrokerIdError(node_id)
+        log.info('Initializing connection for node_id %s at %s:%s (rack=%s)', node_id, node.host, node.port, node.rack)
         conn = KafkaConnection(self._net, node_id=node_id, broker_version_data=self.broker_version_data, **self.config)
         if pop_on_close:
             conn.close_future.add_both(lambda _: self._conns.pop(node.node_id, None))

--- a/kafka/net/transport.py
+++ b/kafka/net/transport.py
@@ -24,6 +24,7 @@ class KafkaTCPTransport:
         self._write = True
         self.last_write = time.monotonic()
         self.last_read = time.monotonic()
+        log.info('%s: transport initialized', self)
 
     @property
     def last_activity(self):

--- a/kafka/net/transport.py
+++ b/kafka/net/transport.py
@@ -24,7 +24,6 @@ class KafkaTCPTransport:
         self._write = True
         self.last_write = time.monotonic()
         self.last_read = time.monotonic()
-        log.info('%s: transport initialized', self)
 
     @property
     def last_activity(self):
@@ -334,7 +333,7 @@ class KafkaTCPTransport:
         return self.writelines(data)
 
     async def handshake(self):
-        pass
+        log.info('%s: connected to %s', self, self._sock)
 
     def host_port(self):
         if self._sock is None:
@@ -366,6 +365,7 @@ class KafkaSSLTransport(KafkaTCPTransport):
         while True:
             try:
                 self._sock.do_handshake()
+                log.info('%s: connected to %s', self, self._sock)
                 return
             except ssl.SSLWantReadError:
                 await self._net.wait_read(self._sock)

--- a/kafka/protocol/broker_version_data.py
+++ b/kafka/protocol/broker_version_data.py
@@ -100,8 +100,12 @@ class BrokerVersionData:
                 f" and broker [{broker_min_version}-{broker_max_version}].")
         return min(max_version, broker_max_version)
 
+    @property
+    def broker_version_str(self):
+        return '.'.join(map(str, self.broker_version))
+
     def __str__(self):
-        return '<BrokerVersionData %s>' % '.'.join(map(str, self.broker_version))
+        return '<BrokerVersionData %s>' % self.broker_version_str
 
     def __eq__(self, other):
         return self.broker_version == other.broker_version and self.api_versions == other.api_versions


### PR DESCRIPTION
* adds more info logging for successful connects in kafka.net.transport and kafka.net.connection
* adds info log for kafka.net.manager new connection attempts
* adds logging when connection closed, whether normally (info) or with exception (error)
* skips logging broker version check if it matches user-supplied / manager-supplied api_version.