### PR TITLE
Fix JsonSerializer returning None and raising TypeError on deserialize

### DIFF
--- a/kafka/serializer/json.py
+++ b/kafka/serializer/json.py
@@ -1,9 +1,9 @@
 import json
 
-from .abstract import Serializer, Deserializer
+from .default import DefaultSerializer
 
 
-class JsonSerializer(Serializer, Deserializer):
+class JsonSerializer(DefaultSerializer):
     def serialize(self, topic, headers, data):
         if data is None:
             return None

--- a/test/test_serializer.py
+++ b/test/test_serializer.py
@@ -1,0 +1,47 @@
+# pylint: skip-file
+
+import pytest
+
+from kafka.serializer import DefaultSerializer, JsonSerializer
+
+
+@pytest.mark.parametrize('encoding', ['utf-8', 'utf-16'])
+def test_default_serializer_roundtrip(encoding):
+    ser = DefaultSerializer(encoding)
+    data = 'héllo wörld'
+    encoded = ser.serialize('topic', [], data)
+    assert isinstance(encoded, bytes)
+    assert ser.deserialize('topic', [], encoded) == data
+
+
+@pytest.mark.parametrize('data', [b'raw', bytearray(b'raw'), memoryview(b'raw'), None])
+def test_default_serializer_passthrough_bytes_like(data):
+    assert DefaultSerializer().serialize('topic', [], data) == data
+
+
+def test_default_serializer_deserialize_none():
+    assert DefaultSerializer().deserialize('topic', [], None) is None
+
+
+def test_default_serializer_rejects_non_bytes_str():
+    with pytest.raises(AttributeError):
+        DefaultSerializer().serialize('topic', [], 42)
+
+
+def test_json_serializer_roundtrip():
+    ser = JsonSerializer()
+    data = {'key': 'value', 'n': 42, 'lst': [1, 2]}
+    encoded = ser.serialize('topic', [], data)
+    assert isinstance(encoded, bytes)
+    assert ser.deserialize('topic', [], encoded) == data
+
+
+def test_json_serializer_none():
+    ser = JsonSerializer()
+    assert ser.serialize('topic', [], None) is None
+    assert ser.deserialize('topic', [], None) is None
+
+
+def test_json_serializer_deserializes_plain_json():
+    ser = JsonSerializer()
+    assert ser.deserialize('topic', [], b'{"a": 1}') == {'a': 1}

--- a/test/test_serializer.py
+++ b/test/test_serializer.py
@@ -8,7 +8,7 @@ from kafka.serializer import DefaultSerializer, JsonSerializer
 @pytest.mark.parametrize('encoding', ['utf-8', 'utf-16'])
 def test_default_serializer_roundtrip(encoding):
     ser = DefaultSerializer(encoding)
-    data = 'héllo wörld'
+    data = 'h\u00e9llo w\u00f6rld'
     encoded = ser.serialize('topic', [], data)
     assert isinstance(encoded, bytes)
     assert ser.deserialize('topic', [], encoded) == data


### PR DESCRIPTION
## Problem

`JsonSerializer` is broken since the 3.0 serializer refactor (#3046):

- `JsonSerializer().serialize(topic, headers, data)` always returns `None`
- `JsonSerializer().deserialize(topic, headers, data)` raises
  `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`

This silently corrupts messages produced with `value_serializer=JsonSerializer()` and crashes consumers using `value_deserializer=JsonSerializer()`.

## Root cause

`kafka/serializer/json.py` inherits from `Serializer, Deserializer`, whose abstract methods in `kafka/serializer/abstract.py` are no-ops (`pass`). The `super().serialize(...)` / `super().deserialize(...)` calls in `JsonSerializer` therefore return `None`. Before the 3.0 refactor, `JsonSerializer` inherited from `DefaultSerializer`, which actually performs the UTF-8 encode/decode.

## Fix

Restore delegation to `DefaultSerializer` by inheriting from it:

```python
class JsonSerializer(DefaultSerializer):
```

`serialize` now returns UTF-8 bytes and `deserialize` decodes bytes before `json.loads`.

## Tests

Added `test/test_serializer.py` (no serializer unit tests existed):

- `DefaultSerializer`: roundtrip (utf-8 / utf-16), bytes-like passthrough (bytes / bytearray / memoryview / None), `deserialize(None) -> None`, rejection of non-bytes input
- `JsonSerializer`: roundtrip dict -> bytes -> dict, `None` handling, deserializing plain JSON bytes

All tests pass with the fix; the `JsonSerializer` tests fail against the previous code (reproducing the bug).

## Verification

```
python -m pytest test/test_serializer.py -v
# 11 passed
```