### PR TITLE
Fix OverflowError in offsets_for_times() when timestamp is non-finite float

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -1228,7 +1228,12 @@ class KafkaConsumer:
         """
         timeout_ms = self.config['request_timeout_ms'] if timeout_ms is None else timeout_ms
         for tp, ts in timestamps.items():
-            timestamps[tp] = int(ts)
+            try:
+                timestamps[tp] = int(ts)
+            except (ValueError, TypeError, OverflowError):
+                raise ValueError(
+                    "The target timestamp for partition {} is {}. Timestamps "
+                    "must be a valid integer (milliseconds since epoch).".format(tp, ts))
             if ts < 0:
                 raise ValueError(
                     "The target time for partition {} is {}. The target time "


### PR DESCRIPTION
## Bug

`offsets_for_times()` converts each timestamp value with `int(ts)`. If `ts` is `float('inf')` or `float('nan')`, this raises an `OverflowError` (or `ValueError` for nan) instead of the expected `ValueError` with a clear message.

**Reproducer:**
```python
consumer = KafkaConsumer(bootstrap_servers='localhost:9092')
tp = TopicPartition('my-topic', 0)
consumer.offsets_for_times({tp: float('inf')})
# OverflowError: cannot convert float infinity to integer
```

## Fix

Wrap `int(ts)` in a try/except that catches `ValueError`, `TypeError`, and `OverflowError`, and re-raises as `ValueError` with a descriptive message — consistent with the existing negative-timestamp check.