### PR TITLE
fix: correct suceeded→succeeded typo in print statement (producer_performance.py line 77)

### DIFF
--- a/kafka/benchmarks/producer_performance.py
+++ b/kafka/benchmarks/producer_performance.py
@@ -74,7 +74,7 @@ class ProducerPerformance:
                         count_failure += 1
                     else:
                         raise ValueError(r)
-                print("%d suceeded, %d failed" % (count_success, count_failure))
+                print("%d succeeded, %d failed" % (count_success, count_failure))
 
             start_time = time.monotonic()
             _benchmark()


### PR DESCRIPTION
## Summary
Correct typo `suceeded` → `succeeded` in user-facing print statement in `kafka/benchmarks/producer_performance.py`:
- Line 77: `print("%d succeeded, %d failed" % (count_success, count_failure))`

User-facing benchmark output showing success/failure counts.

## Files changed
- `kafka/benchmarks/producer_performance.py` (1 correction)