### PR TITLE
Fix create_partitions sending empty assignments array instead of null (#3146)

### DIFF
--- a/kafka/admin/_partitions.py
+++ b/kafka/admin/_partitions.py
@@ -45,21 +45,22 @@ class PartitionAdminMixin:
         topics = []
         for topic, count in topic_partitions.items():
             if isinstance(count, int):
-                topics.append(_Topic(name=topic, count=count))
+                total_count, new_assignments = count, None
             elif isinstance(count, dict):
-                topics.append(
-                    _Topic(
-                        name=topic,
-                        count=count['count'],
-                        assignments=[_Assignment(broker_ids=broker_ids)
-                                     for broker_ids in count['assignments']]))
+                total_count, new_assignments = count['count'], count.get('assignments')
             else:
-                topics.append(
-                    _Topic(
-                        name=topic,
-                        count=count.total_count,
-                        assignments=[_Assignment(broker_ids=broker_ids)
-                                     for broker_ids in count.new_assignments]))
+                total_count, new_assignments = count.total_count, count.new_assignments
+            # new_assignments is None -> no manual assignment; leave the request's
+            # assignments field as None so it serialises to null (the broker then
+            # auto-assigns replicas). Passing an empty list instead of None makes
+            # the broker treat it as a manual assignment and reject the request
+            # with InvalidReplicationAssignmentError. See issue #3146.
+            if new_assignments is None:
+                assignments = None
+            else:
+                assignments = [_Assignment(broker_ids=broker_ids)
+                               for broker_ids in new_assignments]
+            topics.append(_Topic(name=topic, count=total_count, assignments=assignments))
         return topics
 
     def create_partitions(self, topic_partitions, timeout_ms=None, validate_only=False, raise_errors=True):

--- a/test/admin/test_admin_topics.py
+++ b/test/admin/test_admin_topics.py
@@ -22,6 +22,40 @@ def test_new_partitions():
     assert good_partitions.new_assignments == [[1, 2, 3]]
 
 
+def test_process_create_partitions_input_auto_assign_is_null():
+    # When the caller does not supply manual replica assignments, the request's
+    # `assignments` field must be None so it serialises to null (broker
+    # auto-assigns). An empty list [] serialises to a present-but-empty array,
+    # which the broker reads as "manual assignment" and rejects with
+    # InvalidReplicationAssignmentError. See issue #3146.
+    proc = KafkaAdminClient._process_create_partitions_input
+
+    # int total-count -> auto-assign
+    topics = proc({'foo': 6})
+    assert len(topics) == 1
+    assert topics[0].name == 'foo'
+    assert topics[0].count == 6
+    assert topics[0].assignments is None
+
+    # bare NewPartitions with no manual assignments -> auto-assign
+    topics = proc({'foo': NewPartitions(6)})
+    assert topics[0].assignments is None
+
+
+def test_process_create_partitions_input_manual_assignments():
+    # Explicit manual assignments must be preserved, for both the dict form
+    # and the (deprecated) NewPartitions form.
+    proc = KafkaAdminClient._process_create_partitions_input
+
+    topics = proc({'foo': {'count': 7, 'assignments': [[1, 2, 3]]}})
+    assert topics[0].count == 7
+    assert [a.broker_ids for a in topics[0].assignments] == [[1, 2, 3]]
+
+    topics = proc({'foo': NewPartitions(7, [[1, 2, 3]])})
+    assert topics[0].count == 7
+    assert [a.broker_ids for a in topics[0].assignments] == [[1, 2, 3]]
+
+
 def test_new_topic():
     good_topic = NewTopic('foo')
     assert good_topic.name == 'foo'


### PR DESCRIPTION
Fixes #3146.

### Problem

`create_partitions({topic: N})` with a plain int total count — the form the docstring recommends — fails against a normal broker with `InvalidReplicationAssignmentError` (error 39):

```
kafka.errors.InvalidReplicationAssignmentError: [Error 39]
  CreatePartitionsTopic(name='demo-topic', count=6, assignments=[])
  error_message='Attempted to add 3 additional partition(s), but only 0 assignment(s) were specified.'
```

`create_partitions({topic: NewPartitions(N)})` (auto-assign, no manual assignments) is also broken — it raises `TypeError: 'NoneType' object is not iterable`, because the branch iterates `count.new_assignments` unconditionally even though it defaults to `None`.

### Root cause

`_process_create_partitions_input` always built the per-topic `assignments` field as a list. For the int form (and a bare `NewPartitions`) that yields an empty list `[]`, which serialises to a **present-but-empty** array rather than `null`. The broker reads a present array as "manual replica assignment" and rejects it because the assignment count doesn't match the number of new partitions.

Verified at the byte level (assignments field only, after `count=00000006`):

```
# v3 (compact array length):
[]   -> ...00000006 01 ...   # length 1 => 0 elements, present array
None -> ...00000006 00 ...   # 0 => null

# v0 (classic 4-byte array length):
[]   -> ...00000006 00000000 ...   # length 0, present
None -> ...00000006 ffffffff ...   # -1 => null
```

`null` means "auto-assign replicas"; a present array means "manual assignment". The empty list is what triggers error 39.

### Fix

Pass `assignments=None` when the caller supplies no manual assignments, so it serialises to `null` and the broker auto-assigns. Manual assignments (dict form and the deprecated `NewPartitions` form) are preserved unchanged.

Minor related change: the dict branch now uses `count.get('assignments')` instead of `count['assignments']`, so `{'count': N}` with no assignments means auto-assign rather than raising `KeyError`. This is backward compatible (any dict that previously worked still works).

### Tests

Added unit coverage in `test/admin/test_admin_topics.py` asserting `_process_create_partitions_input` produces `assignments is None` for the int and bare-`NewPartitions` inputs, and preserves explicit manual assignments. The auto-assign test fails on the current code and passes with this change.

Verified:
- `test/admin/test_admin_topics.py` — 20 passed (incl. the 2 new tests)
- `test/protocol/admin/test_protocol_admin.py` — 121 passed
- End-to-end against a live `confluentinc/cp-kafka:latest` broker: `create_partitions({topic: N})` (int) now increases the partition count instead of raising error 39, confirmed with `rpk topic describe`.
